### PR TITLE
Dev: rename {examplesdir} with example$

### DIFF
--- a/modules/developer_manual/pages/app/advanced/extstorage.adoc
+++ b/modules/developer_manual/pages/app/advanced/extstorage.adoc
@@ -22,7 +22,7 @@ For example:
 
 [source,xml]
 ----
-include::{examplesdir}app/storage-backend/appinfo/info.xml[]
+include::example$app/storage-backend/appinfo/info.xml[]
 ----
 
 == Implement the storage class(es)
@@ -177,7 +177,7 @@ can be done in the `Application` class by implementing the
 
 [source,php]
 ----
-include::{examplesdir}app/storage-backend/OCA/MyStorageApp/AppInfo/Application.php[]
+include::example$app/storage-backend/OCA/MyStorageApp/AppInfo/Application.php[]
 ----
 
 Then in appinfo/app.php instantiate the `Application` class:

--- a/modules/developer_manual/pages/app/advanced/notifications.adoc
+++ b/modules/developer_manual/pages/app/advanced/notifications.adoc
@@ -198,7 +198,7 @@ The notification has a number of properties set that help identify the app that 
 
 [source,php]
 ----
-include::{examplesdir}app/advanced/notifications/intro-notification.php[]
+include::example$app/advanced/notifications/intro-notification.php[]
 ----
 
 TIP: Make sure the app set in the notification matches the one you're expecting, because other notifications for other apps might reach your notifier. 
@@ -216,5 +216,5 @@ You can see an example of how to perform all of these steps in the example below
 
 [source,php]
 ----
-include::{examplesdir}app/advanced/notifications/notification-with-object.php[]
+include::example$app/advanced/notifications/notification-with-object.php[]
 ----

--- a/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/backgroundjobs.adoc
@@ -17,7 +17,7 @@ calling its `run` method.
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/cron/SomeTask.php[]
+include::example$app/fundamentals/cron/SomeTask.php[]
 ----
 
 Try to keep the method as small as possible, because its hard to test

--- a/modules/developer_manual/pages/app/fundamentals/database.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/database.adoc
@@ -10,7 +10,7 @@ Inside your database layer class you can now start running queries like:
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/database-access.php[]
+include::example$app/fundamentals/database/database-access.php[]
 ----
 
 == Database Programming Guidelines
@@ -50,7 +50,7 @@ in the example below
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/authormapper.php[]
+include::example$app/fundamentals/database/authormapper.php[]
 ----
 
 The cursor is closed automatically for all *INSERT*, *DELETE*, *UPDATE* queries and when calling the methods *findOneQuery*, *findEntities*, *findEntity*, *delete*, *insert* and *update*. 
@@ -79,7 +79,7 @@ Table rows are mapped from lower case and underscore separated names to pascal c
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/author.php[]
+include::example$app/fundamentals/database/author.php[]
 ----
 
 == Types
@@ -98,7 +98,7 @@ Since all attributes should be protected, getters and setters are automatically 
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/author-access-attributes.php[]
+include::example$app/fundamentals/database/author-access-attributes.php[]
 ----
 
 == Custom Attribute to Database Column Mapping
@@ -109,7 +109,7 @@ To define a custom mapping, simply override the `columnToProperty` and `property
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/custom-attribute-to-database-column-mapping.php[]
+include::example$app/fundamentals/database/custom-attribute-to-database-column-mapping.php[]
 ----
 
 == Slugs
@@ -119,7 +119,7 @@ Since the URL allows only certain values, the entity `baseclass` provides a `slu
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/slug.php[]
+include::example$app/fundamentals/database/slug.php[]
 ----
 
 == Database Migrations
@@ -148,7 +148,7 @@ Below is a migration code sample for creating an application’s core table.
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/migrations.php[]
+include::example$app/fundamentals/database/migrations.php[]
 ----
 
 You can see examples of how to create the three migration types in the next section.
@@ -177,7 +177,7 @@ The simple migration step skeleton looks like this:
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/create-migration-step.php[]
+include::example$app/fundamentals/database/create-migration-step.php[]
 ----
 
 === A SQL Migration Step
@@ -186,7 +186,7 @@ A SQL migration step skeleton looks like this:
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/sql-migration-step.php[]
+include::example$app/fundamentals/database/sql-migration-step.php[]
 ----
 
 Within the `sql()` method you can generate any number of SQL commands.
@@ -203,7 +203,7 @@ A schema migration step skeleton looks like this:
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/database/schema-migration-step.php[]
+include::example$app/fundamentals/database/schema-migration-step.php[]
 ----
 
 Within the `changeSchema()` method, you can use the {dbal-class-schema-url}[Class Schema] to manipulate the existing database schema.
@@ -233,7 +233,7 @@ An example database XML file would look like this:
 
 [source,xml]
 ----
-include::{examplesdir}app/fundamentals/database/schema-update.xml[]
+include::example$app/fundamentals/database/schema-update.xml[]
 ----
 
 To update the tables used by the app: adjust the `database.xml` file to reflect the changes which you want to make. 

--- a/modules/developer_manual/pages/app/fundamentals/filesystem.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/filesystem.adoc
@@ -115,5 +115,5 @@ A storage's owner can be retrieved using a file id, as in the following example.
 
 [source,php]
 ----
-include::{examplesdir}app/fundamentals/filesystem/getOwnerByFileId.php[]
+include::example$app/fundamentals/filesystem/getOwnerByFileId.php[]
 ----

--- a/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
@@ -25,7 +25,7 @@ This will return a JSON response, similar to the example below, along with a sta
 
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs-capabilities/list-capabilities-response.json[]
+include::example$core/apis/ocs-capabilities/list-capabilities-response.json[]
 ----
 
 In the example, in the `capabilities` element, you can see that the

--- a/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notification-endpoint-v1.adoc
@@ -38,7 +38,7 @@ JSON::
 --
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.json[]
+include::example$core/apis/ocs/notifications/get-server-capabilities-response.json[]
 ----
 --
 
@@ -47,7 +47,7 @@ XML::
 --
 [source,xml]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.xml[]
+include::example$core/apis/ocs/notifications/get-server-capabilities-response.xml[]
 ----
 --
 ====
@@ -58,14 +58,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.json[]
+include::example$core/apis/ocs/notifications/get-server-capabilities-response.json[]
 ----
 
 ==== XML
 
 [source,xml]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-server-capabilities-response.xml[]
+include::example$core/apis/ocs/notifications/get-server-capabilities-response.xml[]
 ----
 endif::[]
 
@@ -79,7 +79,7 @@ Curl::
 --
 [source,bash,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notifications/get-server-capabilities.sh[]
+include::example$core/scripts/curl/ocs/notifications/get-server-capabilities.sh[]
 ----
 --
 ====
@@ -90,7 +90,7 @@ ifeval::["{format}" == "pdf"]
 
 [source,bash,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notifications/get-server-capabilities.sh[]
+include::example$core/scripts/curl/ocs/notifications/get-server-capabilities.sh[]
 ----
 endif::[]
 
@@ -142,7 +142,7 @@ JSON::
 --
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-response.json[]
+include::example$core/apis/ocs/notifications/get-user-notifications-response.json[]
 ----
 --
 ====
@@ -153,7 +153,7 @@ ifeval::["{format}" == "pdf"]
 
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-response.json[]
+include::example$core/apis/ocs/notifications/get-user-notifications-response.json[]
 ----
 endif::[]
 
@@ -167,7 +167,7 @@ JSON::
 --
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-no-notifications-response.json[]
+include::example$core/apis/ocs/notifications/get-user-notifications-no-notifications-response.json[]
 ----
 --
 ====
@@ -178,7 +178,7 @@ ifeval::["{format}" == "pdf"]
 
 [source,json]
 ----
-include::{examplesdir}core/apis/ocs/notifications/get-user-notifications-no-notifications-response.json[]
+include::example$core/apis/ocs/notifications/get-user-notifications-no-notifications-response.json[]
 ----
 endif::[]
 
@@ -281,7 +281,7 @@ Curl::
 --
 [source,bash,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notifications/get-user-notifications.sh[]
+include::example$core/scripts/curl/ocs/notifications/get-user-notifications.sh[]
 ----
 --
 ====
@@ -292,7 +292,7 @@ ifeval::["{format}" == "pdf"]
 
 [source,bash,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notifications/get-user-notifications.sh[]
+include::example$core/scripts/curl/ocs/notifications/get-user-notifications.sh[]
 ----
 endif::[]
 

--- a/modules/developer_manual/pages/core/apis/ocs-notify-public-link-by-email.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-notify-public-link-by-email.adoc
@@ -63,7 +63,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notify-public-link-by-email.sh[]
+include::example$core/scripts/curl/ocs/notify-public-link-by-email.sh[]
 ----
 --
 PHP::
@@ -71,7 +71,7 @@ PHP::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/notify-public-link-by-email.php[]
+include::example$core/scripts/php/notify-public-link-by-email.php[]
 ----
 --
 ====
@@ -82,14 +82,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/notify-public-link-by-email.sh[]
+include::example$core/scripts/curl/ocs/notify-public-link-by-email.sh[]
 ----
 
 === PHP
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/notify-public-link-by-email.php[]
+include::example$core/scripts/php/notify-public-link-by-email.php[]
 ----
 endif::[]
 

--- a/modules/developer_manual/pages/core/apis/ocs-recipient-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-recipient-api.adoc
@@ -58,12 +58,12 @@ If the users admin, user1, user2 and the groups group1 and group2 were registerd
 
 [source,json]
 ----
-include::{examplesdir}core/scripts/responses/recipients/response-success.json[]
+include::example$core/scripts/responses/recipients/response-success.json[]
 ----
 
 The same request with xml body.
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/recipients/response-success.xml[]
+include::example$core/scripts/responses/recipients/response-success.xml[]
 ----

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -78,31 +78,31 @@ If the user that you're connecting with is not authorized, then you will see out
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/not-authorised-response.xml[]
+include::example$core/scripts/responses/not-authorised-response.xml[]
 ----
 
 If the user that you're connecting with _is_ authorized, then you will see output similar to the following:
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/get-all-shares-success-no-shares.xml[]
+include::example$core/scripts/responses/shares/get-all-shares-success-no-shares.xml[]
 ----
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/list-share-details-failure.xml[]
+include::example$core/scripts/responses/shares/list-share-details-failure.xml[]
 ----
 
 .Files shared with the current user in XML format.
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/list-share-details-success.xml[]
+include::example$core/scripts/responses/shares/list-share-details-success.xml[]
 ----
 
 .Files shared with the current user in JSON format.
 [source,json]
 ----
-include::{examplesdir}core/scripts/responses/shares/list-share-details-success.json[]
+include::example$core/scripts/responses/shares/list-share-details-success.json[]
 ----
 
 ==== Code Example
@@ -115,7 +115,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/list-share-details.sh[]
+include::example$core/scripts/curl/list-share-details.sh[]
 ----
 --
 PHP::
@@ -123,7 +123,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/list-share-details.php[]
+include::example$core/scripts/php/list-share-details.php[]
 ----
 --
 Ruby::
@@ -131,7 +131,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/list-share-details.rb[]
+include::example$core/scripts/ruby/list-share-details.rb[]
 ----
 --
 Go::
@@ -139,7 +139,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/list-share-details.go[]
+include::example$core/scripts/go/list-share-details.go[]
 ----
 --
 ====
@@ -150,28 +150,28 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/list-share-details.sh[]
+include::example$core/scripts/curl/list-share-details.sh[]
 ----
 
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/list-share-details.php[]
+include::example$core/scripts/php/list-share-details.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/list-share-details.rb[]
+include::example$core/scripts/ruby/list-share-details.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/list-share-details.go[]
+include::example$core/scripts/go/list-share-details.go[]
 ----
 endif::[]
 
@@ -210,7 +210,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/get-share-info.sh[]
+include::example$core/scripts/curl/get-share-info.sh[]
 ----
 --
 PHP::
@@ -218,7 +218,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/get-share-info.php[]
+include::example$core/scripts/php/get-share-info.php[]
 ----
 --
 Ruby::
@@ -226,7 +226,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/get-share-info.rb[]
+include::example$core/scripts/ruby/get-share-info.rb[]
 ----
 --
 Go::
@@ -234,7 +234,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/get-share-info.go[]
+include::example$core/scripts/go/get-share-info.go[]
 ----
 --
 Kotlin::
@@ -242,7 +242,7 @@ Kotlin::
 --
 [source,kotlin,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/kotlin/get-share-info.kt[]
+include::example$core/scripts/kotlin/get-share-info.kt[]
 ----
 --
 Java::
@@ -250,7 +250,7 @@ Java::
 --
 [source,java,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/java/get-share-info.java[]
+include::example$core/scripts/java/get-share-info.java[]
 ----
 --
 ====
@@ -261,42 +261,42 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/get-share-info.sh[]
+include::example$core/scripts/curl/get-share-info.sh[]
 ----
 
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/get-share-info.php[]
+include::example$core/scripts/php/get-share-info.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/get-share-info.rb[]
+include::example$core/scripts/ruby/get-share-info.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/get-share-info.go[]
+include::example$core/scripts/go/get-share-info.go[]
 ----
 
 ===== Kotlin
 
 [source,kotlin,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/kotlin/get-share-info.kt[]
+include::example$core/scripts/kotlin/get-share-info.kt[]
 ----
 
 ===== Java
 
 [source,java,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/java/get-share-info.java[]
+include::example$core/scripts/java/get-share-info.java[]
 ----
 endif::[]
 
@@ -312,7 +312,7 @@ Success::
 --
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/get-share-info-success.xml[]
+include::example$core/scripts/responses/shares/get-share-info-success.xml[]
 ----
 --
 Failure::
@@ -320,7 +320,7 @@ Failure::
 --
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/get-share-info-failure.xml[]
+include::example$core/scripts/responses/shares/get-share-info-failure.xml[]
 ----
 --
 ====
@@ -331,14 +331,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/get-share-info-success.xml[]
+include::example$core/scripts/responses/shares/get-share-info-success.xml[]
 ----
 
 ===== Failure
 
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/get-share-info-failure.xml[]
+include::example$core/scripts/responses/shares/get-share-info-failure.xml[]
 ----
 endif::[]
 
@@ -392,7 +392,7 @@ Success::
 .Pending share was successfully accepted
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/accept-pending-share-success.xml[]
+include::example$core/scripts/responses/shares/accept-pending-share-success.xml[]
 ----
 --
 Failure::
@@ -401,7 +401,7 @@ Failure::
 .The share id does not exist.
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/accept-pending-share-failure.xml[]
+include::example$core/scripts/responses/shares/accept-pending-share-failure.xml[]
 ----
 --
 ====
@@ -413,7 +413,7 @@ ifeval::["{format}" == "pdf"]
 .Pending share was successfully accepted
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/accept-pending-share-success.xml[]
+include::example$core/scripts/responses/shares/accept-pending-share-success.xml[]
 ----
 
 ===== Failure
@@ -421,7 +421,7 @@ include::{examplesdir}core/scripts/responses/shares/accept-pending-share-success
 .The share id does not exist.
 [source,console]
 ----
-include::{examplesdir}core/scripts/responses/shares/accept-pending-share-failure.xml[]
+include::example$core/scripts/responses/shares/accept-pending-share-failure.xml[]
 ----
 endif::[]
 
@@ -435,7 +435,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/accept-pending-share.sh[]
+include::example$core/scripts/curl/accept-pending-share.sh[]
 ----
 --
 PHP::
@@ -443,7 +443,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/accept-pending-share.php[]
+include::example$core/scripts/php/accept-pending-share.php[]
 ----
 --
 Ruby::
@@ -451,7 +451,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/accept-pending-share.rb[]
+include::example$core/scripts/ruby/accept-pending-share.rb[]
 ----
 --
 Go::
@@ -459,7 +459,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/accept-pending-share.go[]
+include::example$core/scripts/go/accept-pending-share.go[]
 ----
 --
 ====
@@ -470,28 +470,28 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/accept-pending-share.sh[]
+include::example$core/scripts/curl/accept-pending-share.sh[]
 ----
 
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/accept-pending-share.php[]
+include::example$core/scripts/php/accept-pending-share.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/accept-pending-share.rb[]
+include::example$core/scripts/ruby/accept-pending-share.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/accept-pending-share.go[]
+include::example$core/scripts/go/accept-pending-share.go[]
 ----
 endif::[]
 
@@ -574,7 +574,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/decline-pending-share.sh[]
+include::example$core/scripts/curl/decline-pending-share.sh[]
 ----
 --
 PHP::
@@ -582,7 +582,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/decline-pending-share.php[]
+include::example$core/scripts/php/decline-pending-share.php[]
 ----
 --
 Ruby::
@@ -590,7 +590,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/decline-pending-share.rb[]
+include::example$core/scripts/ruby/decline-pending-share.rb[]
 ----
 --
 Go::
@@ -598,7 +598,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/decline-pending-share.go[]
+include::example$core/scripts/go/decline-pending-share.go[]
 ----
 --
 ====
@@ -609,28 +609,28 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/decline-pending-share.sh[]
+include::example$core/scripts/curl/decline-pending-share.sh[]
 ----
 --
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/decline-pending-share.php[]
+include::example$core/scripts/php/decline-pending-share.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/decline-pending-share.rb[]
+include::example$core/scripts/ruby/decline-pending-share.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/decline-pending-share.go[]
+include::example$core/scripts/go/decline-pending-share.go[]
 ----
 endif::[]
 
@@ -731,7 +731,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/create-share.sh[]
+include::example$core/scripts/curl/create-share.sh[]
 ----
 --
 PHP::
@@ -739,7 +739,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/create-share.php[]
+include::example$core/scripts/php/create-share.php[]
 ----
 --
 Ruby::
@@ -747,7 +747,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/create-share.rb[]
+include::example$core/scripts/ruby/create-share.rb[]
 ----
 --
 Go::
@@ -755,7 +755,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/create-share.go[]
+include::example$core/scripts/go/create-share.go[]
 ----
 --
 ====
@@ -766,28 +766,28 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/create-share.sh[]
+include::example$core/scripts/curl/create-share.sh[]
 ----
 
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/create-share.php[]
+include::example$core/scripts/php/create-share.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/create-share.rb[]
+include::example$core/scripts/ruby/create-share.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/create-share.go[]
+include::example$core/scripts/go/create-share.go[]
 ----
 endif::[]
 
@@ -797,14 +797,14 @@ Failure
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/create-share-failure.xml[]
+include::example$core/scripts/responses/shares/create-share-failure.xml[]
 ----
 
 Success
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/create-share-success.xml[]
+include::example$core/scripts/responses/shares/create-share-success.xml[]
 ----
 
 ==== Response Attributes
@@ -922,7 +922,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/delete-share.sh[]
+include::example$core/scripts/curl/delete-share.sh[]
 ----
 --
 PHP::
@@ -930,7 +930,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/delete-share.php[]
+include::example$core/scripts/php/delete-share.php[]
 ----
 --
 Ruby::
@@ -938,7 +938,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/delete-share.rb[]
+include::example$core/scripts/ruby/delete-share.rb[]
 ----
 --
 Go::
@@ -946,7 +946,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/delete-share.go[]
+include::example$core/scripts/go/delete-share.go[]
 ----
 --
 ====
@@ -958,7 +958,7 @@ Curl
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/delete-share.sh[]
+include::example$core/scripts/curl/delete-share.sh[]
 ----
 --
 PHP::
@@ -966,7 +966,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/delete-share.php[]
+include::example$core/scripts/php/delete-share.php[]
 ----
 --
 Ruby::
@@ -974,7 +974,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/delete-share.rb[]
+include::example$core/scripts/ruby/delete-share.rb[]
 ----
 --
 Go::
@@ -982,7 +982,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/delete-share.go[]
+include::example$core/scripts/go/delete-share.go[]
 ----
 endif::[]
 
@@ -992,14 +992,14 @@ Failure
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/delete-share-success.xml[]
+include::example$core/scripts/responses/shares/delete-share-success.xml[]
 ----
 
 Success
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/delete-share-failure.xml[]
+include::example$core/scripts/responses/shares/delete-share-failure.xml[]
 ----
 
 === Update Share
@@ -1054,7 +1054,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/update-share.sh[]
+include::example$core/scripts/curl/update-share.sh[]
 ----
 --
 PHP::
@@ -1062,7 +1062,7 @@ PHP::
 --
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/update-share.php[]
+include::example$core/scripts/php/update-share.php[]
 ----
 --
 Ruby::
@@ -1070,7 +1070,7 @@ Ruby::
 --
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/update-share.rb[]
+include::example$core/scripts/ruby/update-share.rb[]
 ----
 --
 Go::
@@ -1078,7 +1078,7 @@ Go::
 --
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/update-share.go[]
+include::example$core/scripts/go/update-share.go[]
 ----
 --
 ====
@@ -1089,28 +1089,28 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/update-share.sh[]
+include::example$core/scripts/curl/update-share.sh[]
 ----
 
 ===== PHP
 
 [source,php,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/update-share.php[]
+include::example$core/scripts/php/update-share.php[]
 ----
 
 ===== Ruby
 
 [source,ruby,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/ruby/update-share.rb[]
+include::example$core/scripts/ruby/update-share.rb[]
 ----
 
 ===== Go
 
 [source,go,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/go/update-share.go[]
+include::example$core/scripts/go/update-share.go[]
 ----
 endif::[]
 
@@ -1120,14 +1120,14 @@ Failure
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/update-share-failure.xml[]
+include::example$core/scripts/responses/shares/update-share-failure.xml[]
 ----
 
 Success
 
 [source,xml]
 ----
-include::{examplesdir}core/scripts/responses/shares/update-share-success.xml[]
+include::example$core/scripts/responses/shares/update-share-success.xml[]
 ----
 
 == Federated Cloud Shares

--- a/modules/developer_manual/pages/core/apis/ocs-totp-validation-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-totp-validation-api.adoc
@@ -50,7 +50,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/validate-totp.sh[]
+include::example$core/scripts/curl/ocs/validate-totp.sh[]
 ----
 --
 ====
@@ -59,7 +59,7 @@ endif::[]
 ifeval::["{format}" == "pdf"]
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/validate-totp.sh[]
+include::example$core/scripts/curl/ocs/validate-totp.sh[]
 ----
 --
 endif::[]
@@ -90,7 +90,7 @@ JSON::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
 ----
 --
 
@@ -99,7 +99,7 @@ XML::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
 ----
 --
 ====
@@ -110,7 +110,7 @@ ifeval::["{format}" == "pdf"]
 
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-is-valid.json[]
 ----
 
 ===== XML
@@ -118,7 +118,7 @@ include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-valid
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-is-valid.xml[]
 ----
 endif::[]
 
@@ -132,7 +132,7 @@ JSON::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-invalid.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-is-invalid.json[]
 ----
 --
 
@@ -141,7 +141,7 @@ XML::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-invalid.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-is-invalid.xml[]
 ----
 --
 ====
@@ -152,14 +152,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-is-invalid.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-is-invalid.json[]
 ----
 
 ===== XML
 
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-is-invalid.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-is-invalid.xml[]
 ----
 endif::[]
 
@@ -173,7 +173,7 @@ JSON::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-user-is-not-found.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-user-is-not-found.json[]
 ----
 --
 
@@ -182,7 +182,7 @@ XML::
 --
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-user-is-not-found.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-user-is-not-found.xml[]
 ----
 --
 ====
@@ -193,14 +193,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/json/totp-user-is-not-found.json[]
+include::example$core/apis/ocs/totp-validation/responses/json/totp-user-is-not-found.json[]
 ----
 
 ===== XML
 
 [source,console]
 ----
-include::{examplesdir}core/apis/ocs/totp-validation/responses/xml/totp-user-is-not-found.xml[]
+include::example$core/apis/ocs/totp-validation/responses/xml/totp-user-is-not-found.xml[]
 ----
 endif::[]
 

--- a/modules/developer_manual/pages/core/apis/ocs-user-sync-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-user-sync-api.adoc
@@ -51,7 +51,7 @@ The request returns the following status codes.
 
 [source,xml]
 ----
-include::{examplesdir}core/apis/ocs/user-sync/successful-response.xml[]
+include::example$core/apis/ocs/user-sync/successful-response.xml[]
 ----
 
 == Code Example
@@ -64,7 +64,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/user-sync.sh[]
+include::example$core/scripts/curl/ocs/user-sync.sh[]
 ----
 --
 
@@ -73,7 +73,7 @@ PHP::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/ocs/user-sync.php[]
+include::example$core/scripts/php/ocs/user-sync.php[]
 ----
 --
 ====
@@ -84,13 +84,13 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/ocs/user-sync.sh[]
+include::example$core/scripts/curl/ocs/user-sync.sh[]
 ----
 
 === PHP
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/ocs/user-sync.php[]
+include::example$core/scripts/php/ocs/user-sync.php[]
 ----
 endif::[]

--- a/modules/developer_manual/pages/core/apis/roles-api.adoc
+++ b/modules/developer_manual/pages/core/apis/roles-api.adoc
@@ -92,7 +92,7 @@ JSON::
 --
 [source,json,subs="attributes+"]
 ----
-include::{examplesdir}core/apis/ocs/roles/responses/success.json[]
+include::example$core/apis/ocs/roles/responses/success.json[]
 ----
 --
 XML::
@@ -100,7 +100,7 @@ XML::
 --
 [source,xml,subs="attributes+"]
 ----
-include::{examplesdir}core/apis/ocs/roles/responses/success.xml[]
+include::example$core/apis/ocs/roles/responses/success.xml[]
 ----
 --
 ====
@@ -111,14 +111,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,json,subs="attributes+"]
 ----
-include::{examplesdir}core/apis/ocs/roles/responses/success.json[]
+include::example$core/apis/ocs/roles/responses/success.json[]
 ----
 
 === XML
 
 [source,xml,subs="attributes+"]
 ----
-include::{examplesdir}core/apis/ocs/roles/responses/success.xml[]
+include::example$core/apis/ocs/roles/responses/success.xml[]
 ----
 endif::[]
 

--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -108,14 +108,14 @@ IMPORTANT: Don't forget to create `read-config.php` from the included code below
 
 [source,bash]
 ----
-include::{examplesdir}scripts/theme-bootstrap.sh[]
+include::example$scripts/theme-bootstrap.sh[]
 ----
 
 *read-config.php*
 
 [source,php]
 ----
-include::{examplesdir}scripts/read-config.php[]
+include::example$scripts/read-config.php[]
 ----
 
 == How to Create a New Theme

--- a/modules/developer_manual/pages/general/backporting.adoc
+++ b/modules/developer_manual/pages/general/backporting.adoc
@@ -46,7 +46,7 @@ WARNING: While adding, renaming or changing files has no issues for backporting,
 
 [source,console]
 ----
-include::{examplesdir}scripts/backport.sh[]
+include::example$scripts/backport.sh[]
 ----
 
 TIP: It is highly recommended to use the merge SHA1 hash when backporting a Pull Request. The merge commit includes all PR sub commits to be backported. With that, no individual sub commit backporting is necessary.

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -988,7 +988,7 @@ Here's example code for a `Given` step:
 
 [source,php]
 ----
-include::{examplesdir}core/acceptance-tests/given-step.php[]
+include::example$core/acceptance-tests/given-step.php[]
 ----
 
 The code calls the method for the `When` step and then checks the HTTP status code.
@@ -1004,7 +1004,7 @@ Here's example code for a `When` step:
 
 [source,php]
 ----
-include::{examplesdir}core/acceptance-tests/when-step.php[]
+include::example$core/acceptance-tests/when-step.php[]
 ----
 
 The code saves the response so that later `Then` steps can examine it.
@@ -1018,7 +1018,7 @@ Here's example code for a `Then` step:
 
 [source,php]
 ----
-include::{examplesdir}core/acceptance-tests/then-step.php[]
+include::example$core/acceptance-tests/then-step.php[]
 ----
 
 However, a `Then` step may need to do actions of its own to retrieve more information about the state of the system.
@@ -1026,7 +1026,7 @@ For example, after changing a user password we could check that the user can sti
 
 [source,php]
 ----
-include::{examplesdir}core/acceptance-tests/then-step-with-actions.php[]
+include::example$core/acceptance-tests/then-step-with-actions.php[]
 ----
 
 In the above example, `listFolder` is called and does an API call to access the file and then asserts that the response has a valid ETag.

--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -156,7 +156,7 @@ Given the class `MyClass` in your app:
 ./srv/http/owncloud/apps/myapp/tests/lib/MyClass.php
 [source,php]
 ----
-include::{examplesdir}core/unit-testing/MyClass.php[MyClass.php]
+include::example$core/unit-testing/MyClass.php[MyClass.php]
 ----
 
 An example for a simple test would be:
@@ -164,7 +164,7 @@ An example for a simple test would be:
 ./srv/http/owncloud/apps/myapp/tests/unit/MyClassTest.php
 [source,php]
 ----
-include::{examplesdir}core/unit-testing/MyClassTest.php[MyClassTest.php]
+include::example$core/unit-testing/MyClassTest.php[MyClassTest.php]
 ----
 
 [NOTE]

--- a/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
@@ -18,7 +18,7 @@ include::{partialsdir}/webdav_api/core_curl_request.adoc[]
 .{request_data_file}
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/request/list-custom-groups.xml[]
+include::example$core/webdav_api/group/request/list-custom-groups.xml[]
 ----
 
 Successful requests return two things: 
@@ -31,7 +31,7 @@ The XML payload contains a `response` element for each group.
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response/list-groups-successful-response.xml[]
+include::example$core/webdav_api/group/response/list-groups-successful-response.xml[]
 ----
 
 ==== No Results
@@ -40,7 +40,7 @@ If there are no custom groups, then a response similar to the following will be 
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response/list-groups-no-results-response.xml[]
+include::example$core/webdav_api/group/response/list-groups-no-results-response.xml[]
 ----
 
 === Rename Custom Group
@@ -59,7 +59,7 @@ include::{partialsdir}/webdav_api/core_curl_request.adoc[]
 .{request_data_file}
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/request/rename-custom-group.xml[]
+include::example$core/webdav_api/group/request/rename-custom-group.xml[]
 ----
 
 ==== Responses
@@ -79,7 +79,7 @@ If the specified group does not exist, then the following XML response body will
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response/list-groups-missing-group-response.xml[]
+include::example$core/webdav_api/group/response/list-groups-missing-group-response.xml[]
 ----
 
 ===  Delete Group

--- a/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
@@ -22,7 +22,7 @@ include::{partialsdir}/webdav_api/core_curl_request.adoc[]
 .{request_data_file}
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/request/list-custom-group-members.xml[]
+include::example$core/webdav_api/group/request/list-custom-group-members.xml[]
 ----
 
 ==== Responses
@@ -38,7 +38,7 @@ You can see an example of the XML payload below.
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response/list-group-members-successful-response.xml[]
+include::example$core/webdav_api/group/response/list-group-members-successful-response.xml[]
 ----
 
 ===== Failure
@@ -151,7 +151,7 @@ You can see an example of the XML payload below.
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response/list-group-memberships-of-a-given-user-successful-response.xml[]
+include::example$core/webdav_api/group/response/list-group-memberships-of-a-given-user-successful-response.xml[]
 ----
 
 ===== Failure
@@ -163,7 +163,7 @@ include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.ado
 .report-customgroups.xml
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/report-customgroups.xml[indent=0]
+include::example$core/webdav_api/group/report-customgroups.xml[indent=0]
 ----
 
 [source,console]
@@ -176,6 +176,6 @@ curl -u admin:admin -X REPORT \
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/group/response-success.xml[indent=0]
+include::example$core/webdav_api/group/response-success.xml[indent=0]
 ----
 ////

--- a/modules/developer_manual/pages/webdav_api/meta.adoc
+++ b/modules/developer_manual/pages/webdav_api/meta.adoc
@@ -45,7 +45,7 @@ If the file of folder is found, then a response similar to the following will be
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/meta/response-success.xml[]
+include::example$core/webdav_api/meta/response-success.xml[]
 ----
 
 === Failure
@@ -55,7 +55,7 @@ If the file is not found, then the following response will be returned with an
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/meta/response-failure.xml[]
+include::example$core/webdav_api/meta/response-failure.xml[]
 ----
 
 == Example Request
@@ -81,5 +81,5 @@ curl -u {oc-examples-username}:{oc-examples-password} \
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/meta/meta-files-filter.xml[]
+include::example$core/webdav_api/meta/meta-files-filter.xml[]
 ----

--- a/modules/developer_manual/pages/webdav_api/public_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/public_files.adoc
@@ -43,7 +43,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/public_files/view_public_link.sh[]
+include::example$core/scripts/curl/dav/public_files/view_public_link.sh[]
 ----
 --
 PHP::
@@ -51,7 +51,7 @@ PHP::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/dav/public_files/view_public_link.php[]
+include::example$core/scripts/php/dav/public_files/view_public_link.php[]
 ----
 --
 ====
@@ -62,14 +62,14 @@ ifeval::["{format}" == "pdf"]
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/public_files/view_public_link.sh[]
+include::example$core/scripts/curl/dav/public_files/view_public_link.sh[]
 ----
 
 === PHP
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/php/dav/public_files/view_public_link.php[]
+include::example$core/scripts/php/dav/public_files/view_public_link.php[]
 ----
 endif::[]
 
@@ -87,19 +87,19 @@ If the public link is available, then output similar to the following will be di
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/public_files/response/public-link-is-available.xml[]
+include::example$core/webdav_api/public_files/response/public-link-is-available.xml[]
 ----
 
 If the share token is missing or invalid, then you will see output similar to the following:
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/public_files/response/listing-members-is-disabled.xml[]
+include::example$core/webdav_api/public_files/response/listing-members-is-disabled.xml[]
 ----
 
 If the user does not have read privileges on the public link, then they will see output similar to the following:
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/public_files/response/listing-members-is-disabled.xml[]
+include::example$core/webdav_api/public_files/response/listing-members-is-disabled.xml[]
 ----

--- a/modules/developer_manual/pages/webdav_api/search/_filter_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/_filter_files.adoc
@@ -60,7 +60,7 @@ In the `search` element, it specifies the search pattern to filter down the list
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/filter_files/minimal_filter_files_report_request_body.xml[indent=0]
+include::example$core/webdav_api/search/request/filter_files/minimal_filter_files_report_request_body.xml[indent=0]
 ----
 
 ==== Limiting Returned File Properties
@@ -71,7 +71,7 @@ include::{partialsdir}/webdav_api/search/file_properties.adoc[]
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/filter_files/search_body_requesting_all_properties.xml[indent=0]
+include::example$core/webdav_api/search/request/filter_files/search_body_requesting_all_properties.xml[indent=0]
 ----
 
 ==== Filtering By Tag
@@ -83,7 +83,7 @@ TIP: Tag ids can be retrieved by using xref:webdav_api/tags.adoc#list-tags[the T
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/filter_files/search_body_filtering_by_system_tag_ids.xml[indent=0]
+include::example$core/webdav_api/search/request/filter_files/search_body_filtering_by_system_tag_ids.xml[indent=0]
 ----
 
 NOTE: The example uses http://xmlsoft.org/xmllint.html[xmllint] to make the response more readable.
@@ -109,7 +109,7 @@ And each `response` element contains three items:
 .Example of a successful search response
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/filter_files/success.xml[indent=0]
+include::example$core/webdav_api/search/response/filter_files/success.xml[indent=0]
 ----
 
 === Failure

--- a/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
@@ -44,7 +44,7 @@ In the `search` element, specify the search pattern to filter the list of files 
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
+include::example$core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
 ----
 
 ==== Filtering Records
@@ -54,7 +54,7 @@ In the example below, you can see how to filter out any file that has not been f
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
+include::example$core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
 ----
 
 
@@ -65,7 +65,7 @@ In the example below, at most one hundred records, starting from record 200, wil
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/search_files/limit_number_of_results.xml[indent=0]
+include::example$core/webdav_api/search/request/search_files/limit_number_of_results.xml[indent=0]
 ----
 
 ==== Reducing The File Properties Returned
@@ -76,7 +76,7 @@ include::{partialsdir}/webdav_api/search/file_properties.adoc[]
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/request/search_files/search_body_with_properties.xml[indent=0]
+include::example$core/webdav_api/search/request/search_files/search_body_with_properties.xml[indent=0]
 ----
 
 NOTE: The example uses http://xmlsoft.org/xmllint.html[xmllint] to make the response more readable.
@@ -102,7 +102,7 @@ And each `response` element contains three items:
 .Search Response
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/search_files/success/search_response.xml[indent=0]
+include::example$core/webdav_api/search/response/search_files/success/search_response.xml[indent=0]
 ----
 
 === Failure
@@ -113,7 +113,7 @@ If the payload file cannot be read or is invalid XML, then the following XML res
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/common/failure/incorrect_payload_or_parse_failure.xml[indent=0]
+include::example$core/webdav_api/search/response/common/failure/incorrect_payload_or_parse_failure.xml[indent=0]
 ----
 
 ==== If a Non-Existent Property Is Requested 
@@ -122,6 +122,6 @@ If a non-existent property is requested, then an additional `propstat` element i
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/common/failure/request_non_existent_property.xml[indent=0,lines=19..25]
+include::example$core/webdav_api/search/response/common/failure/request_non_existent_property.xml[indent=0,lines=19..25]
 ----
 

--- a/modules/developer_manual/pages/webdav_api/trashbin.adoc
+++ b/modules/developer_manual/pages/webdav_api/trashbin.adoc
@@ -57,7 +57,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.sh[]
 ----
 --
 ====
@@ -66,7 +66,7 @@ endif::[]
 ifeval::["{format}" == "pdf"]
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/list-files-in-trashbin.sh[]
 ----
 endif::[]
 
@@ -86,7 +86,7 @@ Curl::
 --
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/trashbin/list-files-in-trashbin-success-response.xml[]
+include::example$core/webdav_api/trashbin/list-files-in-trashbin-success-response.xml[]
 ----
 --
 ====
@@ -95,7 +95,7 @@ endif::[]
 ifeval::["{format}" == "pdf"]
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/trashbin/list-files-in-trashbin-success-response.xml[]
+include::example$core/webdav_api/trashbin/list-files-in-trashbin-success-response.xml[]
 ----
 endif::[]
 
@@ -133,7 +133,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/delete-file-from-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/delete-file-from-trashbin.sh[]
 ----
 --
 ====
@@ -142,7 +142,7 @@ endif::[]
 ifeval::["{format}" == "pdf"]
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/delete-file-from-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/delete-file-from-trashbin.sh[]
 ----
 endif::[]
 
@@ -205,7 +205,7 @@ Curl::
 --
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/restore-file-to-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/restore-file-to-trashbin.sh[]
 ----
 --
 ====
@@ -214,7 +214,7 @@ endif::[]
 ifeval::["{format}" == "pdf"]
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}core/scripts/curl/dav/trashbin_api/restore-file-to-trashbin.sh[]
+include::example$core/scripts/curl/dav/trashbin_api/restore-file-to-trashbin.sh[]
 ----
 endif::[]
 

--- a/modules/developer_manual/partials/webdav_api/files_versions/list_files_versions.adoc
+++ b/modules/developer_manual/partials/webdav_api/files_versions/list_files_versions.adoc
@@ -39,7 +39,7 @@ If the file _is_ found but has only one version, then a response, similar to the
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/files_versions/successful-response-which-contains-one-version.xml[]
+include::example$core/webdav_api/files_versions/successful-response-which-contains-one-version.xml[]
 ----
 
 ==== File Is Found and Has Multiple Versions
@@ -48,7 +48,7 @@ If the file _is_ found and has multiple versions, then a response, similar to th
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/files_versions/successful-response-which-contains-multiple-versions.xml[]
+include::example$core/webdav_api/files_versions/successful-response-which-contains-multiple-versions.xml[]
 ----
 
 ==== File Is Not Found

--- a/modules/developer_manual/partials/webdav_api/search/common_error_responses.adoc
+++ b/modules/developer_manual/partials/webdav_api/search/common_error_responses.adoc
@@ -4,7 +4,7 @@ If the payload file cannot be read or is invalid XML, then the following XML res
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/common/failure/incorrect_payload_or_parse_failure.xml[indent=0]
+include::example$core/webdav_api/search/response/common/failure/incorrect_payload_or_parse_failure.xml[indent=0]
 ----
 
 ==== If a Non-Existent Property Is Requested 
@@ -13,6 +13,6 @@ If a non-existent property is requested, then an additional `propstat` element i
 
 [source,xml]
 ----
-include::{examplesdir}core/webdav_api/search/response/common/failure/request_non_existent_property.xml[indent=0,lines=19..25]
+include::example$core/webdav_api/search/response/common/failure/request_non_existent_property.xml[indent=0,lines=19..25]
 ----
 


### PR DESCRIPTION
Renames the family coordinate from {examplesdir} to example$ to be prepared for Antora 3

This is for the dev manual only as all branches have only a view differences. The admin manual will get its own PR.

Backport to10.9 and 10.8