### PR TITLE
Update naming

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: server
-title: ownCloud Server
+title: ownCloud Classic Server
 version: next
 start_page: ROOT:index.adoc
 nav:

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
-= Introduction to ownCloud Server
+= Introduction to ownCloud Classic Server
 
-Welcome to the ownCloud Server documentation. These documents provide an admin guide with information for installation, configuration and administrative tasks respectively the documentation for developers.
+Welcome to the ownCloud Classic Server documentation. These documents provide an xref:admin_manual:page$index.adoc[admin guide] with information for installation, configuration and administrative tasks respectively the documentation for xref:developer_manual:page$index.adoc[developers].

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,3 @@
-.ownCloud Server Documentation
 * xref:index.adoc[Introduction]
 include::admin_manual:partial$nav.adoc[]
 include::user_manual:partial$nav.adoc[]

--- a/modules/admin_manual/pages/index.adoc
+++ b/modules/admin_manual/pages/index.adoc
@@ -3,7 +3,7 @@
 :ownCloud-channel-url: https://www.youtube.com/channel/UC_4gez4lsWqciH-otOlXo5w
 :community-channel-url: https://www.youtube.com/channel/UCA8Ehsdu3KaxSz5KOcCgHbw
 
-Welcome to the ownCloud Server Administration Guide. This guide describes administration tasks for ownCloud, the flexible open source file synchronization and sharing solution. ownCloud includes the ownCloud server, which runs on Linux, client applications for Microsoft Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
+Welcome to the ownCloud Classic Server Administration Guide. This guide describes administration tasks for ownCloud, the flexible open source file synchronization and sharing solution. ownCloud includes the ownCloud server, which runs on Linux, client applications for Microsoft Windows, Mac OS X and Linux, and mobile clients for the Android and Apple iOS operating systems.
 
 Current editions of ownCloud manuals are always available online at {docs-base-url}[doc.owncloud.com].
 

--- a/modules/developer_manual/pages/index.adoc
+++ b/modules/developer_manual/pages/index.adoc
@@ -1,7 +1,7 @@
 = Introduction
 
-If you want to contribute please read the
-https://owncloud.com/contribute/join-the-development/contributor-agreement/[Contributor agreement]
+Welcome to the ownCloud Classic Server Developer Guide. If you want to contribute please read the
+https://owncloud.com/contribute/join-the-development/contributor-agreement/[Contributor agreement] first.
 
 [width="100%",cols="25%,36%,39%",]
 |===


### PR DESCRIPTION
* Updates the naming from server to classic server in preperation to the ocis server
* Remove the component name from the naviagtion as it is already present

Note that the change does not cover the user documentation as this will be migrated soon into its own repository.

Backport to 10.9 and 10.8