### PR TITLE
Adjust pollinterval in docs

### DIFF
--- a/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
+++ b/modules/developer_manual/examples/core/apis/ocs-capabilities/list-capabilities-response.json
@@ -76,7 +76,7 @@
                   "maintenance" : "false",
                   "version" : "10.0.3.3"
                },
-               "pollinterval" : 60
+               "pollinterval" : 30000
             }
          }
       }

--- a/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-capabilities.adoc
@@ -35,7 +35,7 @@ and their values.
 == Core
 
 Stored under the `core` capabilities element, this returns the server’s
-core status settings, the interval to poll for server side changes, and
+core status settings, the interval to poll for server side changes in milliseconds, and
 it’s WebDAV API root.
 
 == Checksums


### PR DESCRIPTION
Part of issue #109 

Note: after core PR https://github.com/owncloud/core/pull/39143 is merged, a config-to-docs run is needed. `pollinterval` was not previously mentioned in config.sample.php and is added in that PR.

No backport needed - this will be in the next oC10 release (might be numbered 10.10.0)