### PR TITLE
Update manual upgrade documentation

### DIFF
--- a/modules/admin_manual/examples/installation/manual_installation/owncloud_prep.sh
+++ b/modules/admin_manual/examples/installation/manual_installation/owncloud_prep.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Script Version 2022.02.15
 
 # To setup this script for your environment, hand over the following variables according your needs:
 #
@@ -39,7 +40,7 @@ arguments=6
 
 filmod="0640"
 dirmod="0750"
-htamod="0644"
+htamod="0640"
 
 # Because the data directory can be huge or on external storage, an automatic chmod/chown can take a while.
 # Therefore this directory can be treated differently.
@@ -279,7 +280,9 @@ fi
 # tell to remove the old instance, do upgrade and end maintenance mode ect.
 printf "\nSUCCESS\n\n"
 if [ "$do_upgrade" = "y" ]; then
+  echo "Please manually run: cd $ocroot/$ocname"
   echo "Please manually run: sudo -u$htuser ./occ upgrade"
+  echo "Copy any changes manually added in .user.ini and .htaccess from the backup"
   echo "Please manually run: sudo -u$htuser ./occ maintenance:mode --off"
   echo "Please manually remove the directory of the old instance: $oldocpath"
   echo "When successfully done, re-run this script to secure your .htaccess files"

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
@@ -93,7 +93,7 @@ gpg --verify {oc-complete-name}.tar.bz2.asc o{oc-complete-name}.tar.bz2
 === Script-Guided Installation
 
 Use the xref:installation/manual_installation/script_guided_install.adoc[Script-Guided Installation]
-if you want to easily install or upgrade ownCloud or manage ownership and permissions. The page
+if you want to easily **install** or **upgrade** ownCloud or **manage ownership and permissions**. The page
 contains detailed instructions about downloading and usage.
 
 TIP: Using the _Script Guided Installation_, you can handle many useful installation and update

--- a/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
@@ -9,12 +9,11 @@ There are two scripts you can copy and paste for easy installation and upgrades 
 
 The scripts are written for the `bash` shell. After you copy and paste them, save both in a location where you can easily reuse them.
 
-WARNING: Use the following scripts at your own risk. They may not work as expected if not
-properly configured.
+WARNING: Use the following scripts at your own risk. They may not work as expected if not properly configured.
 
 NOTE: The scripts are only working with tar archives as sources for installations and upgrades.
 
-TIP: You can also use these scripts if you want to set strong permissions.
+TIP: You can also use these scripts if you want to set or reapply strong permissions.
 
 == Configuration
 
@@ -72,11 +71,13 @@ The script asks you a couple of questions which follow a logical path. Default a
 the script extracts the files with tar and automatically extracts them to the target location without copying.
 
 .In case of an upgrade
-the old instance path is backed up by renaming and adding a time stamp. A new target folder with the old name is created. This ensures that in case of extracting and preparation issues, you can easily go back to the previous version. After a successful upgrade, you must manually remove the backup folder.
+the old instance path is backed up by _renaming and adding a time stamp_. A new target folder with the old name is created. This ensures that in case of extracting and preparation issues, you can easily go back to the previous version. After a successful upgrade, you must manually remove the backup folder.
 
 TIP: If you do not install or upgrade, the script sets ownership and permissions only.
 
-NOTE: In case of upgrading, if you have customized the `.htaccess` file in the ownCloud webroot, you have to manually backup your changes and reapply the changes made after the script has finished. Only backup the changes made but not the complete file as this file will be recreated on upgrades and may contain different settings provided by ownCloud. Customizing `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams].
+NOTE: In case of upgrading, if you have customized the `.htaccess` or `.user.ini` file in the ownCloud webroot, you have to manually restore any changes made after the script has finished from the backup folder. Take care to only restore the changes made but not the complete file as this file will be recreated on upgrades by the tar source and may contain different settings provided by ownCloud. Customizing `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams].
+
+NOTE: In case of upgrading, if you have used links for the apps, apps-external and data directory, the script will relink these directories. If you have used normal directories, you manually have to copy any content of these directories back after the script has run. Note you have take care not to overwrite new app versions with older ones.
 
 === Script Questions
 

--- a/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
@@ -5,7 +5,7 @@
 
 == Introduction
 
-There are two scripts you can copy and paste for easy installation and upgrades of ownCloud instances. Using these scripts, you can also reapply ownership and access rights. If you administrate more than one ownCloud instance, you still only need the one `owncloud_prep.sh` script. This script is doing the main job. Have as many instance scripts as you have instances to maintain. Only the instance scripts need configuration, e.g. the respective target directory and other predefined information. The `instance.sh` script (or however you will name it) calls `owncloud_prep.sh` with the configuration you defined for the respective instance.
+There are two scripts you can copy and paste for easy **installation** and **upgrades** of ownCloud instances. Using these scripts, you can also reapply **ownership and access rights**. If you administrate more than one ownCloud instance, you still only need the one `owncloud_prep.sh` script. This script is doing the main job. Have as many instance scripts as you have instances to maintain. Only the instance scripts need configuration, e.g. the respective target directory and other predefined information. The `instance.sh` script (or however you will name it) calls `owncloud_prep.sh` with the configuration you defined for the respective instance.
 
 The scripts are written for the `bash` shell. After you copy and paste them, save both in a location where you can easily reuse them.
 
@@ -17,6 +17,34 @@ TIP: You can also use these scripts if you want to set or reapply strong permiss
 
 == Configuration
 
+* This is a brief overview of main directories in case you use linking. Note that `/mnt/owncloud_data` can be for example nfs mounted. The script takes care of proper linking the source to the target.
++
+[source,text]
+----
+/mnt/owncloud_data
+ └ apps-external
+ └ data
+
+/var/www/owncloud
+ └ apps
+ └ apps-external -> /mnt/owncloud_data/apps-external
+ └ data -> /mnt/owncloud_data/data
+  ..
+----
+
+* This is a brief overview of main directories in case you use standard directories
++
+[source,text]
+----
+/var/www/owncloud
+ └ apps
+ └ apps-external
+ └ data
+  ..
+----
+
+As you can see, and while this makes no difference on installing, upgrading is much easier as you do not need to take care on copying/moving directories as they just get relinked.
+
 NOTE: You only need to edit the `instance.sh` script (or however you name it), if you want to change the default settings.
 
 The following table illustrates the variables to be configured and what they mean.
@@ -26,7 +54,7 @@ The following table illustrates the variables to be configured and what they mea
 |Variable | Description
 |ocname   | The name of your directory containing the owncloud files (default is owncloud)
 |ocroot   | The path to ocname, usually /var/www (no trailing slash, default is /var/www)
-|linkroot | The path to your source directory for linking data and apps-external (default /mnt/owncloud_data)
+|linkroot | The path to your source directory for linking **data** and **apps-external** (default /mnt/owncloud_data). You have to prepare this directory in advance and give it proper ownership and r/w permissions for the webserver user. Note that the **apps** directory is always part of the tar archive and therefore be extracted at its default location without being linked.
 |htuser   | The webserver user (default www-data)
 |htgroup  | The webserver group (default www-data)
 |rootuser | The root user (default root)
@@ -44,7 +72,7 @@ The path must be resolvable! Do not use trailing slashes (`/`). +
 The script resolves this for example to `/var/www/owncloud`.
 
 . `linkroot` +
-Although not mandatory, it is highly recommended that you use symbolic links for the `data` and `apps-external` directories. The `data` directory can grow very large and any copy or move process might take a long time on upgrades. Therefore this directory is often put on external drives or on NFS mounts. The `apps-external` directory is used for all apps not provided by the ownCloud installation. With any physical upgrade you perform, manual intervention like copying may be necessary before finalizing and upgrade. The use of symbolic links makes the administration much easier and less error-prone.
+Although not mandatory, it is highly recommended that you use symbolic links for the `data` and `apps-external` directories. The `data` directory can grow very large and any copy or move process might take a long time on upgrades. Therefore this directory is often put on external drives or on NFS mounts. The `apps-external` directory is used for all apps not provided by the ownCloud installation. With any physical upgrade you perform, manual intervention like copying may be necessary before finalizing and upgrade if you are not using links. The use of symbolic links makes the administration much easier and less error-prone.
 +
 The script uses `linkroot` as base for both the `data` and `apps-external` directories. If not already present, it creates the directories from scratch and links them, both for the installation and on upgrades.
 +
@@ -77,7 +105,7 @@ TIP: If you do not install or upgrade, the script sets ownership and permissions
 
 NOTE: In case of upgrading, if you have customized the `.htaccess` or `.user.ini` file in the ownCloud webroot, you have to manually restore any changes made after the script has finished from the backup folder. Take care to only restore the changes made but not the complete file as this file will be recreated on upgrades by the tar source and may contain different settings provided by ownCloud. Customizing `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams].
 
-NOTE: In case of upgrading, if you have used links for the apps, apps-external and data directory, the script will relink these directories. If you have used normal directories, you manually have to copy any content of these directories back after the script has run. Note you have take care not to overwrite new app versions with older ones.
+NOTE: In case of upgrading, if you have used links for the apps-external and data directory, the script will relink these directories. If you have used normal directories, you manually have to copy any content of these directories back after the script has run. Note you have take care not to overwrite new app versions with older ones.
 
 === Script Questions
 
@@ -122,14 +150,14 @@ sudo chmod +x scriptname.sh
 +
 [source,bash]
 ----
-include::{examplesdir}installation/manual_installation/instance.sh[]
+include::example$installation/manual_installation/instance.sh[]
 ----
 
 . The `owncloud_prep.sh` script
 +
 [source,bash]
 ----
-include::{examplesdir}installation/manual_installation/owncloud_prep.sh[]
+include::example$installation/manual_installation/owncloud_prep.sh[]
 ----
 
 == Final Steps
@@ -137,8 +165,16 @@ include::{examplesdir}installation/manual_installation/owncloud_prep.sh[]
 When running the script, you will see success messages when finished.
 
 .When installing
-enter the URL of your ownCloud instance in a browser and continue the setup via the graphical installation wizard. For more information, see xref:installation/installation_wizard.adoc[The Installation Wizard].
+Enter the URL of your ownCloud instance in a browser and continue the setup via the graphical installation wizard. For more information, see xref:installation/installation_wizard.adoc[The Installation Wizard].
 The URL you need to enter in the browser depends on the webserver setup taken and either is an external URL or if you installed locally, you should be able to access your ownCloud instance via a browser at `\http://127.0.0.1/owncloud/` or `\http://localhost/owncloud/`.
 
 .When upgrading
-follow the steps printed on the screen. Do not forget to reapply manually made changes made to `.htaccess` in your owncloud root directory.
+Follow the steps printed on the screen. Do not forget to reapply manually made changes made to `.htaccess` and `.user.ini` in your owncloud root directory.
+
+.How to get the difference of two files quickly
+The following example command eases to find the differences of two files, which is helpful for reapplying manually added changes to `.htaccess` and `.user.ini`. Replace that paths, directories and files accordingly.
+[source,console]
+----
+diff -y -W 70 --suppress-common-lines owncloud/.user.ini owncloud_2022-02-15-09.18.48/.user.ini
+post_max_size=513M                |     post_max_size=1G
+----

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -5,7 +5,9 @@
 
 == Introduction
 
-This document describes how to manually upgrade your ownCloud installation. After preparing the upgrade, you can decide between two ways of upgrading your instance:
+This document describes how to manually upgrade your ownCloud installation. Because installations can vary, this guide can only give an overview of methods and examples. These examples need to be adapted according your needs and your environment.
+
+After preparing the upgrade, you can decide between two ways of upgrading your instance:
 
 .Script-Guided Upgrade
 This upgrade automates most of the tasks to be done including setting the correct ownership and permissions.
@@ -66,24 +68,32 @@ Go to menu:Settings[Admin > Apps] and disable all third-party apps.
 
 If you have made changes in `.htaccess` located at the webroot of ownCloud, you must backup these changes. Only backup the changes made but not the complete file as this file will be recreated on upgrades and may contain different settings provided by ownCloud. Manual changes in `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams].
 
+=== Backup Manual Changes in `.user.ini`
+
+If you have made changes in `.user.ini` located at the webroot of ownCloud, you must backup these changes.
+
 === Download the Latest Release
 
-Download the latest https://owncloud.org/download/[ownCloud server release] to where your previous installation was, in this example the default directory `/var/www/`.
+Download the latest https://owncloud.org/download/[ownCloud server release] to the same location where your previous instance is located, in this example the default directory `/var/www/`.
 [source,console,subs="attributes+"]
 ----
 cd /var/www/
-sudo wget https://download.owncloud.org/community/owncloud-{latest-server-download-version}.tar.bz2
+sudo wget https://download.owncloud.org/community/owncloud-{oc-complete-name}.tar.bz2
 ----
 
 == Script-Guided Upgrade
 
-When using the script-guided upgrade, the script from the xref:installation/manual_installation/manual_installation.adoc#script-guided-installation[Script-Guided Installation] is used. The script xref:installation/manual_installation/script_guided_install.adoc#script-questions[asks questions] and beside other parameters, the *upgrade an existing installation* is selected.
+When using the script-guided upgrade, the script from the xref:installation/manual_installation/manual_installation.adoc#script-guided-installation[Script-Guided Installation] is used. This script can not only **install** a new instance of ownCloud, but also **upgarde** an existing one or can **manage ownership and permissions**. When using the script for upgrading, the script renames the current instance and creates a new instance, copies `config.php` set ownership and permissions etc.
+
+The script xref:installation/manual_installation/script_guided_install.adoc#script-questions[asks questions] and beside other parameters, the *upgrade an existing installation* question is selected.
 
 Follow the script documentation for details on how to install and use it.
 
 NOTE: The script is most convenient if you use links for your `apps`, `apps-external` and your `data` directory, as it takes care of recreating the links. You will be asked about this when you run the script. If you're using regular directories, these are created, but content must be moved or copied manually before finalizing the upgrade. If you aren't using the `apps-external` directory, you must manually take care of copying only those apps which are not part of the new source.
 
 When the script has finished, continue with the xref:upgrade[Upgrade] step described below.
+
+NOTE: When using the script, any manual changes in `.htaccess` or `.user.ini` must be manually transferred from the backup directory the script created to the actual instance directory. 
 
 After the upgrade is finished, you can re-run this script to secure the `.htaccess` files.
 
@@ -106,7 +116,7 @@ Extract the new server release in the location where your previous ownCloud inst
 
 [source,console,subs="attributes+"]
 ----
-sudo tar -xf owncloud-{latest-server-download-version}.tar.bz2
+sudo tar -xf owncloud-{oc-complete-name}.tar.bz2
 ----
 
 With the new source files now in place of where the old ones used to be, copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
@@ -176,10 +186,9 @@ The upgrade operation can take anywhere from a few minutes to a few hours, depen
 
 Reapply any manual changes made to the `.htaccess` file located in the owncloud webroot. 
 
-=== Strong Permissions for .htaccess
+=== Strong Permissions
 
-.Set strong permissions for the .htaccess files
-* Use `chmod` with `0640` for the .htaccess files.
+* Use `chmod` with `0640` for `.htaccess` and `.user.ini` files.
 
 If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well.
 

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -7,6 +7,8 @@
 
 This document describes how to manually upgrade your ownCloud installation. Because installations can vary, this guide can only give an overview of methods and examples. These examples need to be adapted according your needs and your environment.
 
+NOTE: This guide assumes that you have basic knowledge about Unix terminology, commands and concepts. In case you do not feel familiar with this, ownCloud highly recommends that you create a playground first to try the steps and/or get, if you are entitled to, in touch with ownCloud Support to avoid breaking your system or data loss.
+
 After preparing the upgrade, you can decide between two ways of upgrading your instance:
 
 .Script-Guided Upgrade
@@ -15,8 +17,7 @@ This upgrade automates most of the tasks to be done including setting the correc
 .Manual Step-by-Step Upgrade 
 Using this type of upgrade, you have to do all the steps manually but you can also handle special setups.
 
-NOTE: In this description we assume that your ownCloud installation was located in the default directory: `/var/www/owncloud` and the new release will reside there as well. 
-The path might differ, depending on your installation.
+NOTE: In this description we assume that your ownCloud installation was located in the default directory: `/var/www/owncloud` and the new release will reside there as well. The path might differ, depending on your installation.
 
 == General Preparation
 
@@ -24,7 +25,7 @@ There are several steps necessary before you can start with upgrading your ownCl
 
 === Enable Maintenance Mode
 
-Put your server in xref:maintenance/enable_maintenance.adoc[maintenance mode] and *disable xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[Cron jobs]*.
+Put your server in xref:maintenance/enable_maintenance.adoc[maintenance mode] and *disable* xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[Cron jobs].
 Doing so prevents new logins, locks the sessions of logged-in users, and displays a status screen so that users know what is happening.
 
 TIP: In a clustered environment, check that all nodes are in maintenance mode.
@@ -89,9 +90,9 @@ The script xref:installation/manual_installation/script_guided_install.adoc#scri
 
 Follow the script documentation for details on how to install and use it.
 
-NOTE: The script is most convenient if you use links for your `apps`, `apps-external` and your `data` directory, as it takes care of recreating the links. You will be asked about this when you run the script. If you're using regular directories, these are created, but content must be moved or copied manually before finalizing the upgrade. If you aren't using the `apps-external` directory, you must manually take care of copying only those apps which are not part of the new source.
+NOTE: The script is most convenient if you use links for your `apps-external` and your `data` directory, as it takes care of recreating the links. You will be asked about this when you run the script. If you're using regular directories, these are created, but content must be moved or copied manually before finalizing the upgrade. If you aren't using the `apps-external` directory, you must manually take care of copying only those apps which are not part of the new source.
 
-When the script has finished, continue with the xref:upgrade[Upgrade] step described below.
+When the script has finished, continue with the xref:finalize-the-upgrade[Finalize the Upgrade] step described below.
 
 NOTE: When using the script, any manual changes in `.htaccess` or `.user.ini` must be manually transferred from the backup directory the script created to the actual instance directory. 
 
@@ -119,12 +120,7 @@ Extract the new server release in the location where your previous ownCloud inst
 sudo tar -xf owncloud-{oc-complete-name}.tar.bz2
 ----
 
-With the new source files now in place of where the old ones used to be, copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
-
-[source,console]
-----
-sudo cp /var/www/backup_owncloud/config/config.php /var/www/owncloud/config/config.php
-----
+=== Copy the data/ Directory
 
 If you keep your `data/` directory _inside_ your `owncloud/` directory, move it from your old version of ownCloud to your new version:
 
@@ -133,11 +129,18 @@ If you keep your `data/` directory _inside_ your `owncloud/` directory, move it 
 sudo mv /var/www/backup_owncloud/data /var/www/owncloud/data
 ----
 
+If you have linked the data directory, for ownCloud it is still inside the `owncloud` directory and you have to re-link it.
+
 If you keep your `data` **outside** of your `owncloud` directory, then you don’t have to do anything with it, because its location is configured in your original `config.php`, and none of the upgrade steps touch it.
 
 === Copy Relevant config.php Content
 
-Copy, or make sure that all relevant `config.php` content from the backup is present in the new installation.
+With the new source files now in place of where the old ones used to be, copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
+
+[source,console]
+----
+sudo cp /var/www/backup_owncloud/config/config.php /var/www/owncloud/config/config.php
+----
 
 === Market and Marketplace App Upgrades
 
@@ -156,18 +159,44 @@ NOTE: Make sure that all app directories that are defined in the `apps_paths` se
 To finalize the preparation of the upgrade, you need to set the correct ownership and permissions of the new ownCloud files and folders.
 
 .Set correct ownership
+Set the ownership for all files and folders to `root:www-data` **except** the `config` and `data` directory:
+
 [source,console]
 ----
-sudo chown -R www-data:www-data /var/www/owncloud
+sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type d -exec chown root:www-data {} \+
+----
+
+[source,console]
+----
+sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type f -exec chown root:www-data {} \+
+----
+
+Set the ownership for all files and folders to `www-data:www-data` for the `config` and `data` directory. Note that it is not mandatory to set the ownership of the `data/` directory as it should already have the correct ownership and it can take a while to finish, depending on the size:
+
+[source,console]
+----
+sudo chown -R www-data:www-data /var/www/owncloud/config
+sudo chown -R www-data:www-data /var/www/owncloud/data
 ----
 
 .Set correct permissions
 Use `chmod` on files and directories with different permissions:
 
-* For all files use `0640` +
-* For all directories use `0750`
+* For all files use `0640`
++
+[source,console]
+----
+sudo find . -type f -exec chmod 640 {} \;
+----
 
-If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well.
+* For all directories use `0750`
++
+[source,console]
+----
+sudo find . -type d -exec chmod 750 {} \;
+----
+
+If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well as it automates it.
 
 == Finalize the Upgrade
 
@@ -184,13 +213,22 @@ With the apps disabled and ownCloud in maintenance mode, start the xref:configur
 
 The upgrade operation can take anywhere from a few minutes to a few hours, depending on the size of your installation. When it is finished you will see either a success message or an error message that indicates why the process did not complete successfully.
 
-Reapply any manual changes made to the `.htaccess` file located in the owncloud webroot. 
+== Reapply Manual Changes
+
+Reapply any manual changes made to `.htaccess` files and the `.user.ini` file located in the owncloud webroot. 
+
+The following example command eases to find the differences of two files, which is helpful for reapplying manually added changes to `.htaccess` and `.user.ini`. Replace that paths, directories and files accordingly.
+[source,console]
+----
+diff -y -W 70 --suppress-common-lines owncloud/.user.ini owncloud_2022-02-15-09.18.48/.user.ini
+post_max_size=513M                |     post_max_size=1G
+----
 
 === Strong Permissions
 
-* Use `chmod` with `0640` for `.htaccess` and `.user.ini` files.
+* Check that `chmod` with `0640` for `.htaccess` and `.user.ini` files has been applied.
 
-If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well.
+If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well as it automates it.
 
 === Disable Maintenance Mode
 

--- a/site.yml
+++ b/site.yml
@@ -54,7 +54,7 @@ asciidoc:
     oc-examples-server-ip: '127.0.0.1'
     oc-examples-username: 'username'
     oc-examples-password: 'password'
-    oc-complete-name: 'owncloud-complete-20220112'
+    oc-complete-name: 'owncloud-complete-latest'
     occ-command-example-prefix: 'sudo -u www-data php occ'
     occ-command-example-prefix-no-sudo: 'php occ'
     php-net-url: 'https://www.php.net'


### PR DESCRIPTION
Fixes: https://github.com/owncloud/enterprise/issues/5019 ([Documentation from Manual Upgrade generates problems by the Customers](https://github.com/owncloud/enterprise/issues/5019#))

Improves the manual upgrade documentation.

Backport to 10.9 and 10.8

@cdamken fyi