### PR TITLE
Add page-component-build-list to site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -25,6 +25,8 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
+    # the page-component-build-list is used in docs-ui
+    page-component-build-list: 'docs, server, ocis, user, desktop, ios-app, android'
 #   common
     docs-base-url: 'https://doc.owncloud.com'
     oc-contact-url: 'https://owncloud.com/contact/'


### PR DESCRIPTION
Add `page-component-build-list` attribute to `site.yml` as it is in `docs`.

Used in the local build to get the correct opengraph image.

Backport to 10.8 and 10.9