### PR TITLE
fix the partial family resource ID in nav.adoc

### DIFF
--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,5 +1,5 @@
 .ownCloud Server Documentation
 * xref:index.adoc[Introduction]
-include::admin_manual:{partialsdir}nav.adoc[]
-include::user_manual:{partialsdir}nav.adoc[]
-include::developer_manual:{partialsdir}nav.adoc[]
+include::admin_manual:partial$nav.adoc[]
+include::user_manual:partial$nav.adoc[]
+include::developer_manual:partial$nav.adoc[]


### PR DESCRIPTION
The family ressource ID in `nav.adoc` needs to be changed from `{partialsdir}` -> `partial$`

Backport to 10.9 and 10.8