### PR TITLE
Fix antora.yml version 10.9 only

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: server
 title: ownCloud Server
-version: 10.9
+version: '10.9'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/partials/nav.adoc


### PR DESCRIPTION
Set the version in antora.yml in single quotes, else it may get interpreted as number (Antora).

No backport, 10.8 will be an independent PR