### PR TITLE
move attribute to correct location

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -5,7 +5,6 @@
 :ubuntu_upgrade_url: https://www.cyberciti.biz/faq/upgrade-ubuntu-18-04-to-20-04-lts-using-command-line/
 :remove_ppa_url: https://itsfoss.com/how-to-remove-or-delete-ppas-quick-tip/
 :php-common: https://tecadmin.net/enable-disable-php-modules-ubuntu/
-:disabling-thp-url: https://stackoverflow.com/questions/48743100/why-thp-transparent-huge-pages-are-not-recommended-for-databases-like-oracle-a
 :ondrej-php-url: https://launchpad.net/~ondrej/+archive/ubuntu/php
 :libsmbclient-php_url: https://github.com/eduardok/libsmbclient-php
 :update-alternatives_url: https://manpages.ubuntu.com/manpages/precise/man8/update-alternatives.8.html

--- a/modules/admin_manual/partials/installation/manual_installation/useful_tips.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/useful_tips.adoc
@@ -1,6 +1,7 @@
 :iscsi_initiator-url: https://ubuntu.com/server/docs/service-iscsi
 :overriding-vendor-settings-url: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 :transport-huge-pages-url: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge
+:disabling-thp-url: https://stackoverflow.com/questions/48743100/why-thp-transparent-huge-pages-are-not-recommended-for-databases-like-oracle-a
 
 == Start a Service After a Resource is Mounted
 


### PR DESCRIPTION
Moves an attribute to the correct location (from document to partial document where it gets used)

Backport to 10.9