### PR TITLE
Fix docker compose example link

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -129,7 +129,7 @@ mkdir owncloud-docker-server
 cd owncloud-docker-server
 
 # Copy docker-compose.yml from the GitHub repository
-wget https://raw.githubusercontent.com/owncloud/docs/master/modules/admin_manual/examples/installation/docker/docker-compose.yml
+wget https://raw.githubusercontent.com/owncloud/docs-server/master/modules/admin_manual/examples/installation/docker/docker-compose.yml
 
 # Create the environment configuration file
 cat << EOF > .env


### PR DESCRIPTION
This fixes the docker compose example link used by wget

Fixes: https://github.com/owncloud/docs/issues/4692 (bad URL in docker compose instructions)

Backport to 10.9 and 10.8