### PR TITLE
Fix broken antora component links to docs

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -92,7 +92,7 @@ ownCloud provides two encryption types:
 | *User-Key:*
 a| Every user has their own private/public key pairs, and the private key is protected by the user’s password.
 
-IMPORTANT: User-Key encryption has been depreciated with xref:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+IMPORTANT: User-Key encryption has been depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 |===
 
 WARNING: These encryption types are *not compatible*.
@@ -248,7 +248,7 @@ You may only disable encryption by using the xref:configuration/server/occ_comma
 
 === Limitations of User-Key-Based Encryption 
 
-* Depreciated with xref:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+* Depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 * Users added to groups cannot decrypt files on existing shares.
 * OnlyOffice will not work.
 * Impersonate will not work.

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -92,7 +92,7 @@ ownCloud provides two encryption types:
 | *User-Key:*
 a| Every user has their own private/public key pairs, and the private key is protected by the user’s password.
 
-IMPORTANT: User-Key encryption has been depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+IMPORTANT: User-Key encryption has been deprecated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 |===
 
 WARNING: These encryption types are *not compatible*.
@@ -248,7 +248,7 @@ You may only disable encryption by using the xref:configuration/server/occ_comma
 
 === Limitations of User-Key-Based Encryption 
 
-* Depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+* Deprecated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 * Users added to groups cannot decrypt files on existing shares.
 * OnlyOffice will not work.
 * Impersonate will not work.

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -62,7 +62,7 @@ If the master key has been compromised or exposed, you can replace it. You will 
 
 == User-Key-Based Encryption
 
-IMPORTANT: User-Key encryption has been depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+IMPORTANT: User-Key encryption has been deprecated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 
 === Activate User-Key-Based Encryption
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -62,7 +62,7 @@ If the master key has been compromised or exposed, you can replace it. You will 
 
 == User-Key-Based Encryption
 
-IMPORTANT: User-Key encryption has been depreciated with xref:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+IMPORTANT: User-Key encryption has been depreciated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 
 === Activate User-Key-Based Encryption
 

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -159,7 +159,7 @@ Users can choose an earlier expiration date if they wish.
 Disabling this option activates the "Pending Shares" feature. Users will be notified and have to accept new
 incoming user shares before they appear in the file list and are available for access giving them more control
 over their account. More information about
-xref:ROOT:server_release_notes.adoc#pending-shares[pending shares] can be found in the release notes.
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#pending-shares[pending shares] can be found in the release notes.
 
 === Allow resharing
 
@@ -190,7 +190,7 @@ They can still share with all users of the instance but not with groups they are
 To restrict sharing to users in groups the sharer is a member of the option "Restrict users to only share
 with users in their groups" can be used.
 More information about
-xref:ROOT:server_release_notes.adoc#more-granular-sharing-restrictions[more granular sharing restrictions]
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#more-granular-sharing-restrictions[more granular sharing restrictions]
 can be found in the release notes.
 
 === Allow users to send mail notification for shared files to other users

--- a/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
@@ -11,7 +11,7 @@ IMPORTANT: This approach should not be used unattended nor in clustered setups.
 
 In general, we discourage upgrades with a Linux package manager because you might encounter unwanted side effects and you'll have to manage the PHP installation separately. For further information on upgrading PHP, see section xref:installation/manual_installation/manual_installation.adoc#prepare-your-server[Prepare Your Server]
 
-If you want to proceed anyway, read the xref:ROOT:server_release_notes.adoc[release notes] for important information first.
+If you want to proceed anyway, read the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] for important information first.
 
 Before installing upgraded packages, perform the following steps: 
 
@@ -32,7 +32,7 @@ After the upgrade is finished, perform the following actions:
 include::{partialsdir}maintenance/major_release_note.adoc[]
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at the
-xref:ROOT:server_release_notes.adoc#changes-in-9-1[release notes] for important information about the needed migration steps during that upgrade.
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#changes-in-9-1[release notes] for important information about the needed migration steps during that upgrade.
 
 == Upgrading Only ownCloud or the Complete System
 

--- a/modules/admin_manual/pages/maintenance/upgrading/update.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/update.adoc
@@ -9,7 +9,7 @@ access, such as shared hosting, for installations with a smaller number
 of users and data, and it automates xref:installation/manual_installation/manual_installation.adoc[manual installations].
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Addressbooks please have a look at the
-xref:ROOT:server_release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
 
 [CAUTION]
 ====

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
@@ -11,7 +11,7 @@ the btn:[notification], it will bring you here.
 
 Before beginning an upgrade, please keep the following points in mind:
 
-* Review the xref:ROOT:server_release_notes.adoc[release notes] for important information
+* Review the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] for important information
 about the needed migration steps during that upgrade to help ensure a
 smooth upgrade process.
 * Check ownCloud's xref:installation/manual_installation/manual_installation_prerequisites.adoc[mandatory requirements] (such as PHP versions and extensions), which can change from one version to the next.

--- a/site.yml
+++ b/site.yml
@@ -8,7 +8,7 @@ content:
   - url: .
     branches:
     - HEAD
-  # the docs git is just present for the test build to satisfy used refrences
+  # the docs git is just present for the test build to satisfy used references
   # the real build is made in the docs repo using correct values
   - url: https://github.com/owncloud/docs.git
     branches:

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,11 @@ content:
   - url: .
     branches:
     - HEAD
+  # the docs git is just present for the test build to satisfy used refrences
+  # the real build is made in the docs repo using correct values
+  - url: https://github.com/owncloud/docs.git
+    branches:
+    - master
 
 ui:
   output_dir: assets
@@ -35,6 +40,9 @@ asciidoc:
     oc-marketplace-url: 'https://marketplace.owncloud.com'
     oc-central-url: 'https://central.owncloud.org'
     oc-support-url: 'https://owncloud.com/support'
+#   docs
+    latest-docs-version: 'next'
+    previous-docs-version: 'next'
 #   server
     latest-server-version: '10.9'
     latest-server-download-version: '10.9.1'
@@ -56,6 +64,21 @@ asciidoc:
     std-port-memcache: '11211'
     std-port-mysql: '3306'
     std-port-redis: '6379'
+#   ocis
+    latest-ocis-version: 'next'
+    previous-ocis-version: 'next'
+#   desktop
+    latest-desktop-version: 'next'
+    previous-desktop-version: 'next'
+#   ios-app
+    latest-ios-version: 'next'
+    previous-ios-version: 'next'
+#   android
+    latest-android-version: 'next'
+    previous-android-version: 'next'
+#   branded
+    latest-branded-version: 'next'
+    previous-branded-version: 'next'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
Fixes the references to documents in docs, eg release notes.

Backport to 10.9 and 10.8