### PR TITLE
Admin: rename {partialsdir} with partial$

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/index.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Appliance Configuration
 :section-preamble-ender: to configure the ownCloud appliance. 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/appliance/maintenance/index.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Appliance Maintenance
 :section-preamble-ender: to maintain the ownCloud appliance. 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -74,7 +74,7 @@ Section: Files Which Are Never Encrypted
 is also used in the user guide, therefore included
 ////
 
-include::{partialsdir}/configuration/files/encryption/not-encrypted-files.adoc[]
+include::partial$/configuration/files/encryption/not-encrypted-files.adoc[]
 
 == Using a Hardware Security Module (HSM)
 

--- a/modules/admin_manual/pages/configuration/files/encryption/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/index.adoc
@@ -2,4 +2,4 @@
 :section-preamble-ender: to configure encryption in ownCloud
 :page-aliases: configuration/files/encryption/root.adoc
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/configuration/files/external_storage/index.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/index.adoc
@@ -1,5 +1,5 @@
 :section-title: External Storage
 :section-preamble-ender: to configure external storage in ownCloud
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/configuration/server/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Server Configuration
 :section-preamble-ender: to configure ownCloud
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
@@ -235,7 +235,7 @@ By default, passwords and other sensitive data are omitted from the report so th
 
 [source,json]
 ----
-include::{partialsdir}configuration/server/occ_command/config-list-report.json[]
+include::partial$configuration/server/occ_command/config-list-report.json[]
 ----
 
 === Displaying Sensitive Information

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -22,4 +22,4 @@ You can also set it up to run as xref:background-jobs-selector[a background job]
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
 
-include::{partialsdir}configuration/server/occ_command/system_command.adoc[leveloffset=+1]
+include::partial$configuration/server/occ_command/system_command.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -559,7 +559,7 @@ Resets the password of the named user.
 {occ-command-example-prefix} user:resetpassword [options] [--] <user>
 ----
 
-include::{partialsdir}configuration/user/update-password-note.adoc[]
+include::partial$configuration/user/update-password-note.adoc[]
 
 === Arguments
 

--- a/modules/admin_manual/pages/configuration/server/security/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/index.adoc
@@ -1,7 +1,7 @@
 :section-title: Server Security
 :section-preamble-ender: to configure ownCloud securely
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 
 * xref:configuration/server/security/oauth2.adoc[OAuth2]
 * xref:configuration/server/security/password_policy.adoc[Password Policy]

--- a/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
@@ -34,4 +34,4 @@ the default Apache HTTP user:group on Linux distros:
 
 See xref:configuration/server/occ_command.adoc[Using the occ Command] to learn more about using the `occ` command.
 
-include::{partialsdir}configuration/user/update-password-note.adoc[]
+include::partial$configuration/user/update-password-note.adoc[]

--- a/modules/admin_manual/pages/configuration/user/reset_user_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_user_password.adoc
@@ -12,4 +12,4 @@ automatic reset:
 'lost_password_link' => 'https://example.org/link/to/password/reset',
 ----
 
-include::{partialsdir}configuration/user/update-password-note.adoc[]
+include::partial$configuration/user/update-password-note.adoc[]

--- a/modules/admin_manual/pages/enterprise/clients/index.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Enterprise Clients
 :section-preamble-ender: to configure ownCloud enterprise clients 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/enterprise/collaboration/index.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Enterprise Collaboration
 :section-preamble-ender: to configure enterprise collaboration in ownCloud
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/enterprise/external_storage/index.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/index.adoc
@@ -1,4 +1,4 @@
 :section-title: External Storage
 :section-preamble-ender: to configure enterprise external storage in ownCloud
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/file_management/index.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Enterprise File Management
 :section-preamble-ender: to configure enterprise file management in ownCloud. 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/enterprise/firewall/index.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Enterprise Firewall Configuration
 :section-preamble-ender: to configure enterprise firewall configuration in ownCloud appliance. 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/enterprise/logging/index.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Enterprise Logging Configuration
 :section-preamble-ender: to configure enterprise logging configuration in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/reporting/index.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Enterprise Reporting
 :section-preamble-ender: to setup reporting for the ownCloud Enterprise installation 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/security/index.adoc
+++ b/modules/admin_manual/pages/enterprise/security/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Enterprise Security
 :section-preamble-ender: to configure enterprise security in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/server_branding/index.adoc
+++ b/modules/admin_manual/pages/enterprise/server_branding/index.adoc
@@ -1,4 +1,4 @@
 :section-title: Enterprise Server Branding
 :section-preamble-ender: to configure enterprise server branding in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/user_management/index.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/index.adoc
@@ -1,7 +1,7 @@
 :section-title: Enterprise User Management
 :section-preamble-ender: to configure enterprise user management in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 
 * xref:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
 

--- a/modules/admin_manual/pages/installation/apps/index.adoc
+++ b/modules/admin_manual/pages/installation/apps/index.adoc
@@ -1,6 +1,6 @@
 :section-title: Managing Apps
 :section-preamble-ender: for installing and configuring apps
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 
 

--- a/modules/admin_manual/pages/installation/letsencrypt/index.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/index.adoc
@@ -1,7 +1,7 @@
 :section-title: Let's Encrypt SSL Certificates
 :section-preamble-ender: to configure ownCloud with Let's Encrypt
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 
 * xref:installation/letsencrypt/using_letsencrypt.adoc[Using Let’s Encrypt SSL Certificates]
 * xref:installation/letsencrypt/apache.adoc[Configure Apache with Let's Encrypt]

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -35,7 +35,7 @@ MariaDB is the ownCloud recommended database. It may be used with either ownClou
 xref:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
 guides.
 
-include::{partialsdir}installation/manual_installation/mariadb.adoc[leveloffset=+1]
+include::partial$installation/manual_installation/mariadb.adoc[leveloffset=+1]
 
 == PostgreSQL
 

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -330,4 +330,4 @@ to install it.
 
 == Useful Tips
 
-include::{partialsdir}installation/manual_installation/useful_tips.adoc[leveloffset=+1]
+include::partial$installation/manual_installation/useful_tips.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/maintenance/encryption/index.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Encryption
 :section-preamble-ender: to maintain encryption in ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -122,7 +122,7 @@ encryption|enabled|yes
 encryption|useMasterKey|1
 ----
 
-include::{partialsdir}/configuration/server/disable-single-user-mode.adoc[leveloffset=+1]
+include::partial$/configuration/server/disable-single-user-mode.adoc[leveloffset=+1]
 
 == Post Note
 

--- a/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
@@ -29,7 +29,7 @@ After the upgrade is finished, perform the following actions:
 * Take your ownCloud server out of xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].
 * Re-enable third-party apps.
 
-include::{partialsdir}maintenance/major_release_note.adoc[]
+include::partial$maintenance/major_release_note.adoc[]
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at the
 xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#changes-in-9-1[release notes] for important information about the needed migration steps during that upgrade.

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
@@ -26,7 +26,7 @@ installation and then restore your data from backup. Before attempting this,
 file a support ticket (if you have paid support) or ask for help in the
 ownCloud forums to resolve your issue without downgrading.
 
-include::{partialsdir}maintenance/major_release_note.adoc[]
+include::partial$maintenance/major_release_note.adoc[]
 
 == Prerequisites
 

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -14,7 +14,7 @@ This guide takes you through upgrading your installation of PHP to one of the su
 :to-version: 7.3
 :to-pkg-version: 73
 
-include::{partialsdir}/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
+include::partial$/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
 == Restart Apache
 

--- a/modules/admin_manual/pages/troubleshooting/index.adoc
+++ b/modules/admin_manual/pages/troubleshooting/index.adoc
@@ -1,5 +1,5 @@
 :section-title: Troubleshooting
 :section-preamble-ender: to troubleshoot ownCloud 
 
-include::{partialsdir}section_page.adoc[]
+include::partial$section_page.adoc[]
 


### PR DESCRIPTION
Renames the family coordinate from {partialsdir} to partial$ to be prepared for Antora 3

This is for the admin manual only because branches may have some differences. The dev manual will get its own PR.

Backport to10.9 and 10.8