### PR TITLE
Dev: rename {partialsdir} with partial$

### DIFF
--- a/modules/developer_manual/pages/app/fundamentals/info.adoc
+++ b/modules/developer_manual/pages/app/fundamentals/info.adoc
@@ -7,7 +7,7 @@ explanation of what each of file's elements.
 
 [source,xml,subs="attributes+"]
 ----
-include::{partialsdir}app/fundamentals/complete-info.xml[]
+include::partial$app/fundamentals/complete-info.xml[]
 ----
 
 == id

--- a/modules/developer_manual/pages/core/apis/index.adoc
+++ b/modules/developer_manual/pages/core/apis/index.adoc
@@ -1,4 +1,4 @@
 :section-title: APIs
 :section-preamble-ender: to use APIs in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/developer_manual/pages/testing/index.adoc
+++ b/modules/developer_manual/pages/testing/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Testing
 :section-preamble-ender: to learn about testing ownCloud's apps
 
-include::{partialsdir}section_page.adoc[optional attributes]
+include::partial$section_page.adoc[optional attributes]
 

--- a/modules/developer_manual/pages/webdav_api/files_versions.adoc
+++ b/modules/developer_manual/pages/webdav_api/files_versions.adoc
@@ -13,4 +13,4 @@ The files versions API allows for two things:
 
 //Note that "xref:restore-another-version-of-a-file" is missing in the included partial... using git log --follow -p modules/developer_manual/pages/_partials/webdav_api/files_versions/list_files_versions.adoc does not return a deletion = it was missing from teh beginning
 
-include::{partialsdir}webdav_api/files_versions/list_files_versions.adoc[leveloffset=+1]
+include::partial$webdav_api/files_versions/list_files_versions.adoc[leveloffset=+1]

--- a/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/custom_groups_endpoints.adoc
@@ -11,9 +11,9 @@
 
 This endpoint returns a list of all custom groups.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 .{request_data_file}
 [source,xml]
@@ -52,9 +52,9 @@ This endpoint allows a custom group to be renamed.
 
 NOTE: Only group admins can rename the groups that they manage.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 .{request_data_file}
 [source,xml]
@@ -71,7 +71,7 @@ No other information will be returned or displayed.
 
 ===== Failure
 
-include::{partialsdir}webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ====== Missing Group
 
@@ -91,9 +91,9 @@ This endpoint allows for a custom group to be deleted.
 
 NOTE: Only group admins can delete a group.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -104,7 +104,7 @@ No other information will be returned or displayed.
 
 ===== Failure
 
-include::{partialsdir}webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ===  Create Group
 :request_method: MKCOL
@@ -114,9 +114,9 @@ This endpoint allows for creating a custom group.
 
 NOTE:  The group's creator automatically becomes the group's admin and its initial member.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -127,5 +127,5 @@ No other information will be returned or displayed.
 
 ===== Failure
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 

--- a/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
+++ b/modules/developer_manual/pages/webdav_api/groups/group_membership_endpoints.adoc
@@ -15,9 +15,9 @@ This endpoint allows for listing all of the members in a custom group.
 
 NOTE: Only group members can list a group's members. Other users will receive a status of `HTTP/1.1 403 Forbidden`
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 .{request_data_file}
 [source,xml]
@@ -43,7 +43,7 @@ include::example$core/webdav_api/group/response/list-group-members-successful-re
 
 ===== Failure
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ===  Add Member
 :request_method: PUT
@@ -54,9 +54,9 @@ This endpoint allows for adding members to a custom group.
 
 NOTE: Only group admins can add members.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -79,7 +79,7 @@ If the request was made using any other method than `PUT`, then an `HTTP/1.1 405
 </d:error>
 ----
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ===  Remove Member
 :request_method: DELETE
@@ -92,9 +92,9 @@ NOTE: Only group admins can remove members.
 Group admins cannot remove themselves if no other admin exists in the group.
 A group member can remove themselves using this API call.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -105,7 +105,7 @@ No other information will be returned or displayed.
 
 ===== Failure
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ===  Change Admin Role of a Member
 :request_method: PROPPATCH
@@ -114,9 +114,9 @@ include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.ado
 
 This endpoint allows for changing the admin role of an existing member of the group.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -124,7 +124,7 @@ include::{partialsdir}/webdav_api/core_curl_request.adoc[]
 
 ===== Failure
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 
 ===  List Group Memberships of a Given User
 :request_method: PROPFIND
@@ -134,9 +134,9 @@ include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.ado
 
 This endpoint lists the groups that a user is a member of.
 
-include::{partialsdir}/webdav_api/uri_request_table.adoc[]
+include::partial$/webdav_api/uri_request_table.adoc[]
 
-include::{partialsdir}/webdav_api/core_curl_request.adoc[]
+include::partial$/webdav_api/core_curl_request.adoc[]
 
 ==== Responses
 
@@ -156,7 +156,7 @@ include::example$core/webdav_api/group/response/list-group-memberships-of-a-give
 
 ===== Failure
 
-include::{partialsdir}/webdav_api/responses/insufficient-privileges-overview.adoc[]
+include::partial$/webdav_api/responses/insufficient-privileges-overview.adoc[]
 ////
 == REPORT
 

--- a/modules/developer_manual/pages/webdav_api/index.adoc
+++ b/modules/developer_manual/pages/webdav_api/index.adoc
@@ -1,4 +1,4 @@
 :section-title: WebDAV APIs
 :section-preamble-ender: to ownCloud's WebDAV APIs 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/developer_manual/pages/webdav_api/meta.adoc
+++ b/modules/developer_manual/pages/webdav_api/meta.adoc
@@ -18,7 +18,7 @@ TIP: To retrieve a list of available files, use the
 xref:webdav_api/search.adoc#limiting-returned-file-properties[Filter Files endpoint],
 and ensure that returned properties includes `fileid`. 
 
-include::{partialsdir}webdav_api/core_request_details.adoc[leveloffset=+1]
+include::partial$webdav_api/core_request_details.adoc[leveloffset=+1]
 
 == Request Parameters
 

--- a/modules/developer_manual/pages/webdav_api/search/_filter_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/_filter_files.adoc
@@ -8,7 +8,7 @@
 
 The `filter-files` report allows for retrieving a list of files in an ownCloud user's filesystem, based on two criteria:
 
-include::{partialsdir}/webdav_api/core_request_details.adoc[leveloffset=+1]
+include::partial$/webdav_api/core_request_details.adoc[leveloffset=+1]
 
 == The Request
 
@@ -67,7 +67,7 @@ include::example$core/webdav_api/search/request/filter_files/minimal_filter_file
 
 If only a specific list of properties is required for each file, then a `prop` element needs to be included in the response body, such as in the example below.
 
-include::{partialsdir}/webdav_api/search/file_properties.adoc[]
+include::partial$/webdav_api/search/file_properties.adoc[]
 
 [source,xml]
 ----
@@ -114,4 +114,4 @@ include::example$core/webdav_api/search/response/filter_files/success.xml[indent
 
 === Failure
 
-include::{partialsdir}/webdav_api/search/common_error_responses.adoc[]
+include::partial$/webdav_api/search/common_error_responses.adoc[]

--- a/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
@@ -15,7 +15,7 @@ When installed, they replace ownCloud's default search provider and the search A
 TIP: When using the default search provider, if you use the search string "_ownCloud_", files whose filename has "ownCloud" in it will be matched. 
 However, if installed https://github.com/owncloud/search_elastic[the search_elastic app], the report also retrieves files that have "_ownCloud_" in the file's contents.
 
-include::{partialsdir}/webdav_api/core_request_details.adoc[leveloffset=+1]
+include::partial$/webdav_api/core_request_details.adoc[leveloffset=+1]
 
 == The Request
 
@@ -72,7 +72,7 @@ include::example$core/webdav_api/search/request/search_files/limit_number_of_res
 
 However, if a specific list of properties is required for each file, then a `prop` element needs to be included in the response body, such as in the example below.
 
-include::{partialsdir}/webdav_api/search/file_properties.adoc[]
+include::partial$/webdav_api/search/file_properties.adoc[]
 
 [source,xml]
 ----


### PR DESCRIPTION
Renames the family coordinate from {partialsdir} to partial$ to be prepared for Antora 3

This is for the dev manual only as all branches have only a view differences. The admin manual will get its own PR.

Backport to10.9 and 10.8