### PR TITLE
Admin: rename {examplesdir} with example$

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -159,7 +159,7 @@ Example:
 
 [source]
 ----
-include::{examplesdir}configuration/user/user_auth_ldap/group_filter.ldif[]
+include::example$configuration/user/user_auth_ldap/group_filter.ldif[]
 ----
 --
 
@@ -177,7 +177,7 @@ Enter this filter to access this feature for a single group:
 
 [source]
 ----
-include::{examplesdir}configuration/user/user_auth_ldap/single_group_search.ldif[]
+include::example$configuration/user/user_auth_ldap/single_group_search.ldif[]
 ----
 
 Enter your group name instead of the `<groupname>` placeholder.
@@ -185,7 +185,7 @@ If you want to search multiple groups with this feature, adjust your filter like
 
 [source]
 ----
-include::{examplesdir}configuration/user/user_auth_ldap/multi_group_search.ldif[]
+include::example$configuration/user/user_auth_ldap/multi_group_search.ldif[]
 ----
 
 You can add as many groups to recurse by using the format: `(|(m1)(m2)(m3).....)`.
@@ -251,14 +251,14 @@ user upon login.
 +
 [source,ldap]
 ----
-include::{examplesdir}configuration/user/user_auth_ldap/only_username.ldif[]
+include::example$configuration/user/user_auth_ldap/only_username.ldif[]
 ----
 
 * Username or Email Address:
 +
 [source]
 ----
-include::{examplesdir}configuration/user/user_auth_ldap/username_email.ldif[]
+include::example$configuration/user/user_auth_ldap/username_email.ldif[]
 ----
 --
 

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -30,7 +30,7 @@ Further Shibboleth specific configuration as defined in `/etc/apache2/conf.d/shi
 
 [source,apache]
 ----
-include::{examplesdir}enterprise/user_management/shibboleth/apache-2.4-configuration.conf[]
+include::example$enterprise/user_management/shibboleth/apache-2.4-configuration.conf[]
 ----
 
 To allow users to login via the IdP, add a login alternative with the `login.alternatives` option in `config/config.php`.
@@ -134,7 +134,7 @@ You can allow other login mechanisms (e.g., LDAP or ownCloud native) by creating
 
 [source,apache]
 ----
-include::{examplesdir}enterprise/user_management/shibboleth/other-login-mechanisms-vhost.conf[]
+include::example$enterprise/user_management/shibboleth/other-login-mechanisms-vhost.conf[]
 ----
 
 NOTE: The second location in the above configuration is *not* protected by Shibboleth, and you can use your other ownCloud login mechanisms.

--- a/modules/admin_manual/pages/installation/apps_management_installation.adoc
+++ b/modules/admin_manual/pages/installation/apps_management_installation.adoc
@@ -90,7 +90,7 @@ The configuration example below shows how to add a second directory, called `app
 
 [source,php]
 ----
-include::{examplesdir}installation/custom-app-directory-configuration.php[]
+include::example$installation/custom-app-directory-configuration.php[]
 ----
 
 After you add a new directory configuration, you can then move apps from the original app directory to the new one. 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -384,5 +384,5 @@ and then add it to the `/etc/fstab` file, for example:
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}installation/deployment_recommendations/set_session_path.sh[]
+include::example$installation/deployment_recommendations/set_session_path.sh[]
 ----

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -338,7 +338,7 @@ Since ownCloud Server 10.5, the dedicated enterprise docker image `registry.ownc
 
 [source,yaml]
 ----
-include::{examplesdir}installation/docker/docker-compose.yml[Example Docker Compose YAML configuration file for ownCloud Server.]
+include::example$installation/docker/docker-compose.yml[Example Docker Compose YAML configuration file for ownCloud Server.]
 ----
 
 == Troubleshooting

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -144,7 +144,7 @@ This file defines some default settings used by Certbot. Use the email address y
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/cli.ini[]
+include::example$installation/lets_encrypt/cli.ini[]
 ----
 
 [NOTE]
@@ -163,7 +163,7 @@ This script lists all your issued certificates.
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/list.sh[]
+include::example$installation/lets_encrypt/list.sh[]
 ----
 
 === renew.sh
@@ -175,7 +175,7 @@ This script:
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/renew.sh[]
+include::example$installation/lets_encrypt/renew.sh[]
 ----
 
 === renew-cron.sh
@@ -189,7 +189,7 @@ NOTE: This script is intended for use via Cron.
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/renew-cron.sh[]
+include::example$installation/lets_encrypt/renew-cron.sh[]
 ----
 
 === delete.sh
@@ -199,7 +199,7 @@ Use the `list.sh` script to list issued certificates.
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/delete.sh[]
+include::example$installation/lets_encrypt/delete.sh[]
 ----
 
 === <your-domain-name>.sh
@@ -213,7 +213,7 @@ You can create different certificates for different sub-domains, such as `exampl
 
 [source,console]
 ----
-include::{examplesdir}installation/lets_encrypt/your-domain-name.sh[]
+include::example$installation/lets_encrypt/your-domain-name.sh[]
 ----
 
 NOTE: You can enable the `--dry-run` option which does a test run of the client only.

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
@@ -87,7 +87,7 @@ Next, compare the value set for `UNIQUE_ID` in the output of `phpinfo()` with th
 
 [source,json]
 ----
-include::{examplesdir}installation/webservers/apache/log-entry.json[]
+include::example$installation/webservers/apache/log-entry.json[]
 ----
 
 === Using SSL

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -94,7 +94,7 @@ service apache2 restart
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}installation/ubuntu/18.04/create-vhost-config.sh[]
+include::example$installation/ubuntu/18.04/create-vhost-config.sh[]
 ----
 
 ==== Enable the Virtual Host Configuration
@@ -206,7 +206,7 @@ Execute this command to set up {logrotate-url}[log rotation].
 
 [source,console,subs="attributes+"]
 ----
-include::{examplesdir}installation/ubuntu/18.04/configure-log-rotation.sh[]
+include::example$installation/ubuntu/18.04/configure-log-rotation.sh[]
 ----
 
 ==== Finalise the Installation


### PR DESCRIPTION
Renames the family coordinate from {examplesdir} to example$ to be prepared for Antora 3

This is for the admin manual only because branches may have some differences. The dev manual will get its own PR.

Backport to10.9 and 10.8