### PR TITLE
Config-to-docs Run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -389,7 +389,14 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 		  // defines the claim which holds the picture of the user - must be a URL
 		'picture-claim' => 'picture',
 		  // defines a list of groups to which the newly created user will be added automatically
-		'groups' => ['admin', 'guests', 'employees']
+		'groups' => ['admin', 'guests', 'employees'],
+		  // sets a claim which is defined at the IDP. the IDP will return a single value or an array like:
+		  // "allowed_applications": ["erp", "owncloud"],
+		'provisioning-claim' => 'allowed_applications',
+		  // defines the matching case for the provisioning. the attribute can only be a single value
+		  // in case no match is found against the IDP response, no provisioning will be made,
+		  // "User not found" will be returned
+		'provisioning-attribute' => 'owncloud'
 	],
 	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud
 	'mode' => 'email',
@@ -484,6 +491,8 @@ Possible keys: `wnd.activity.registerExtension` BOOL
 Possible keys: `wnd.activity.sendToSharees` BOOL
 
 Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
+
+Possible keys: `wnd.connector.opts.timeout` INTEGER
 
 *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely.
 
@@ -631,6 +640,20 @@ recommended to enable this option only if there are a high number of ACLs target
 [source,php]
 ....
 'wnd.groupmembership.checkUserFirst' => false,
+....
+
+=== The timeout (in ms) for all the operations against the backend.
+
+The same timeout will be applied for all the connections.
+
+Increase it if requests to the server sometimes time out. This can happen when SMB3
+encryption is selected and smbclient is overwhelming the server with requests.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.connector.opts.timeout' => 20000,  // 20 seconds
 ....
 
 == App: Workflow / Tagging


### PR DESCRIPTION
Config-to-docs run to add the latest changes.

References:
https://github.com/owncloud/docs/issues/3502 ([OIDC] AutoProvisioning based on a Provisioning Claim)
https://github.com/owncloud/core/pull/39732 (Add wnd.listen.reconnectAfterTime config sample)

Backport to 10.9 only