### PR TITLE
[10.9] [PR 117] Enable encryption via occ is incomplete and leads to deprecated user-key mode

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -120,16 +120,17 @@ To enable the encryption app, run the following command:
 ----
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
-{occ-command-example-prefix} encryption:select-encryption-type masterkey
+{occ-command-example-prefix} encryption:select-encryption-type masterkey -y
 ----
 
-If the encryption app is successfully enabled, you should see the following confirmation:
+If the encryption app is successfully enabled, you should see the following confirmations:
 
 ----
 encryption enabled
 Encryption enabled
 
 Default module: OC_DEFAULT_MODULE
+Master key successfully enabled.
 ----
 
 === Enable Encryption in the Web-UI

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -119,12 +119,17 @@ To enable the encryption app, run the following command:
 [source,console,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
+{occ-command-example-prefix} encryption:enable
+{occ-command-example-prefix} encryption:select-encryption-type masterkey
 ----
 
 If the encryption app is successfully enabled, you should see the following confirmation:
 
 ----
 encryption enabled
+Encryption enabled
+
+Default module: OC_DEFAULT_MODULE
 ----
 
 === Enable Encryption in the Web-UI


### PR DESCRIPTION
Backport of PR #117 