### PR TITLE
Shift the wizard location by one to the left

### DIFF
--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -17,7 +17,7 @@
 ****** xref:admin_manual:installation/quick_guides/ubuntu_20_04.adoc[Quick Install ownCloud on Ubuntu 20.04]
 ***** Linux Package Manager
 ****** xref:admin_manual:installation/linux_packetmanager_install.adoc[Linux Package Manager Installation]
-***** xref:admin_manual:installation/installation_wizard.adoc[The Installation Wizard]
+**** xref:admin_manual:installation/installation_wizard.adoc[The Installation Wizard]
 *** xref:admin_manual:installation/troubleshooting.adoc[Troubleshooting]
 *** xref:admin_manual:installation/changing_the_web_route.adoc[Changing Your ownCloud URL]
 *** xref:admin_manual:installation/apps_management_installation.adoc[Installing and Managing Apps]


### PR DESCRIPTION
The Installation Wizard had the wrong position. Its intent was under manual installation and not that same level.

Backport to 10.9 and 10.8