### PR TITLE
Fix the resource coordinates in the introduction

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
 = Introduction to ownCloud Classic Server
 
-Welcome to the ownCloud Classic Server documentation. These documents provide an xref:admin_manual:page$index.adoc[admin guide] with information for installation, configuration and administrative tasks as well as documentation for xref:developer_manual:page$index.adoc[developers].
+Welcome to the ownCloud Classic Server documentation. These documents provide an xref:admin_manual:index.adoc[admin guide] with information for installation, configuration and administrative tasks as well as documentation for xref:developer_manual:index.adoc[developers].


### PR DESCRIPTION
Post fix for #44

To address a page in a module you need to use following format (using version and component only if accessed from outside the repo) `xref:version@component:module:filename.adoc[]`. The family coordinate: `page$` for pages must not be used as falsly introduced by #44. While this renders correctly doing a local build, it errors for the build via docs.

Backport to 10.9 and 10.8 necessary

