### PR TITLE
[10.8] [PR 16] fix the partial family resource ID in nav.adoc

### DIFF
--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,5 +1,5 @@
 .ownCloud Server Documentation
 * xref:index.adoc[Introduction]
-include::admin_manual:{partialsdir}nav.adoc[]
-include::user_manual:{partialsdir}nav.adoc[]
-include::developer_manual:{partialsdir}nav.adoc[]
+include::admin_manual:partial$nav.adoc[]
+include::user_manual:partial$nav.adoc[]
+include::developer_manual:partial$nav.adoc[]


### PR DESCRIPTION
Backport of PR #16