### PR TITLE
mpm_event conflicts with php

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
@@ -124,3 +124,16 @@ sudo service apache2 reload
 
 If you want to use a threaded MPM, look at a FastCGI configuration where PHP is running
 in its own memory space. ownCloud limit´s its support to Apache prefork only.
+
+[NOTE]
+====
+In case you have enbaled `mpm_event` during an earlier setup of Apache, you may get conflicts notes from Apache. Use the following commands to solve this issue. The order of commands is recommended to ensure a smooth transition. 
+
+[source,console]
+----
+sudo a2dismod mpm_event
+sudo systemctl restart apache2
+sudo a2enmod mpm_prefork
+sudo systemctl restart apache2
+----
+====

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
@@ -123,11 +123,11 @@ sudo service apache2 reload
 `worker` with `mod_php`, because PHP is currently {php-net-url}/manual/en/install.unix.apache2.php[not thread safe].
 
 If you want to use a threaded MPM, look at a FastCGI configuration where PHP is running
-in its own memory space. ownCloud limit´s its support to Apache prefork only.
+in its own memory space. ownCloud limits its support to Apache prefork only.
 
 [NOTE]
 ====
-In case you have enbaled `mpm_event` during an earlier setup of Apache, you may get conflicts notes from Apache. Use the following commands to solve this issue. The order of commands is recommended to ensure a smooth transition. 
+In case you have enabled `mpm_event` during an earlier setup of Apache, you may get conflict notes from Apache. Use the following commands to solve this issue. The order of commands is recommended to ensure a smooth transition. 
 
 [source,console]
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -193,9 +193,9 @@ The following command installs the Apache Web Server.
 sudo apt install libapache2-mod-php apache2
 ----
 
-See the important note using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
+See the important note on using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
 
-Even not supported by ownCloud, you can configure Apache to use `php-fpm`, the
+Although it's not supported by ownCloud, you can configure Apache to use `php-fpm`, the
 FastCGI Process Manager, which is a non-standard setup and not covered by this document.
 
 == Multiple Concurrent PHP Versions

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -193,6 +193,8 @@ The following command installs the Apache Web Server.
 sudo apt install libapache2-mod-php apache2
 ----
 
+See the important note using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
+
 Even not supported by ownCloud, you can configure Apache to use `php-fpm`, the
 FastCGI Process Manager, which is a non-standard setup and not covered by this document.
 

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -67,18 +67,11 @@ apt install -y \
 
 Note : php 7.4 is the default version installable with Ubuntu 20.04
 
-Note : if apache reports conflicts with mpm_event, then try
-
-[source,console]
-----
-sudo a2dismod mpm_event
-sudo systemctl restart apache2
-sudo a2enmod mpm_prefork
-sudo systemctl restart apache2
-----
+See the important note using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
 
 === Install the Recommended Packages
 
+[source,console]
 ----
 apt install -y \
   ssh bzip2 rsync curl jq \

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -67,6 +67,14 @@ apt install -y \
 
 Note : php 7.4 is the default version installable with Ubuntu 20.04
 
+Note : if apache reports conflicts with mpm_event, then try
+----
+a2dismod mpm_event
+systemctl restart apache2
+a2enmod mpm_prefork
+systemctl restart apache2
+----
+
 === Install the Recommended Packages
 
 ----

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -68,11 +68,13 @@ apt install -y \
 Note : php 7.4 is the default version installable with Ubuntu 20.04
 
 Note : if apache reports conflicts with mpm_event, then try
+
+[source,console]
 ----
-a2dismod mpm_event
-systemctl restart apache2
-a2enmod mpm_prefork
-systemctl restart apache2
+sudo a2dismod mpm_event
+sudo systemctl restart apache2
+sudo a2enmod mpm_prefork
+sudo systemctl restart apache2
 ----
 
 === Install the Recommended Packages

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -67,7 +67,7 @@ apt install -y \
 
 Note : php 7.4 is the default version installable with Ubuntu 20.04
 
-See the important note using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
+See the important note on using the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
 
 === Install the Recommended Packages
 

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 site:
   title: ownCloud Server Documentation
   url: https://doc.owncloud.com
+  start_page: server::index.adoc
 
 content:
   sources:


### PR DESCRIPTION
The quick install guide fails, if mpm_event is already installed.

Backport to 10.9 and 10.8