### PR TITLE
Correct source languages

### DIFF
--- a/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
@@ -121,6 +121,7 @@ Once logged in, check if there is an upgrade available.
 You can use the command `univention-app info`. This command lists
 information about the current state of every installed App.
 
+[source,console]
 ----
 root@ucs-9446:~# univention-app info
 UCS: 4.2-1 errata165
@@ -148,6 +149,7 @@ version of ownCloud. As in the example below, you should see that the
 installed version is now higher than before, and that ownCloud is no
 longer upgradable.
 
+[source,console]
 ----
 root@ucs-9446:~# univention-app info
 UCS: 4.2-1 errata165
@@ -167,7 +169,7 @@ version suffix in the name. For example the ownCloud 8.2 app is named
 
 For ownCloud 8.2 users: during the ownCloud App upgrade, user files will be moved to the new Docker data directory, `/var/lib/univention-appcenter/apps/owncloud/data/files`.  Essentially, the following the command will be executed:
 
-[source,console]
+[source,bash]
 ----
 mv /var/lib/owncloud/* /var/lib/univention-appcenter/apps/owncloud/data/files
 ----
@@ -177,9 +179,9 @@ Please check your filesystems and mountpoints and make sure enough space is avai
 Given that, you first have to uninstall the existing version and then
 install the 10.x version. To do so, run the following commands:
 
+The following assumes that owncloud82 is the currently installed version
 [source,console]
 ----
-# Assumes that owncloud82 is the currently installed version
 univention-app remove owncloud82
 univention-app update
 univention-app install owncloud

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -31,6 +31,7 @@ NOTE: You can do the same for MySQL by replacing `mariadb.conf.d/50-server.cnf` 
 key_buffer_size         = 32M
 table_cache             = 400
 query_cache_size        = 128M
+
 #in InnoDB:
 innodb_flush_method=O_DIRECT
 innodb_flush_log_at_trx_commit=1
@@ -53,7 +54,7 @@ collation-server      = utf8mb4_general_ci
 
 When you have changed the database parameters, restart your database by running following command:
 
-[source,console]
+[source,bash]
 ----
 sudo service mysql restart
 ----
@@ -62,7 +63,7 @@ sudo service mysql restart
 
 After you have restarted the database, run the following occ command in your ownCloud root folder, to convert the database to the new format:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} db:convert-type [options] type username hostname database
 ----
@@ -73,7 +74,7 @@ The converter searches for apps in your configured app folders and uses the sche
 As a result, tables of removed apps will not be converted — even with option `--all-apps`
 For example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} db:convert-type --all-apps mysql oc_mysql_user 127.0.0.1 new_db_name
 ----
@@ -87,10 +88,9 @@ ownCloud config `config.php`.
 == Unconvertible Tables
 
 If you updated your ownCloud installation then the old tables, which are
-not used anymore, might still exist. The converter will tell you which
-ones.
+not used anymore, might still exist. The converter will tell you which ones.
 
-[source,console]
+[source,text]
 ----
 The following tables will not be converted:
   oc_permissions

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -55,17 +55,16 @@ clients/users and many parallel operations). This requires a disabled or correct
 binary logging when using MySQL or MariaDB. Your system is affected if you see the following
 in your log file during the installation or update of ownCloud:
 
-[source]
+[source,text]
 ----
 An unhandled exception has been thrown: exception `PDOException' with message `SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ----
 
-There are two solutions.
-One is to disable binary logging.
-Binary logging records all changes to your database, and how long each change took.
-The purpose of binary logging is to enable replication and to support backup operations.
+There are two solutions:
 
-The other is to change the BINLOG_FORMAT = STATEMENT in your database configuration file,
+* One is to disable binary logging. Binary logging records all changes to your database, and how long each change took. The purpose of binary logging is to enable replication and to support backup operations.
+
+* The other is to change the BINLOG_FORMAT = STATEMENT in your database configuration file,
 or possibly in your database startup script, to BINLOG_FORMAT = MIXED or BINLOG_FORMAT = ROW.
 See {mariadb-binary-log-overview-url}[Overview of the Binary Log] and
 {mysql-binary-log-overview-url}[The Binary Log] for detailed information.
@@ -160,6 +159,7 @@ need to do two things:
 . In your MySQL configuration, add the configuration settings below.
 If you already have them configured, update them to reflect the values specified:
 +
+[source,mysql]
 ----
 [mysqld]
 innodb_large_prefix=ON
@@ -169,7 +169,7 @@ innodb_file_per_table=ON
 
 . Run the following occ command:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} db:convert-mysql-charset
 ----
@@ -202,7 +202,7 @@ If you decide to use a PostgreSQL database, make sure that you have installed an
 configuration in `/etc/php/{recommended-php-version}/apache2/conf.d/20-pgsql.ini`
 could look like this:
 
-[source,console]
+[source,bash]
 ----
 # configuration for PHP PostgreSQL module
 extension=pdo_pgsql.so
@@ -226,7 +226,7 @@ authentication method is used in your setup.
 
 To start the PostgreSQL command-line mode use:
 
-[source,console]
+[source,bash]
 ----
 sudo -u postgres psql -d template1
 ----
@@ -277,7 +277,7 @@ for an example.
 To check the server’s network availability, use the ping command on the server's hostname
 (`db.server.com` in this example):
 
-[source,console]
+[source,bash]
 ----
 ping db.server.com
 
@@ -299,7 +299,7 @@ The easiest way to test if a database can be accessed is by starting the command
 Assuming the database server is installed on the same system you’re running the command
 from, use:
 
-[source,console]
+[source,bash]
 ----
 mysql -uUSERNAME -p
 ----
@@ -307,7 +307,7 @@ mysql -uUSERNAME -p
 To access a MySQL installation on a different machine, add the -h option with the
 respective hostname:
 
-[source,console]
+[source,bash]
 ----
 mysql -uUSERNAME -p -h HOSTNAME
 ----
@@ -329,14 +329,14 @@ mysql> quit
 Assuming the database server is installed on the same system you’re running the command
 from, use:
 
-[source,console]
+[source,psql]
 ----
 psql -Uusername -downcloud
 ----
 
 To access a PostgreSQL installation on a different machine, add the `-h` option with the applicable hostname:
 
-[source,console]
+[source,psql]
 ----
 psql -Uusername -downcloud -h HOSTNAME
 ----

--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -42,7 +42,7 @@ PrivateTmp=false
 
 When done, you need to reload the daemon and restart the service:
 
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 sudo systemctl restart httpd
@@ -169,7 +169,7 @@ Disable mod_reqtimeout on Ubuntu::
 +
 On Ubuntu, you can disable the module by running the following command:
 +
-[source,console]
+[source,bash]
 ----
 sudo a2dismod reqtimeout
 ----

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -116,7 +116,7 @@ Before you can use encryption, you must enable the encryption app. You can do th
 
 To enable the encryption app, run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
@@ -125,6 +125,7 @@ To enable the encryption app, run the following command:
 
 If the encryption app is successfully enabled, you should see the following confirmations:
 
+[source,console]
 ----
 encryption enabled
 Encryption enabled
@@ -154,28 +155,28 @@ You can do basic configuration of encryption via the Web-UI, but it is recommend
 
 To be safe and avoid any issues on a running instance, put your server in single user mode with the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 ----
 
 Enabling encryption via the command line involves several commands. If not already done, enable the default encryption module app with the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 ----
 
 Then enable encryption, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:enable
 ----
 
 After that, enable the master key, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:select-encryption-type masterkey
 ----
@@ -184,7 +185,7 @@ NOTE: The master key mode has to be set up in a newly created instance.
 
 Finally, encrypt all data, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:encrypt-all --yes
 ----
@@ -193,7 +194,7 @@ NOTE: This command is not typically required as the master key is often enabled 
 
 Now you can turn off the single user mode:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----
@@ -202,7 +203,7 @@ Now you can turn off the single user mode:
 
 Get the current encryption status and the loaded encryption module:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:status
 ----
@@ -215,7 +216,7 @@ If the master key needs replacement, for example because it has been compromised
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -223,7 +224,7 @@ Single user mode is currently enabled
 
 Decrypt all user data files, or optionally a single user:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:decrypt-all [username]
 ----
@@ -232,7 +233,7 @@ Decrypt all user data files, or optionally a single user:
 
 To disable encryption, put your ownCloud server into single-user mode, and then disable your encryption module with these commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -240,7 +241,7 @@ To disable encryption, put your ownCloud server into single-user mode, and then 
 
 Take it out of single-user mode when you are finished, by using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----
@@ -267,42 +268,42 @@ You may only disable encryption by using the xref:configuration/server/occ_comma
 
 To avoid any issues on a running instance, put your server in single user mode with the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 ----
 
 If not already done, enable the default encryption module app, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 ----
 
 After that, enable encryption, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:enable
 ----
 
 Then, enable the user-key, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:select-encryption-type user-keys
 ----
 
 Finally, encrypt all data, using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:encrypt-all --yes
 ----
 
 Now you can turn off the single user mode:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----
@@ -311,7 +312,7 @@ Now you can turn off the single user mode:
 
 Get the current encryption status and the loaded encryption module:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:status
 ----
@@ -361,7 +362,7 @@ IMPORTANT: Replacing the recovery key will mean that all users will lose the pos
 
 You must first put your ownCloud server into single-user mode to prevent any user activity until encryption is completed.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode is currently enabled
@@ -371,7 +372,7 @@ Single user mode is currently enabled
 
 You may disable encryption only with `occ`. Make sure you have backups of all the encryption keys, including those for all users. Next, put your ownCloud server into single-user mode, and then disable your encryption module with this command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:disable
@@ -383,7 +384,7 @@ If you don’t have access to at least one of these then there is no way to decr
 Then, take it out of single-user mode when you are finished with this
 command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----
@@ -396,7 +397,7 @@ NOTE: It is *not* planned to move this to the next user login or a background jo
 
 View current location of keys:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -404,7 +405,7 @@ Current key storage root:  default storage location (data/)
 
 You can move the keys to another folder inside your data directory. Moving your keys outside of your data folder is not supported. The folder must already exist, be owned by and restricted to root and the webserver group. This example is for Ubuntu Linux. Note that the new folder is relative to your data directory:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 mkdir /var/www/owncloud/data/new_keys
 chown -R root:www-data /var/www/owncloud/data/new_keys

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -16,7 +16,7 @@ This quick guide gives a brief summary of the commands needed without going into
 
 === Activate Master Key-Based Encryption
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} app:enable encryption
@@ -28,7 +28,7 @@ This quick guide gives a brief summary of the commands needed without going into
 
 === View the Encryption Status
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:status
 ----
@@ -37,7 +37,7 @@ This quick guide gives a brief summary of the commands needed without going into
 
 Depending on the amount of existing data, this operation can take a long time.
 
-[source,php,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
@@ -46,16 +46,17 @@ Depending on the amount of existing data, this operation can take a long time.
 
 === Deactivate Master-Key-Based Encryption
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:disable
+
 # ignore the "already disabled" message
 {occ-command-example-prefix} app:disable encryption
 ----
 
 If the master key has been compromised or exposed, you can replace it. You will need the current master key for it.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:recreate-master-key
 ----
@@ -66,7 +67,7 @@ IMPORTANT: User-Key encryption has been deprecated with xref:{latest-docs-versio
 
 === Activate User-Key-Based Encryption
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} app:enable encryption
@@ -93,7 +94,7 @@ They need to:
 
 === View the Encryption Status
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:status
 ----
@@ -102,10 +103,11 @@ They need to:
 
 If you have an ownCloud instance with only a few users, you can use the following example to decrypt the files. Note that you have to enter the password for each user manually. The admin must ensure all users have enabled the recovery password option in their personal settings page.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} encryption:decrypt-all
+
 #Choose the "Recovery key" Option
 #Enter **Recovery Key** for **each user**
 
@@ -117,7 +119,7 @@ If you have a large instance with many users, use this to decrypt the files:
 
 * Set the environment  variable with e.g. `export OC_RECOVERY_PASSWORD=1111`, then run this set of commands and replace "1111" with your actual Recovery Key:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 export OC_RECOVERY_PASSWORD=1111
 {occ-command-example-prefix} maintenance:singleuser --on
@@ -127,7 +129,7 @@ sudo -E -u www-data php occ encryption:decrypt-all -m recovery -c yes
 
 === Deactivate User-Specific Key-based Encryption
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:disable
 
@@ -148,7 +150,7 @@ DELETE FROM oc_appconfig WHERE appid='encryption';
 
 The removal of remaining encryption keys is a manual process. You have to delete all encryption keys on the storage by running the following command. Modify the path to your data directory according to your installation. The `find` command limits the search to exactly one directory below the user level and for security reasons prompts before each deletion:
 
-[source,console]
+[source,bash]
 ----
 find /var/www/owncloud/data/ -mindepth 2 -maxdepth 2 -type d -name "files_encryption" -exec rm -R -i {} +
 ----

--- a/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
@@ -127,7 +127,7 @@ in the folder hierarchy of the external storage.
 
 You might need to setup a cron job that runs
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --all`
 ----

--- a/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -37,12 +37,14 @@ Examples:
 
 When configuring as an *admin*:
 
+[source,text]
 ----
 http(s)://<<Server_Address>>/settings/admin?sectionid=storage
 ----
 
 When configuring as a *user*:
 
+[source,text]
 ----
 http(s)://<<Server_Address>>/settings/personal?sectionid=storage
 ----

--- a/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
@@ -32,11 +32,12 @@ because the Google interface is a bit of a maze and it’s easy to get lost.
 In the examples used, `<your domain>` represents how you access your ownCloud server,
 where you see the login screen. This may look like:
 
+[source,text]
 ----
 https://example.com
-or
+ or
 http://example.com
-or
+ or
 IP/owncloud
 ----
 
@@ -102,9 +103,10 @@ To configure _Authorized Redirect URIs_, select one of the two possible URI Sche
 If you are configuring storage as an administrator - choose the admin URI,
 if you are a user and configure your personal storage - pick the personal URI.
 
+[source,text]
 ----
 https://<your domain>/index.php/settings/admin?sectionid=storage
-or
+ or
 https://<your domain>/index.php/settings/personal?sectionid=storage
 ----
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/smb.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/smb.adoc
@@ -19,7 +19,7 @@ information, prerequisites and requirements.
 
 To ensure that you can connect to your file server with SMB, do a small test upfront like the following.
 
-[source,console]
+[source,bash]
 ----
 sudo smbclient -L <file_server_name> -U <full_domain_name>/<user_name>
 ----

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -30,6 +30,7 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
   This job is required to get the verification token from the other server to establish a federation connection between two servers. 
   The resetting ensures that it will be executed when we run xref:configuration/server/background_jobs_configuration.adoc#cron[system:cron] later.
 +
+[source,bash]
 ----
 mysql -u root -e "update oc_jobs set last_run=0 where class='OCA\\Federation\\SyncJob';" owncloud;
 mysql -u root -e "update oc_jobs set last_checked=0 where class='OCA\\Federation\\SyncJob';" owncloud;
@@ -39,21 +40,21 @@ mysql -u root -e "update oc_jobs set last_checked=0 where class='OCA\\Federation
 . Add **server 2** to the trusted servers on **server 1**.
 . Now run the cron job in your ownCloud directory (for example `/var/www/owncloud/`).
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} system:cron
 ----
 . Now the check should be green
 . Sync now your users with
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:sync-system-addressbook
 {occ-command-example-prefix} federation:sync-addressbook
 ----
 . Configure automatic acceptance of new federated shares.
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set federation auto_accept_trusted --value '0'
 {occ-command-example-prefix} config:app:set federatedfilesharing auto_accept_trusted --value 'yes'
@@ -108,7 +109,7 @@ image:configuration/files/sharing/federated-cloud-sharing/scan-cronjob.png[Check
 
 Alternatively you can use the command line:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_sharing cronjob_scan_external_enabled --value 'yes'
 ----
@@ -117,28 +118,28 @@ You can also configure these settings of the cronjob:
 
 . the minimum amount of time since last login of a user so that a scan is triggered (ensures only active users get fed shares synced)
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_sharing cronjob_scan_external_min_login --value <integer-seconds>
 ----
 
 . the minimum amount of time since last scanned so that the next scan is triggered (avoid frequent scan when active collaboration)
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_sharing cronjob_scan_external_min_scan --value <integer-seconds>
 ----
 
 . the maximum number of federated share scans per 10 minutes (scan performed only if fed share files got updated)
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_sharing cronjob_scan_external_batch --value <integer-number>
 ----
 
 Use the following command to force a run of the scanner cronjob:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:execute --force --accept-warning <id-of-fed-scanner-job>
 ----
@@ -166,7 +167,7 @@ The following functionality has been recorded:
 
 It is possible to configure the VCARD properties that are searched in order to retrieve a list of federated users in the share dialog. By default, ownCloud uses CLOUD and FN properties, however this list may be configured by the admin:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set dav remote_search_properties --value=CLOUD,FN,EMAIL
 ----
@@ -188,14 +189,14 @@ Currently there is no ownCloud `occ` command to list federated shares, that's wh
 
 Federated shares are saved in your database. 
 
-[source,mysql]
+[source,bash]
 ----
 sudo mysql -u <ownCloud_DB_User> -p<ownCloud_DB_Password> -h <ownCloud_DB_Host> <ownCloud_DB_Name>
 ----
 
 Incoming shares can be listed with the following query:
 
-[source,mysql]
+[source,sql]
 ----
 select * from oc_share where share_type=6;
 ----
@@ -205,7 +206,7 @@ Each unique ID gives you an incoming federated share.
 Outgoing shares can be listed with the following query:
 (replace `cloud.example.com` with your instance URL)
 
-[source,mysql]
+[source,sql]
 ----
 select * from oc_share_external where remote NOT IN ('https//cloud.example.com'); 
 ----
@@ -214,7 +215,7 @@ Each unique ID gives you an outgoing federated share.
 
 Exit the database console with this command:
 
-[source,mysql]
+[source,sql]
 ----
 quit
 ----

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -94,7 +94,7 @@ However, it can be changed to any of the currently available languages.
 It is also possible to change this setting on the command-line by using
 xref:configuration/server/occ_command.adoc#config-commands[the occ config:app:set command], as in this example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} \
     config:app:set core shareapi_public_notification_lang \
@@ -243,15 +243,16 @@ Trashbin contents are not transferred.
 
 Here is an example of how to transfer all files from one user to another.
 
+[source,bash,subs="attributes+"]
 ----
-occ files:transfer-ownership <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership <source-user> <destination-user>
 ----
 
 Here is an example of how to transfer _a limited group_ a single folder
 from one user to another. In it, `folder/to/move`, and any file and
 folder inside it will be moved to `<destination-user>`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
 ----
@@ -299,12 +300,11 @@ If you need to create new shares using command-line scripts, there are two avail
 === occ files_external:create
 
 This command provides for the creation of both personal (for a specific user) and general shares.
-The command’s configuration options can be provided either as individual arguments or collectively, as a JSON object.
-For more information about the command, refer to the xref:configuration/server/occ_command.adoc#files-external[the occ files-external documentation].
+The command’s configuration options can be provided either as individual arguments or collectively, as a JSON object. For more information about the command, refer to the xref:configuration/server/occ_command.adoc#files-external[the occ files-external documentation].
 
 ==== Personal Share
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -312,7 +312,7 @@ For more information about the command, refer to the xref:configuration/server/o
     --user someuser
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -325,14 +325,14 @@ For more information about the command, refer to the xref:configuration/server/o
 
 ==== General Share
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'}
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
     password::logincredentials \
@@ -349,14 +349,14 @@ You can create general and personal shares passing the configuration details via
 
 ==== General Share
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:import /import.json
 ----
 
 ==== Personal Share
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:import /import.json --user someuser
 ----

--- a/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
+++ b/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
@@ -44,7 +44,7 @@ Go to menu:Settings[Admin > Additional]
 image::configuration/files/manual_file_locking/manual-file-locking-with-lock-breaker.png[Enable file locking]
 
 Using the occ command::
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files enable_lock_file_action --value yes
 ----
@@ -69,14 +69,14 @@ The image is the same as shown above when enabling or disabling _Manual File Loc
 Using the occ command::
 * Default locks timeout
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files lock_timeout_default --value 1800
 ----
 +
 * Maximum locks timeout
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files lock_timeout_max --value 86400
 ----
@@ -85,7 +85,7 @@ Using the occ command::
 +
 The example below defines two lock breaker groups named `unlockers` and `admin`.
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set core lock-breaker-groups --value '["unlockers","admin"]'
 ----

--- a/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
@@ -40,7 +40,7 @@ Please note that the ownCloud preview system comes already with sensible default
 
 The default list of enabled preview providers which do not need to be explicitly enabled in the config are:
 
-[source,console]
+[source,text]
 ----
 OC\Preview\BMP
 OC\Preview\GIF
@@ -63,23 +63,23 @@ When defining your own preview providers, some things need to be considered. For
 
 If you handle the security risk and decide to allow creating previews for PDF files, change the following imagick security policy. Use an editor of your choice like `nano` and change the following file, adapt the path if using ImageMagick 7:
 
-[source,console]
+[source,bash]
 ----
 sudo nano /etc/ImageMagick-6/policy.xml
-or
+ or
 sudo nano /etc/ImageMagick-7/policy.xml
 ----
 
 Search for the following content:
 
-[source,console]
+[source,text]
 ----
 <policy domain="coder" rights="none" pattern="PDF" />
 ----
 
 and change:
 
-[source,console]
+[source,text]
 ----
 rights="none" --> rights="read|write"
 ----
@@ -90,7 +90,7 @@ After changing the policy file for ImageMagic, restart your Apache web server or
 
 To be able to create previews for video files when using the `OC\Preview\Movie` provider, you must install `ffmpeg`. There can be significant load on the server during conversion when video thumbnail generation is enabled.
 
-[source,console]
+[source,bash]
 ----
 sudo apt install -y ffmpeg
 ----
@@ -99,7 +99,7 @@ sudo apt install -y ffmpeg
 
 To get a list of file extensions linked to the image or video provider, change into the `owncloud` directory and run the following example command. Use a different filter for other provider types.
 
-[source,console]
+[source,bash]
 ----
 cat resources/config/mimetypemapping.dist.json | grep image
 ----
@@ -108,7 +108,7 @@ cat resources/config/mimetypemapping.dist.json | grep image
 
 The following providers require the php `imagick` extension:
 
-[source,console]
+[source,text]
 ----
 OC\Preview\AI
 OC\Preview\EPS
@@ -123,7 +123,7 @@ OC\Preview\TTF
 
 The following providers are only available if either LibreOffice or OpenOffice is installed on the server:
 
-[source,console]
+[source,text]
 ----
 OC\Preview\MSOfficeDoc
 OC\Preview\MSOffice2003
@@ -134,7 +134,7 @@ OC\Preview\StarOffice
 
 The following providers are available, but disabled by default due to performance or privacy/security concerns:
 
-[source,console]
+[source,text]
 ----
 OC\Preview\Font
 OC\Preview\Illustrator
@@ -159,7 +159,7 @@ Under certain circumstances, for example if the server has limited resources, yo
 
 Set the configuration option `enable_previews` to `false`:
 
-[source,console]
+[source,php]
 ----
   'enable_previews' => false,
 ----
@@ -168,7 +168,7 @@ Set the configuration option `enable_previews` to `false`:
 
 The example below adds the preview provider for `SGI` and `HEIC` images:
 
-[source,console]
+[source,php]
 ----
 'enabledPreviewProviders' => [
 	'OC\Preview\SGI',
@@ -192,7 +192,7 @@ There are two configuration options for setting the maximum size (in pixels) of 
 
 The following example would limit previews to a maximum size of 100 px × 100 px:
 
-[source,console]
+[source,php]
 ----
   'preview_max_x' => 100,
   'preview_max_y' => 100,
@@ -204,21 +204,21 @@ NOTE: If you want no limit applied for one or both of these values then set them
 
 If a lot of small pictures are stored on the ownCloud instance and the preview system generates blurry previews, you might want to consider setting a maximum scale factor. By default, pictures are upscaled to 10 times the original size:
 
-[source,console]
+[source,php]
 ----
   'preview_max_scale_factor' => 10,
 ----
 
 If you want to disable scaling at all, you can set the config value to `1':
 
-[source,console]
+[source,php]
 ----
   'preview_max_scale_factor' => 1,
 ----
 
 If you want to disable the maximum scaling factor, you can set the config value to `null`:
 
-[source,console]
+[source,php]
 ----
   'preview_max_scale_factor' => null,
 ----
@@ -227,7 +227,7 @@ If you want to disable the maximum scaling factor, you can set the config value 
 
 The JP(E)G image quality can be defined in [%] for displaying thumbnails and image previews for apps like Files or Files Mediaviewer. Note that this setting is for displaying only and has no impact on the stored thumbnail / preview quality or size.
 
-[source,console]
+[source,php]
 ----
   'previewJPEGImageDisplayQuality' => -1,
 ----

--- a/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
+++ b/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
@@ -12,6 +12,7 @@ As the ownCloud server administrator, you have two `occ` commands for
 permanently deleting files from the Trashbin manually, without waiting
 for the normal aging-out process:
 
+[source,text]
 ----
 trashbin
  trashbin:cleanup   Remove deleted files
@@ -22,7 +23,7 @@ The `trashbin:cleanup` command removes the deleted files of all users,
 or you may specify certain users in a space-delimited list. This example
 removes all the deleted files of all users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -35,7 +36,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of user2 and user4:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:cleanup user2 user4
  Remove deleted files of user2
@@ -51,7 +52,7 @@ storage quotas. Files may not be deleted if the space is not needed.
 The default is to delete expired files for all users, or you may list
 users in a space-delimited list:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:cleanup user1 user2
  Remove deleted files of user1

--- a/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/code_signing.adoc
@@ -209,9 +209,11 @@ manually with the `occ` command. The first command scans the ownCloud
 core files, and the second command scans the named app. There is not yet
 a command to manually scan all apps:
 
+
+[source,bash,subs="attributes+"]
 ----
-occ integrity:check-core
-occ integrity:check-app $appid
+{occ-command-example-prefix} integrity:check-core
+{occ-command-example-prefix} integrity:check-app <appid>
 ----
 
 TIP: See xref:configuration/server/occ_command.adoc[the occ command] to learn more about using `occ`.

--- a/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/general_troubleshooting.adoc
@@ -97,14 +97,14 @@ When you are finished reviewing your information you must delete `phpinfo.php`, 
 
 To retrieve your PHP version, run the following command:
 
-[source,console]
+[source,bash]
 ----
 php -v
 ----
 
 To retrieve a list of PHP's active modules, run the following command.
 
-[source,console]
+[source,bash]
 ----
 php -m
 ----
@@ -173,10 +173,10 @@ directive to your Apache configuration, whether in the general Apache
 config, in a configuration include file, or in ownCloud’s .htaccess
 file.
 
+[source,apache]
 ----
 SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 ----
-
 
 == Missing Data Directory
 

--- a/modules/admin_manual/pages/configuration/mimetypes/index.adoc
+++ b/modules/admin_manual/pages/configuration/mimetypes/index.adoc
@@ -73,7 +73,7 @@ Some common mimetypes that may be useful in creating aliases are:
 Once you have made changes to `config/mimetypealiases.json`, use xref:configuration/server/occ_command.adoc[the occ command] to propagate the changes throughout your ownCloud installation.
 Here is an example for Ubuntu Linux:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ----
@@ -103,7 +103,7 @@ NOTE: The name and location of the file are important. The location is because t
 
 1.  Run the following command to update the mimetype alias database.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 $ {occ-command-example-prefix} maintenance:mimetype:update-js
 ----

--- a/modules/admin_manual/pages/configuration/search/index.adoc
+++ b/modules/admin_manual/pages/configuration/search/index.adoc
@@ -16,7 +16,7 @@ NOTE: Version 1.0.0 of the Full Text Search app only works with Elasticsearch ve
 The ingest-attachment processor lets Elasticsearch extract file attachments in common formats. 
 To install the processor, run the following command from your Elasticsearch installation directory:
 
-[source=console]
+[source=bash]
 ----
 bin/elasticsearch-plugin install ingest-attachment
 service elasticsearch restart

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -15,7 +15,7 @@ Use the xref:configuration/server/occ_command.adoc#background-jobs-selector[occ 
 
 As an example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:cron
 ----
@@ -42,17 +42,17 @@ Using the operating system Cron feature is the preferred method for executing re
 
 For example, to run a Cron job on a *nix system every 15 minutes (recommended), under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ `background:cron` command:
 
-[source,console]
+[source,bash]
 ----
-# sudo crontab -u www-data -e
+sudo crontab -u www-data -e
 */15  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
 ----
 
 You can verify if the cron job has been added and scheduled by executing:
 
-[source,console]
+[source,bash]
 ----
-# sudo crontab -u www-data -l
+sudo crontab -u www-data -l
 */15  *  *  *  * /usr/bin/php -f /path/to/your/owncloud/occ system:cron
 ----
 
@@ -84,7 +84,7 @@ Regardless of the approach which you take, since ownCloud 9.1, Cron jobs can be 
 
 There is no way to do so via the ownCloud UI. But, the most direct way to do so, is by opening three console tabs and in each one run
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} system:cron
 ----
@@ -119,7 +119,7 @@ NOTE: There is no matching background job to delete from the `oc_jobs` table.
 
 The ExpireTrash job, contained in `OCA\Files_Trashbin\BackgroundJob\ExpireTrash`, will remove any file in the ownCloud trash bin which is older than the specified maximum file retention time.  It can be run, as follows, using the xref:configuration/server/occ_command.adoc#trashbin[OCC trashbin] command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:expire
 ----
@@ -128,7 +128,7 @@ The ExpireTrash job, contained in `OCA\Files_Trashbin\BackgroundJob\ExpireTrash`
 
 The ExpireVersions job, contained in `OCA\Files_Versions\BackgroundJob\ExpireVersions`, will expire versions of files which are older than the specified maximum version retention time. It can be run, as follows, using the xref:configuration/server/occ_command.adoc#versions[OCC versions] command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:expire
 ----
@@ -139,7 +139,7 @@ CAUTION: Please take care when adding `ExpireTrash` and `ExpireVersions` as xref
 
 The `CardDAV SyncJob`, contained in `OCA\DAV\CardDAV\SyncJob`, syncs the local system address book, updating any existing contacts, and deleting any expired contacts. It can be run, as follows, using the xref:configuration/server/occ_command.adoc#dav-commands[OCC dav] command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:sync-system-addressbook
 ----
@@ -151,7 +151,7 @@ OCAFederationSyncJob
 It can be run, as follows, using the
 xref:configuration/server/occ_command.adoc#federation-sync[OCC federation sync] command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} federation:sync-addressbooks
 ----

--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -53,7 +53,7 @@ The cache directory defaults to `data/$user/cache` where `$user` is the current 
 
 Opcache should be enabled by default in your php installation. To check it, run the following command:
 
-[source,php]
+[source,bash]
 ----
 php -r 'phpinfo();' | grep opcache.enable
 ----
@@ -64,9 +64,9 @@ The easiest cache to use is APCu, because it is a data cache, very fast and noth
 
 ==== Installing APCu
 
-[source,console]
+On Ubuntu/Debian/Mint systems:
+[source,bash]
 ----
-# On Ubuntu/Debian/Mint systems
 sudo apt install php-apcu
 ----
 
@@ -87,7 +87,7 @@ NOTE: The default shipped Redis version and the php-redis extension for Ubuntu 2
 
 If you have Ubuntu 16.04 or higher:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install redis-server php-redis
 ----
@@ -100,11 +100,11 @@ After that, assuming that you don’t encounter any errors, restart Apache and t
 
 APCu is faster at local caching than Redis. If you have enough memory, use APCu for memory caching and Redis for file locking. If you are low on memory, use Redis for both.
 
-
 ==== Clearing the Redis Cache
 
 The Redis cache can be flushed from the command-line using the {rediscli_url}[redis-cli tool], as in the following example:
 
+[source,bash]
 ----
 sudo redis-cli
 SELECT <dbIndex>
@@ -133,7 +133,7 @@ NOTE: Be sure to install the *memcached* PHP module, and not _memcache_, as in t
 
 On Ubuntu/Debian/Mint run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get install memcached php-memcached
 ----
@@ -158,7 +158,7 @@ After that, assuming that you don’t encounter any errors:
 
 The Memcached cache can be flushed from the command line, using a range of common Linux/Unix tools including `netcat` and `telnet`. The following example uses telnet to log in, run the {flushall_url}[flush_all command], and log out:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 telnet localhost {std-port-memcache}
 flush_all
@@ -247,7 +247,7 @@ If setting up Redis to be accessed via a Unix socket from a webserver user, then
 
 To see a benchmark comparison, run:
 
-[source,console]
+[source,bash]
 ----
 sudo redis-benchmark -q -n 100000
 sudo redis-benchmark -s /var/run/redis/redis-server.sock -q -n 100000

--- a/modules/admin_manual/pages/configuration/server/custom_client_repos.adoc
+++ b/modules/admin_manual/pages/configuration/server/custom_client_repos.adoc
@@ -4,6 +4,7 @@ You may configure the URLs to your own download repositories for your
 ownCloud desktop clients and mobile apps in config/config.php. This
 example shows the default download locations:
 
+[source,php]
 ----
 <?php
 
@@ -18,12 +19,14 @@ repos.
 You may test alternate URLs without editing config/config.php by setting
 a test URL as an environment variable:
 
+[source,bash]
 ----
 export OCC_UPDATE_URL=https://test.example.com
 ----
 
 When you’re finished testing you can disable the environment variable:
 
+[source,bash]
 ----
 unset OCC_UPDATE_URL
 ----

--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -213,6 +213,7 @@ no-reply@example.com
 
 Use the ping command to check the server availability
 
+[source,bash]
 ----
 ping smtp.server.dom
 ----
@@ -226,11 +227,12 @@ PING smtp.server.dom (ip-address) 56(84) bytes of data.
 
 The best way to get mail server information is to ask your mail server admin. If you are the mail server admin, or need information in a hurry, you can use the `netstat` command. This example shows all active servers on your system, and the ports they are listening on. The SMTP server is listening on localhost port 25.
 
+[source,bash]
 ----
-# netstat -pant
+netstat -pant
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 Active Internet connections (servers and established)
 Proto Recv-Q Send-Q Local Address   Foreign Address  State  ID/Program name
@@ -257,6 +259,7 @@ SMTP servers usually announce the availability of STARTTLS immediately after a c
 
 NOTE: You must enter the marked lines to obtain the information displayed.
 
+[source,bash]
 ----
 telnet smtp.domain.dom 25
 ----

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -32,7 +32,7 @@ This is because ownCloud needs to integrate in to a diverse range of environment
 If you are yet to implement a rate-limiting solution for your ownCloud instance, start by retrieving a list of all active routes.
 This information is obtained by running xref:configuration/server/occ_command.adoc#security[occ's security:routes command], as in the following example.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:routes
 ----
@@ -144,6 +144,7 @@ warnings.
 This can be achieved by adding the following settings in the Apache
 VirtualHost file containing the `<VirtualHost *:443>` entry:
 
+[source,apache]
 ----
 <IfModule mod_headers.c>
   Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
@@ -260,6 +261,7 @@ NOTE: If you’re not familiar with what’s going on, this snippet highlights a
 
 On Ubuntu, you can install Fail2ban using the following commands:
 
+[source,bash]
 ----
 apt update && apt upgrade
 apt install fail2ban
@@ -272,6 +274,7 @@ ownCloud uses your local timezone for writing log entries; otherwise,
 fail2ban cannot react appropriately to attacks. To do this, edit your
 `config.php` file and add the following line:
 
+[source,php]
 ----
 'logtimezone' => 'Europe/Berlin',
 ----
@@ -290,6 +293,7 @@ Next, define a new Fail2ban filter rule for ownCloud. To do so, create a
 new file called `/etc/fail2ban/filter.d/owncloud.conf`, and insert the
 following configuration:
 
+[source,conf]
 ----
 [Definition]
 failregex={.*Login failed: \'.*\' \(Remote IP: \'<HOST>\'\)"}

--- a/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
@@ -17,6 +17,7 @@ Finally the user running your Web server (e.g. `www-data`) needs to be able to w
 
 The first step is to configure the `overwrite.cli.url` and `htaccess.RewriteBase` config.php options (See config_sample_php_parameters). If you’re accessing your ownCloud instance via `\https://example.com/` the following two options need to be added / configured:
 
+[source,php]
 ----
 'overwrite.cli.url' => 'https://example.com',
 'htaccess.RewriteBase' => '/',
@@ -24,6 +25,7 @@ The first step is to configure the `overwrite.cli.url` and `htaccess.RewriteBase
 
 If the instance is accessed via `\https://example.com/owncloud` the following configuration is needed:
 
+[source,php]
 ----
 'overwrite.cli.url' => 'https://example.com/owncloud',
 'htaccess.RewriteBase' => '/owncloud',

--- a/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/legal_settings_configuration.adoc
@@ -44,13 +44,16 @@ NOTE: The values entered will auto-save.
 
 From the command line, you can use the `occ config:app:get` and `occ config:app:set` commands, as in the code sample below.
 
-[source,console,subs="attributes+"]
+Get the current values, if any, for the Imprint and Privacy Policy URLs:
+[source,bash,subs="attributes+"]
 ----
-# Get the current values, if any, for the Imprint and Privacy Policy URLs
 {occ-command-example-prefix} config:app:get core legal.imprint_url
 {occ-command-example-prefix} config:app:get core legal.privacy_policy_url
+----
 
-# Set the Imprint and Privacy Policy URLs
+Set the Imprint and Privacy Policy URLs:
+[source,bash,subs="attributes+"]
+----
 {occ-command-example-prefix} config:app:set core legal.imprint_url --value=new_value
 {occ-command-example-prefix} config:app:set core legal.privacy_policy_url --value=new_value
 ----

--- a/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
@@ -37,6 +37,7 @@ The desired date format can optionally be defined using the *logdateformat* para
 By default the {php-net-url}/manual/en/function.date.php[PHP date function] parameter `__c__` is used, and therefore the date/time is written in the format `__2013-01-10T15:20:25+02:00__`. 
 By using the date format in the example below, the date/time format will be written in the format `__January 10, 2013 15:20:25__`.
 
+[source,php]
 ----
 "log_type" => "owncloud",
 "logfile" => "owncloud.log",
@@ -48,6 +49,7 @@ By using the date format in the example below, the date/time format will be writ
 
 All log information will be sent to your default syslog daemon.
 
+[source,php]
 ----
 "log_type" => "syslog",
 "logfile" => "",
@@ -58,11 +60,14 @@ The syslog format can be changed to remove or add information. In
 addition to the `%replacements%` below `%level%` can be used, but it is
 used as a dedicated parameter to the syslog logging facility anyway.
 
+[source,php]
 ----
 'log.syslog.format' => '[%reqId%][%remoteAddr%][%user%][%app%][%method%][%url%] %message%',
+----
 
-   For the old syslog message format use:
-
+For the old syslog message format use:
+[source,php]
+----
 'log.syslog.format' => '{%app%} %message%',
 ----
 
@@ -105,6 +110,7 @@ to the same logfile defined:
 
 * Requests matching `log_secret` are debug logged.
 
+[source,bash]
 ----
 curl -X PROPFIND -u sample-user:password \
   https://your_domain/remote.php/webdav/?log_secret=57b58edb6637fe3059b3595cf9c41b9

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -57,7 +57,7 @@ NOTE: The Linux kernel will silently truncate the TCP-backlog setting to the val
 To fix this warning, set the value of `net.core.somaxconn` to `65535` in
 `/etc/rc.local`, so that it persists upon reboot, by running the following command.
 
-[source,console]
+[source,bash]
 ----
 sudo echo sysctl -w net.core.somaxconn=65535 >> /etc/rc.local
 ----
@@ -65,7 +65,6 @@ sudo echo sysctl -w net.core.somaxconn=65535 >> /etc/rc.local
 After the next reboot, 65535 connections will be allowed, instead of the default value.
 
 === Transparent Huge Pages (THP)
-
 
 If you are experiencing latency problems with Redis, the following
 warning may appear in your Redis logs:
@@ -88,7 +87,7 @@ thousand pages, causing the copy-on-write of almost the entire process memory.
 
 As a result, make sure to disable Transparent Huge Pages using the following command:
 
-[source,console]
+[source,bash]
 ----
 echo never > /sys/kernel/mm/transparent_hugepage/enabled
 ----
@@ -184,8 +183,9 @@ MaxKeepAliveRequests 200
 
 ==== Hostname Lookups
 
+[source,bash]
 ----
-# cat /etc/httpd/conf/httpd.conf
+cat /etc/httpd/conf/httpd.conf
     ...
 HostnameLookups off
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -78,7 +78,7 @@ On a regular ownCloud installation, `occ` is in the `owncloud/` directory, this 
 [TIP]
 ====
 Use the following command to find your HTTP user:
-[source,console]
+[source,bash]
 ----
 ps -ef | egrep '(apache|apache2)' | grep -v `whoami` | grep -v root | head -n1 | awk '{print $1}'
 ----
@@ -87,7 +87,7 @@ ps -ef | egrep '(apache|apache2)' | grep -v `whoami` | grep -v root | head -n1 |
 If your HTTP server is configured to use a different PHP version than the default (/usr/bin/php), `occ` should be run with the same version. +
 For example, in CentOS with SCL-PHP74 installed, the command looks like this:
 
-[source,console]
+[source,bash]
 ----
 sudo -u apache /opt/rh/php74/root/usr/bin/php /var/www/html/owncloud/occ
 ----
@@ -102,13 +102,13 @@ The `occ` command has _options_, _commands_, and _arguments_.
 
 The generic syntax is:
 
-[source,console]
+[source,bash]
 ----
 occ [options] command [arguments]
 ----
 
 .Example command running occ in Ubuntu
-[source,console]
+[source,bash]
 ----
 sudo -u www-data /var/www/owncloud/occ
 ----
@@ -119,7 +119,7 @@ If your web server is configured to use a different PHP version than the default
 
 If your ownCloud instance is set up in a docker container, you need a user in the group `docker` to perform `occ` commands. An example command looks like this:
 
-[source,console]
+[source,docker]
 ----
 docker exec --user www-data <owncloud-container-name> php occ <your-command>
 ----
@@ -140,7 +140,7 @@ If you want to find out more about the Appliance, click xref:appliance/index.ado
 
 Running `occ` with no options lists all commands and options, like this example on Ubuntu:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix}
 ownCloud version 10.8.0
@@ -171,14 +171,14 @@ Available commands:
 This is the same as `{occ-command-example-prefix} list`. 
 Run it with the `-h` option for syntax help:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} -h
 ----
 
 Display your ownCloud version:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} -V
   ownCloud version 10.8.0
@@ -186,7 +186,7 @@ Display your ownCloud version:
 
 Query your ownCloud server status:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} status
   - installed: true
@@ -199,7 +199,7 @@ The `status` command from above has an option to define the output format.
 
 The default is plain text, but it can also be `json`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} status --output=json
 {"installed":true,"version":"10.8.0.4","versionstring":"10.8.0","edition":""}
@@ -207,7 +207,7 @@ The default is plain text, but it can also be `json`:
 
 or `json_pretty`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} status --output=json_pretty
 {
@@ -222,7 +222,7 @@ This output option is available on all list and list-like commands, which includ
 
 Get detailed information on individual commands with the `help` command, like in this example for the `maintenance:mode` command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} help maintenance:mode --help
 Usage:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
@@ -17,7 +17,7 @@ The following commands are available for the 2-Factor Authentication app:
 
 Delete the redundant secrets of non-existing users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} twofactor_totp:delete-redundant-secret
 ----
@@ -26,7 +26,7 @@ Delete the redundant secrets of non-existing users:
 
 Set secret verification status of specified users or all users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix}  twofactor_totp:set-secret-verification-status [options] [--] <set-verified>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
@@ -12,7 +12,7 @@ The `activity` command is used for sending automated activity email notification
 
 The `activity:send-emails` command sends all pending activity emails immediately, regardless of the time they are scheduled.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} activity:send-emails
 ----
@@ -23,21 +23,21 @@ Starting with Activity app version 2.7.0, rename and move action notifications c
 
 === Enable Rename and Move Action Notifications
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set activity enable_move_and_rename_activities --value "yes"
 ----
 
 === Disable Rename and Move Action Notifications
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set activity enable_move_and_rename_activities --value "no"
 ----
 
 or
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete activity enable_move_and_rename_activities
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
@@ -11,7 +11,7 @@ Ignore all CLI triggered events.
 
 To ignore all CLI triggered events, you can set the following option, defaults to track cli events:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
      "admin_audit ignore_cli_events" \
@@ -22,7 +22,7 @@ To ignore all CLI triggered events, you can set the following option, defaults t
 
 This command reads the value of `admin_audit ignore_cli_events`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:get "admin_audit ignore_cli_events"
 ----
@@ -36,7 +36,7 @@ yes
 
 This command completely removes the key and the value:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete "admin_audit ignore_cli_events"
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_antivirus_commands.adoc
@@ -7,7 +7,7 @@ Parametrisation must be done with the `occ config` command set.
 
 == List the Current Settings
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list files_antivirus
 ----
@@ -16,7 +16,7 @@ Parametrisation must be done with the `occ config` command set.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus <Key> --value=<Value> --update-only
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_brute_force_protection_commands.adoc
@@ -8,7 +8,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 == List the Current Settings
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list brute_force_protection
 ----
@@ -17,7 +17,7 @@ The combination of `uid` and `IP address` is used to trigger the ban.
 
 To set a new value, use the command below and replace `<Key>` and value `<Value>` accordingly.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set brute_force_protection <Key> --value=<Value> --update-only
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
@@ -42,7 +42,7 @@ lifecycle
 
 Archive files which have reached a certain age.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:archive [options]
 ----
@@ -60,7 +60,7 @@ Archive files which have reached a certain age.
 
 Expire files from archive which have reached a certain age.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:expire [options]
 ----
@@ -78,7 +78,7 @@ Expire files from archive which have reached a certain age.
 
 Restore files from archive to the original location. Note that the location for archived files always follows the pattern `$userid/archive/files/...`
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:restore <path>
 ----
@@ -95,7 +95,7 @@ Restore files from archive to the original location. Note that the location for 
 
 Restore all files in folder `project1` for user alice with path `/work/projects/project1`
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:restore /alice/archive/files/work/projects/project1
 ----
@@ -104,7 +104,7 @@ Restore all files in folder `project1` for user alice with path `/work/projects/
 
 Restore all archived files for all users in the system back to their original locations. This command has no additional arguments or options.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:restore-all
 ----
@@ -116,7 +116,7 @@ Set upload time for files which do not have one.
 NOTE: Files without upload time are silently skipped by `occ lifecycle:archive`
 This can happen with files that were uploaded before the files_lifecycle app was configured or when it was temporarily disabled and therefore do not have an upload time set.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:set-upload-time [options] [--] <date>
 ----
@@ -148,7 +148,7 @@ The number of days since upload (or restore) after which files will be archived.
 
 The following example command sets the time passed since upload (or restore) for archiving files to 90 days.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle archive_period --value='90'
 ----
@@ -159,7 +159,7 @@ The number of days since archiving after which files will be permanently deleted
 
 The following example command sets the time passed to delete files to 180 days.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle expire_period --value='180'
 ----
@@ -170,7 +170,7 @@ Define groups of users that are exempt from the lifecycle policies (comma-separa
 
 The following example command specifies groups whose members will not be part of the lifecycle management.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle excluded_groups --value='group1,group2'
 ----
@@ -181,7 +181,7 @@ Set a policy who can restore files. Use the value `soft` for self-service and `h
 
 The following example command sets the restoration policy for users to `soft` (default).
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle policy --value='soft'
 ----
@@ -192,14 +192,14 @@ Disable the whole user interface for the File Lifecycle Management app.
 
 The following example command disables the user interface for the File Lifecycle Management app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle disable_ui --value='yes'
 ----
 
 You can reenable it by deleting the key:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete files_lifecycle disable_ui
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
@@ -19,7 +19,7 @@ ldap
 
 Search for an LDAP user, using this syntax:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search [options] [--] <search>
 ----
@@ -111,7 +111,7 @@ The best way understanding `offset` and `limit` is the following table when usin
 
 Searches match at the beginning of the attribute value only. This example searches for `givenNames` that start with 'rob':
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search "rob"
 ----
@@ -119,14 +119,14 @@ Searches match at the beginning of the attribute value only. This example search
 This will find "robbie", "roberta", and "robin".
 Broaden the search to find, for example, `jeroboam` with the asterisk wildcard:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search "*rob"
 ----
 
 The following examples use `offset` and `limit` options:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search "re"
 Rebecca OShea (Rebecca.OShea)
@@ -136,7 +136,7 @@ Rekha Cox (Rekha.Cox)
 Rekha Craft (Rekha.Craft)
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search "re" --offset 0 --limit 3
 Rebecca OShea (Rebecca.OShea)
@@ -144,7 +144,7 @@ Rebecca Vintin (Rebecca.Vintin)
 Rebekka Da-Cahuna (Rebekka.Da-Cahuna)
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:search "re" --offset 3 --limit 3
 Rekha Cox (Rekha.Cox)
@@ -155,7 +155,7 @@ Rekha Craft (Rekha.Craft)
 
 This only works if the ownCloud server is connected to an LDAP server.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 ldap:check-user [options] [--] <ocName>
 ----
@@ -178,14 +178,14 @@ ldap:check-user [options] [--] <ocName>
 
 Example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:check-user robert
 ----
 
 `ldap:check-user` will not run a check when it finds a disabled LDAP connection. This prevents users that exist on disabled LDAP connections from being marked as deleted. If you know for sure that the user you are searching for is not in one of the disabled connections and exists on an active connection, use the `--force` option to force a check of all active LDAP connections.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:check-user --force robert
 ----
@@ -194,7 +194,7 @@ Example:
 
 Create an empty LDAP configuration.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 ldap:create-empty-config [<configID>]
 ----
@@ -209,7 +209,7 @@ ldap:create-empty-config [<configID>]
 
 Configurations that you create without assigning a <configID> are automatically assigned IDs.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:create-empty-config
    Created new configuration with configID 's01'
@@ -219,7 +219,7 @@ Configurations that you create without assigning a <configID> are automatically 
 
 You can list and view your configurations:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:show-config [options] [--] [<configID>]
 ----
@@ -247,14 +247,14 @@ You can list and view your configurations:
 
 If you omit the `configID`, all configuration ID's with their settings are listed:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:show-config
 ----
 
 View the configuration for a single `configID`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:show-config s01
 ----
@@ -263,7 +263,7 @@ View the configuration for a single `configID`:
 
 Deletes an existing LDAP configuration.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
  ldap:delete-config <configID>
 ----
@@ -276,7 +276,7 @@ Deletes an existing LDAP configuration.
 |  The configuration ID
 |===
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:delete  s01
 Deleted configuration with configID 's01'
@@ -286,7 +286,7 @@ Deleted configuration with configID 's01'
 
 This command invalidates the LDAP cache for all users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:invalidate-cache
 ----
@@ -295,7 +295,7 @@ This command invalidates the LDAP cache for all users:
 
 This command manipulates LDAP configurations.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:set-config <configID> <configKey> <configValue>
 ----
@@ -318,7 +318,7 @@ If a `configKey` allows multiple entries like the key `ldapAttributesForUserSear
 
 This example sets search attributes:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:set-config s01 ldapAttributesForUserSearch "cn;givenname;sn;displayname;mail"
 ----
@@ -384,7 +384,7 @@ Available keys, along with default values for configValue, are listed in the tab
 
 Tests whether your configuration is correct and can bind to the server.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:test-config <configID>
 ----
@@ -399,7 +399,7 @@ Tests whether your configuration is correct and can bind to the server.
 
 Example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:test-config s01
 The configuration is valid and the connection could be established!
@@ -407,7 +407,7 @@ The configuration is valid and the connection could be established!
 
 == Set and Unset LDAP App Configurations
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set user_ldap updateAttributesInterval --value=7200
 ----
@@ -422,7 +422,7 @@ Config value updateAttributesInterval for app user_ldap set to 7200
 
 If you want to reset (or unset) the setting, then you can use the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete user_ldap updateAttributesInterval
 ----
@@ -433,7 +433,7 @@ If you want to allow new LDAP logins to attempt to reuse existing `oc_accounts` 
 
 Below is an example of how to do so.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set user_ldap reuse_accounts --value="yes"
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
@@ -31,7 +31,7 @@ To install an application from the Marketplace, you need to supply the app’s i
 For example, the URL for _Two factor backup codes_ is {oc-marketplace-url}/apps/twofactor_backup_codes.
 So its app id is `twofactor_backup_codes`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install <ids> [option]
 ----
@@ -57,7 +57,7 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 
 == Usage Example
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 # Install an app from the marketplace.
 {occ-command-example-prefix} market:install twofactor_backup_codes
@@ -72,7 +72,7 @@ NOTE: The target directory has to be *accessible to the webserver user* and you 
 
 To uninstall an application use the following commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:uninstall <ids>
 ----
@@ -89,7 +89,7 @@ To uninstall an application use the following commands:
 This command lists apps available on the marketplace.
 It returns the ids of the apps.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:list
 ----
@@ -98,7 +98,7 @@ It returns the ids of the apps.
 
 Install new app versions if available on the marketplace by using following commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:upgrade <ids> [options]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
@@ -21,7 +21,7 @@ Writes the key `metrics_shared_secret` and the secret to config.php. The name mu
 Note: You can also set the config key/value manually into your config.php file.
 
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set \
      "metrics_shared_secret" \
@@ -39,7 +39,7 @@ The above command adds the following at the end of `config.php`:
 
 This command reads the value of the `metrics_shared_secret` key from config.php:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:get "metrics_shared_secret"
 ----
@@ -53,7 +53,7 @@ your-metrics-secret
 
 This command completely removes the key and the value from config.php:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:delete "metrics_shared_secret"
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_password_policy_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_password_policy_commands.adoc
@@ -6,7 +6,7 @@ Command to expire a user or group of users’ passwords.
 
 == Command Description
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:expire-password <uid> [<expiredate>]
 ----
@@ -54,7 +54,7 @@ The password for frank is set to expire on 2018-07-12 13:15:28 UTC.
 
 == Command Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 # The password for user "frank" will be set as being expired 24 hours before the command was run.
 {occ-command-example-prefix} user:expire-password -u frank

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ransomware_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ransomware_protection_commands.adoc
@@ -8,7 +8,7 @@ You can find more information about the application in xref:enterprise/security/
 
 == Command Description
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ransomguard:scan <timestamp> <user>
 ----
@@ -21,7 +21,7 @@ You can find more information about the application in xref:enterprise/security/
 `<user>`          | Report all changes in a user's account, starting from timestamp.
 |===
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ransomguard:restore <timestamp> <user>
 ----
@@ -34,7 +34,7 @@ You can find more information about the application in xref:enterprise/security/
 `<user>`          | Revert all operations in a user account after a point in time.
 |===
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ransomguard:lock <user>
 ----
@@ -47,7 +47,7 @@ You can find more information about the application in xref:enterprise/security/
 malicious activity is suspected.
 |===
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ransomguard:unlock <user>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
@@ -36,7 +36,7 @@ This command sets the WOPI Server to `[IP/URL]:port` +
 
 Adding the port is only necessary when not using standard ports.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments wopi_url --value='[IP/URL]:port'
 ----
@@ -47,7 +47,7 @@ Enable Secure View (possible values: true/false, default: false).
 
 The following example command enables secure view globally on the system:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments secure_view_option --value='true'
 ----
@@ -58,7 +58,7 @@ A watermark pattern is displayed in the document when it is viewed. It can be an
 
 The following example command sets the watermark pattern displayed in the document:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments watermark_text --value='Restricted to \{viewer-email}'
 ----
@@ -69,7 +69,7 @@ By default, documents will open in a new tab if not otherwise defined. You can c
 
 The following example command makes documents open in the same tab:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments open_in_new_tab --value='false'
 ----
@@ -80,7 +80,7 @@ Enable documents in secure view mode to be printed and exported (possible values
 
 The following example command enables the option to globally print and export documents although secure view is enabled:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set secure_view_can_print_default --value='true'
 ----
@@ -91,7 +91,7 @@ Open documents in secure view with watermark by default (possible values: true/f
 
 The following example command enables the option to globally enforce displaying the watermark when documents are viewed:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments secure_view_open_action_default --value='true'
 ----
@@ -100,14 +100,14 @@ The following example command enables the option to globally enforce displaying 
 
 You can delete a key with the following example command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete richdocuments secure_view_open_action_default
 ----
 
 You can change a key with the following example command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set richdocuments secure_view_option --value='false'
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_s3objectstore_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_s3objectstore_commands.adoc
@@ -6,7 +6,7 @@ Marketplace URL: {oc-marketplace-url}/apps/files_primary_s3[S3 Primary Object St
 
 == List objects, buckets or versions of an object
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} s3:list
 ----
@@ -21,7 +21,7 @@ Marketplace URL: {oc-marketplace-url}/apps/files_primary_s3[S3 Primary Object St
 
 == Create a bucket as necessary to be used
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} s3:create-bucket
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
@@ -22,7 +22,7 @@ xref:enterprise/external_storage/windows-network-drive_configuration.adoc#wnd-no
 
 Listen to smb changes and store notifications for later processing in the database
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen [options] [--] <host> <share> <username> [<password>]
 ----
@@ -78,7 +78,7 @@ Listen to smb changes and store notifications for later processing in the databa
 
 Process the notifications stored by the `wnd:listen` command
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:process-queue [options] [--] <host> <share>
 ----
@@ -107,7 +107,7 @@ NOTE: This command is deprecated starting with ownCloud 10.8. All mount options 
  
 Sets the service account for the target mount point. You'll be asked for the password of the service account.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:set-service-account [options] [--] <mount-id>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_2fa_core_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_2fa_core_commands.adoc
@@ -17,7 +17,7 @@ The following commands are available for the two-factor authentication:
 
 Disable two-factor authentication for a user:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} twofactorauth:disable [options] [--] <uid>
 ----
@@ -34,7 +34,7 @@ Disable two-factor authentication for a user:
 
 Enable two-factor authentication for a user:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} twofactorauth:enable [options] [--] <uid>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
@@ -17,7 +17,7 @@ app
 List all of your installed apps or optionally provide a search pattern to restrict the list of apps to those whose name matches the given regular expression. 
 The output shows whether they are enabled or disabled.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:list [--] [<search-pattern>]
 ----
@@ -59,7 +59,7 @@ When used, the output will contain the app's version number as well.
 
 Enable an app, for example the Market app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable market
 market enabled
@@ -67,7 +67,7 @@ market enabled
 
 == Disable an App
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:disable market
 market disabled
@@ -84,7 +84,7 @@ NOTE: Be aware that the following apps cannot be disabled: _DAV_, _FederatedFile
 
 By default all checks are enabled. The Activity app is an example of a correctly-formatted app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:check-code notifications
 App is compliant - awesome job!
@@ -92,7 +92,7 @@ App is compliant - awesome job!
 
 If your app has issues, you'll see output like this.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:check-code foo_app
 Analysing /var/www/owncloud/apps/files/foo_app.php
@@ -107,7 +107,7 @@ Analysing /var/www/owncloud/apps/files/foo_app.php
 
 You can get the full file path to an app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:getpath notifications
 /var/www/owncloud/apps/notifications

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
@@ -13,7 +13,7 @@ background
 
 == Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 # Set the background scheduler to Ajax
 {occ-command-example-prefix} background:ajax

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
@@ -8,7 +8,7 @@ If not, please refer to the documentation on configuring xref:installation/manua
 
 Apply the xref:installation/manual_installation/manual_installation.adoc#script-guided-installation[correct permissions] to your ownCloud directories. Then choose your `occ` options. This lists your available options:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} occ
 ownCloud is not installed - only a limited number of commands are available
@@ -45,7 +45,7 @@ Available commands:
 
 Display your `maintenance:install` options.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} help maintenance:install
 ownCloud is not installed - only a limited number of commands are available
@@ -110,7 +110,7 @@ sales=
 
 This example completes the installation:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:install \

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_upgrade_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_upgrade_commands.adoc
@@ -5,7 +5,7 @@ List all options, like this example on CentOS Linux:
 
 == Command Description
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade --help
 Usage:
@@ -25,7 +25,7 @@ PHP scripts invoked from the Web interface are limited to 3600 seconds.
 In larger environments this may not be enough, leaving the system in an inconsistent state.
 After performing all the preliminary steps (see xref:maintenance/upgrade.adoc[the maintenance upgrade documentation]) use this command to upgrade your databases, like this example on CentOS Linux:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ownCloud or one of the apps require upgrade - only a limited number of
@@ -42,7 +42,7 @@ Turned off maintenance mode
 
 Note how it details the steps. Enabling verbosity displays timestamps:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade -v
 ownCloud or one of the apps require upgrade - only a limited number of commands are available

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
@@ -64,7 +64,7 @@ These commands manage the configurations of apps. Keys and values are stored in 
 
 == config:app:delete
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete [options] [--] <app> <name>
 ----
@@ -87,7 +87,7 @@ These commands manage the configurations of apps. Keys and values are stored in 
 
 === Examples:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete myappname provisioning_api
 Config value provisioning_api of app myappname deleted
@@ -96,7 +96,7 @@ Config value provisioning_api of app myappname deleted
 The delete command will by default not complain if the configuration was not set before. 
 If you want to be notified in that case, set the `--error-if-not-exists` flag.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete doesnotexist --error-if-not-exists
 Config provisioning_api of app appname could not be deleted because it did not exist
@@ -104,7 +104,7 @@ Config provisioning_api of app appname could not be deleted because it did not e
 
 == config:app:get
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:get [options] [--] <app> <name>
 ----
@@ -128,7 +128,7 @@ the command will exit with 1.
 
 === Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:get activity installed_version
 2.2.1
@@ -136,7 +136,7 @@ the command will exit with 1.
 
 == config:app:set
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set [options] [--] <app> <name>
 ----
@@ -160,7 +160,7 @@ the command will exit with 1.
 
 === Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
    files_sharing \
@@ -172,7 +172,7 @@ Config value incoming_server2server_share_enabled for app files_sharing set to y
 
 The `config:app:set` command creates the value, if it does not already exist. To update an existing value, set `--update-only`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
    doesnotexist \
@@ -191,14 +191,14 @@ The exported content can also be imported again to allow the fast setup of simil
 The import command will only add or update values. 
 Values that exist in the current configuration, but not in the one that is being imported are left untouched.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:import filename.json
 ----
 
 It is also possible to import remote files, by piping the input:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:import < local-backup.json
 ----
@@ -210,7 +210,7 @@ Use the `occ app:enable`, `occ app:disable` and `occ update` commands instead.
 
 The `config:list` command lists all configuration values for your ownCloud setup as well as for any apps.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list [options] [--] [<app>]
 ----
@@ -242,7 +242,7 @@ include::partial$configuration/server/occ_command/config-list-report.json[]
 
 To generate a full report which includes sensitive values, such as passwords and salts, use the `--private` option, as in the following example.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list --private
 ----
@@ -252,7 +252,7 @@ To generate a full report which includes sensitive values, such as passwords and
 The output can be filtered to just the core information, core and apps, or one specific app.
 In the example below, you can see how to filter for each of these categories.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 # List only system configuration details
 {occ-command-example-prefix} config:list -- system
@@ -285,7 +285,7 @@ These commands manage system configurations.
 
 == config:system:delete
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:delete [options] [--] <name> (<name>)...
 ----
@@ -307,7 +307,7 @@ These commands manage system configurations.
 
 === Examples:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:delete maintenance:mode
 System config value maintenance:mode deleted
@@ -315,7 +315,7 @@ System config value maintenance:mode deleted
 
 == config:system:get
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:get [options] [--] <name> (<name>)...
 ----
@@ -338,7 +338,7 @@ the command will exit with 1.
 
 === Examples:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:get version
 10.7.0.4
@@ -346,7 +346,7 @@ the command will exit with 1.
 
 == config:system:set
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set [options] [--] <name> (<name>)...
 ----
@@ -375,7 +375,7 @@ NOTE: In order to write a boolean, float, JSON, or integer value to the configur
 
 Disable the maintenance mode:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set maintenance \
    --value=false \
@@ -387,7 +387,7 @@ System config value maintenance set to boolean false
 
 Create the `app_paths` config setting (using a JSON payload because of multi array values):
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set apps_paths \
       --type=json \
@@ -407,7 +407,7 @@ Create the `app_paths` config setting (using a JSON payload because of multi arr
 
 Adding Redis to the configuration:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set \
    redis \
@@ -420,7 +420,7 @@ System config value redis set to json {"host": "{oc-examples-server-ip}", "port"
 Some configurations (e.g., the trusted domain setting) are an array of data. 
 The array starts counting with 0. In order to set (and also get) the value of one key, you can specify multiple `config` names separated by spaces:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:get trusted_domains
 localhost
@@ -430,7 +430,7 @@ sample.tld
 
 To replace `sample.tld` with `example.com` trusted_domains => 2 needs to be set:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set trusted_domains 2 --value=example.com
 System config value trusted_domains => 2 set to string example.com

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
@@ -5,7 +5,7 @@ This command generates the same JSON-based report as the Admin Config Report, wh
 
 From the command-line in the root directory of your ownCloud installation, run it as your webserver user as follows, (assuming your webserver user is `www-data`):
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} configreport:generate
 ----
@@ -13,14 +13,14 @@ From the command-line in the root directory of your ownCloud installation, run i
 This will generate the report and send it to `STDOUT`. 
 You can optionally pipe the output to a file and then attach it to an email to ownCloud support, by running the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} configreport:generate > generated-config-report.txt
 ----
 
 Alternatively, you could generate the report and email it all in one command, by running:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} configreport:generate | mail \
     -s "configuration report" \

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
@@ -17,7 +17,7 @@ You need:
 
 This is example converts SQLite to MySQL/MariaDB:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} db:convert-type mysql oc_dbuser 127.0.0.1 oc_database
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
@@ -18,7 +18,7 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 
 `dav:cleanup-chunks` cleans up outdated chunks (uploaded files) more than a certain number of days old. By default, the command cleans up chunks more than 2 days old. However, by supplying the number of days to the command, the range can be increased.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:cleanup-chunks [options] [--] [<minimum-age-in-days>]
 ----
@@ -44,7 +44,7 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 
 In the example below, chunks older than 10 days will be removed.
  
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:cleanup-chunks 10
 
@@ -58,7 +58,7 @@ Cleaning chunks for admin
 
 Create a dav address book.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:create-addressbook <user> <name>
 ----
@@ -78,7 +78,7 @@ Create a dav address book.
 
 This example creates the address book `mollybook` for the user molly:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:create-addressbook molly mollybook
 ----
@@ -89,7 +89,7 @@ Molly will immediately see her address book.
 
 Create a dav calendar.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:create-calendar <user> <name>
 ----
@@ -109,7 +109,7 @@ Create a dav calendar.
 
 This example creates a new calendar `mollycal` for user molly:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:create-calendar molly mollycal
 ----
@@ -123,7 +123,7 @@ Molly will immediately see her calendar.
 
 Synchronizes the birthday calendar. It adds all birthdays to your calendar from address books shared with you.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:sync-birthday-calendar [<user>]
 ----
@@ -140,7 +140,7 @@ Synchronizes the birthday calendar. It adds all birthdays to your calendar from 
 
 This example syncs to your calendar from user `bernie`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:sync-birthday-calendar bernie
 ----
@@ -149,7 +149,7 @@ This example syncs to your calendar from user `bernie`:
 
 Synchronizes all users to the system addressbook.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} dav:sync-system-addressbook
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
@@ -41,7 +41,7 @@ encryption
 `occ encryption:status` shows whether you have active encryption and your default encryption module. 
 To enable encryption you must first enable the Encryption app and then run `occ encryption:enable`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
@@ -54,7 +54,7 @@ To enable encryption you must first enable the Encryption app and then run `occ 
 
 Server-side encryption for local storage like the users home and remote storages like Google Drive can operate independently of each other. By doing so, you can encrypt a remote storage without also having to encrypt the users home storage on your ownCloud server. Possible values are `0` and `1`
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 config:app:set encryption encryptHomeStorage --value '1' 
 ----
@@ -65,14 +65,14 @@ config:app:set encryption encryptHomeStorage --value '1'
 It takes one argument, which defines your new root folder. 
 The folder must exist and the path is relative to your data directory.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:change-key-storage-root ../data/security/oc-keys
 ----
 
 You can see the current location of your keys folder:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:show-key-storage-root
 Current key storage root:  default storage location (data/)
@@ -103,7 +103,7 @@ This argument automatically answers, potential, questions with "yes", which is p
 
 `encryption:decrypt-all` decrypts all user data files, or optionally a single user:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:decrypt freda
 ----
@@ -163,7 +163,7 @@ The `-y` switch can be supplied to automate acceptance of user input.
 
 == Fix Encrypted Version
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:fix-encrypted-version [options] [--] <user>
 ----
@@ -199,7 +199,7 @@ Searches in increments from -n to +n. [default: "5"]
 
 === Export or Import the Masterkey
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:hsmdaemon [options]
 ----
@@ -225,7 +225,7 @@ The private key file in the directory may be named like `master_08ea43b7.private
 
 Allows to test the `hsmdaemon` setup by providing an encrypted string to ownCloud and test if it can be decrypted.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:hsmdaemon:decrypt [options] [--] <decrypt>
 ----
@@ -253,7 +253,7 @@ Allows to test the `hsmdaemon` setup by providing an encrypted string to ownClou
 
 Set the url on which the `hsmdaemon` REST-API is reachable.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set encryption hsm.url --value 'http://127.0.0.1:8513'
 ----
@@ -262,7 +262,7 @@ Set the url on which the `hsmdaemon` REST-API is reachable.
 
 To access the `hsmdaemon` API, ownCloud must authenticate with a JWT (JSON Web Token). The given secret is shared between the `hsdmdaemon` (see the hsmdaemon.toml configuration file) and ownCloud to sign the JWT. See the xref:configuration/server/security/hsmdaemon/index.adoc[HSM documentation] for an example how to generate a secret.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set encryption hsm.jwt.secret --value '7a7d1826-b514-4d9f-afc7-a7485084e8de'
 ----
@@ -271,7 +271,7 @@ To access the `hsmdaemon` API, ownCloud must authenticate with a JWT (JSON Web T
 
 The JWT described above has an expiry timestamp. In case the time clocks on ownCloud and hsmdaemon system drift or skew apart, additional time is added to the expiry time to counteract this situation. Set or change the clockskew only if ownCloud advises to do so. Defaults to 120, value is in seconds.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set encryption hsm.jwt.clockskew --value '120' 
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_federation_sync_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_federation_sync_commands.adoc
@@ -5,7 +5,7 @@ Synchronize the address books of all federated ownCloud servers.
 Servers connected with federation shares can share user address books, and auto-complete usernames in share dialogs. 
 Use this command to synchronize federated servers:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} federation:sync-addressbooks
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -33,7 +33,7 @@ As such, the cases where you need to run this command should be extremely rare.
 This is why this command is only provided to check for one file instead of scanning the whole of ownCloud's filesystem.
 ====
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:check-cache --help
  Usage:
@@ -57,14 +57,14 @@ This is why this command is only provided to check for one file instead of scann
 
 Examples of checking files for user maria:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:check-cache maria welcome.txt
 
 welcome.txt has been accessed properly
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:check-cache maria maria@smbhome/myfile.txt
 
@@ -88,7 +88,7 @@ CAUTION: Executing this command might take some time depending on the file count
 
 Below is sample output that you can expect to see when using the command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:checksums:verify
 
@@ -131,7 +131,7 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --help
  Usage:
@@ -183,7 +183,7 @@ For example:
 In the example above, the user_id `alice` is determined implicitly from the path component given.
 To get a list of scannable mounts for a given user, use the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:list user_id
 ----
@@ -215,7 +215,7 @@ The `--repair` option can be run within two different scenarios:
 The following commands show how to enable single user mode, run a repair file scan in bulk on all storages, and then disable single user mode.
 This way is much faster than running the command for every user separately, but it requires single user mode.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} files:scan --all --repair
@@ -224,7 +224,7 @@ This way is much faster than running the command for every user separately, but 
 
 The following command filters by the storage of the specified user.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan USERID --repair
 ----
@@ -241,7 +241,7 @@ If the target users don't exist, they will be created.
 
 This command is useful before removing users.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:transfer-ownership --help
  Usage:
@@ -272,7 +272,7 @@ never logged in and command aborts otherwise.
 
 For example, to move all files from `<source-user>` to `<destination-user>` transfer folder, use the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:transfer-ownership \
     <source-user> \
@@ -282,7 +282,7 @@ For example, to move all files from `<source-user>` to `<destination-user>` tran
 You can also move a limited set of files from `<source-user>` to `<destination-user>` transfer folder by making use of the `--path` switch, as in the example below.
 Ownership of `folder/to/move` and all files and folders which it contains will be transferred to `<destination-user>` transfer folder.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:transfer-ownership \
     --path="folder/to/move" \
@@ -293,7 +293,7 @@ Ownership of `folder/to/move` and all files and folders which it contains will b
 If the entire user folder of `<source-user>` needs to be migrated to `<destination-user>` user folder, use the `--destination-use-user-folder` switch, as in the example below.
 The destination user needs to be created but never log in, we recommend using owncloud maintenance mode for this operation.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:transfer-ownership \
     --destination-use-user-folder \
@@ -319,7 +319,7 @@ For example, transferred shares that may now have an invalid share owner.
 
 NOTE: By default, the command performs a dry run and displays the problems found to the console output.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:troubleshoot-transfer-ownership --help
  Usage:
@@ -344,7 +344,7 @@ NOTE: By default, the command performs a dry run and displays the problems found
 
 Run the command with one of the type arguments:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:troubleshoot-transfer-ownership \
     <all|invalid-owner|invalid-initiator>
@@ -353,7 +353,7 @@ Run the command with one of the type arguments:
 The command can attempt to fix the issues with the `--fix` flag, +
 or execute for a single user using `--uid <uid>`
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:troubleshoot-transfer-ownership all \
     --fix \

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
@@ -58,7 +58,7 @@ files_external:list [--show-password] [--full] [-a|--all] [-s|--short] [--] [<us
 
 === Example
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files_external:list user_1 --short
 +----------+------------------+----------+

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
@@ -39,7 +39,7 @@ A full text search index is created for all users, if this value is omitted.
 
 This example creates a full text search index for the user with user id `testuser`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} search:index:create testuser
 
@@ -50,7 +50,7 @@ Indexing user testuser
 
 This example creates a full text search index for the users with user ids `admin` and `testuser`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} search:index:create admin testuser
 
@@ -143,7 +143,7 @@ The command `search:index:reset` resets (recreates and clears) the full text sea
 
 === Example
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} search:index:reset
 This will delete the whole search index! Do you want to proceed?
@@ -174,7 +174,7 @@ The command `search:index:update` updates the full text search index by running 
 
 This example updates the full text search index for all users.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} search:index:update
 Start Updating the Elastic search index:

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
@@ -27,7 +27,7 @@ group:add groupname
 
 This example adds a new group, called "Finance":
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:add Finance
   Created group "Finance"
@@ -55,7 +55,7 @@ If you do not provide a search-pattern then all groups are listed.
 
 This example lists groups containing the string "finance".
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:list finance
  - All-Finance-Staff
@@ -65,7 +65,7 @@ This example lists groups containing the string "finance".
 
 This example lists groups containing the string "finance" formatted with `json_pretty`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:list --output=json_pretty finance
  [
@@ -93,7 +93,7 @@ group:list-members [options] <group>
 
 This example lists members of the "Finance" group.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:list-members Finance
  - aaron: Aaron Smith
@@ -102,7 +102,7 @@ This example lists members of the "Finance" group.
 
 This example lists members of the Finance group formatted with `json_pretty`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:list-members --output=json_pretty Finance
  {
@@ -123,7 +123,7 @@ group:add-member [-m|--member [MEMBER]] <group>
 
 This example adds members "aaron" and "julie" to group "Finance":
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:add-member --member aaron --member julie Finance
   User "aaron" added to group "Finance"
@@ -134,7 +134,7 @@ You may attempt to add members that are already in the group, without error.
 This allows you to add members in a scripted way without needing to know if the user is already a member of the group. 
 For example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:add-member --member aaron --member julie --member fred Finance
   User "aaron" is already a member of group "Finance"
@@ -153,7 +153,7 @@ group:remove-member [-m|--member [MEMBER]] <group>
 
 This example removes members "aaron" and "julie" from group "Finance".
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:remove-member --member aaron --member julie Finance
   Member "aaron" removed from group "Finance"
@@ -164,7 +164,7 @@ You may attempt to remove members that have already been removed from the group,
 This allows you to remove members in a scripted way without needing to know if the user is still a member of the group. 
 For example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:remove-member --member aaron --member fred Finance
   Member "aaron" could not be found in group "Finance"
@@ -175,7 +175,7 @@ For example:
 
 To delete a group, you use the `group:delete` command, as in the example below:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} group:delete Finance
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_incoming_shares_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_incoming_shares_commands.adoc
@@ -8,7 +8,7 @@ ownCloud and system administrators can use the `incoming-shares:poll` command to
 
 NOTE: The command polls all received federated shares, so does not require a path.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} incoming-shares:poll
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
@@ -15,7 +15,7 @@ integrity
 
 After creating your signing key, sign your app like this example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} integrity:sign-app \
    --privateKey=/Users/karlmay/contacts.key \
@@ -25,7 +25,7 @@ After creating your signing key, sign your app like this example:
 
 Verify your app:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} integrity:check-app --path=/pathto/app appname
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
@@ -40,7 +40,7 @@ $PLURAL_FORMS = "nplurals=2; plural=(n != 1);";
 
 After that, run the following command to create the translation.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} l10n:createjs comments de_AT
 ----
@@ -51,7 +51,7 @@ This will generate two translation files, `de_AT.js` and `de_AT.json`, in `/var/
 
 To create translations in multiple languages simultaneously, supply multiple languages to the command, as in the following example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} l10n:createjs comments de_AT de_DE hu_HU es fr
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
@@ -13,7 +13,7 @@ log
 
 Run `log:owncloud` to see your current logging status:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} log:owncloud
 Log backend ownCloud: enabled
@@ -45,7 +45,7 @@ Options for `log:manage`:
 
 Log level can be adjusted by entering the number or the name:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} log:manage --level 4
 {occ-command-example-prefix} log:manage --level error

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
@@ -18,7 +18,7 @@ maintenance
 Users who are not already logged in cannot log in until maintenance mode is turned off. 
 When you take the server out of maintenance mode logged-in users must refresh their Web browsers to continue working.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 {occ-command-example-prefix} maintenance:mode --off
@@ -27,7 +27,7 @@ When you take the server out of maintenance mode logged-in users must refresh th
 Putting your ownCloud server into single-user mode allows admins to log in and work, but not ordinary users. 
 This is useful for performing maintenance and troubleshooting on a running server.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 Single user mode enabled
@@ -35,7 +35,7 @@ Single user mode enabled
 
 Turn it off when you're finished:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 Single user mode disabled
@@ -88,7 +88,7 @@ a|Increase the verbosity of messages:
 
 Here is an example of running the command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:repair
 ----
@@ -121,7 +121,7 @@ OCA\DAV\Repair\RemoveInvalidShares -> Remove invalid calendar and addressbook sh
 
 To run a single repair step, use either the `-s` or `--single` options, as in the following example.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:repair --single="OCA\DAV\Repair\RemoveInvalidShares"
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
@@ -30,7 +30,7 @@ WARNING: Deleting a job cannot be undone. Be sure that you want to delete the jo
 
 This example deletes queued background job #12.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:delete 12
 
@@ -64,7 +64,7 @@ background:queue:execute [options] [--] <Job ID>
 
 This example executes queued background job #12.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:execute 12
 
@@ -88,7 +88,7 @@ background:queue:status
 
 This example lists the queue status:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:status
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_migration_steps_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_migration_steps_commands.adoc
@@ -2,7 +2,7 @@
 
 You can run migration steps with the `migrations` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} migrations:execute <app> <version>
 ----
@@ -19,7 +19,7 @@ You can run migration steps with the `migrations` command.
 
 This example executes the migration step for the core app:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} migrations:execute core 20181220085457
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_notifications_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_notifications_commands.adoc
@@ -10,7 +10,7 @@ notifications
 
 == Command Description
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} notifications:generate [-u|--user USER] [-g|--group GROUP] [-l|--link <linktext>] [--] <subject> [<message>]
 ----
@@ -40,7 +40,7 @@ At least one user or group must be set.
 A link can be useful for notifications shown in client apps.
 Example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} notifications:generate -g Office "Emergency Alert" "Rebooting in 5min"
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
@@ -21,7 +21,7 @@ security:routes [options]
 
 Example 1:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:routes
 ----
@@ -40,7 +40,7 @@ Example 1:
 
 Example 2:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:routes --output=json-pretty
 ----
@@ -57,7 +57,7 @@ Example 2:
 
 Example 3:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:routes --with-details
 ----
@@ -84,21 +84,21 @@ security:certificates:remove  Remove trusted certificate
 
 This example lists your installed certificates:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:certificates
 ----
 
 Import a new certificate:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:certificates:import /path/to/certificate
 ----
 
 Remove a certificate:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} security:certificates:remove [certificate name]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -13,7 +13,7 @@ As a result, any user(s) who the share was re-shared with will now get an error 
 That's why the command is available.
 So, to cleanup all orphaned remote storages, run it as follows:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} sharing:cleanup-remote-storages
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
@@ -13,7 +13,7 @@ trashbin
 The `trashbin:cleanup` command removes the deleted files of the specified users in a space-delimited list, or all users if none are specified. 
 This example removes all the deleted files of all users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:cleanup
 Remove all deleted files
@@ -27,7 +27,7 @@ Remove deleted files for users on backend Database
 
 This example removes the deleted files of users `molly` and `freda`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} trashbin:cleanup molly freda
 Remove deleted files of   molly

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -31,7 +31,7 @@ user
 
 You can create a new user with the `user:add` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:add \
     [--password-from-env] \
@@ -75,7 +75,7 @@ This example adds new user, Layla Smith, and adds her to the `users` and `db-adm
 If either group does not exist, it is created.
 
 .Create a user with a password, email address, and display name, and add them to two groups
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:add \
   --display-name="Layla Smith" \
@@ -92,7 +92,7 @@ If either group does not exist, it is created.
 ----
 
 .Create a user with a temporary password (the user will receive a link to set their password).
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:add \
   --display-name "Layla Smith" \
@@ -111,7 +111,7 @@ User layla added to group db-admins
 
 To delete a user, you use the `user:delete` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:delete [options] [--] <uid>
 ----
@@ -133,7 +133,7 @@ To delete a user, you use the `user:delete` command.
 | Try to force the deletion of the user data even if the user is missing.
 |===
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:delete fred
 ----
@@ -142,7 +142,7 @@ To delete a user, you use the `user:delete` command.
 
 Admins can disable users via the occ command too:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:disable <uid>
 ----
@@ -159,7 +159,7 @@ NOTE: Once users are disabled, their connected browsers will be disconnected. Us
 
 == Enable Users
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:enable <uid>
 ----
@@ -178,7 +178,7 @@ List all available root directories for user homes that are currently in use. Fo
 
 This command is complementary when using `user:move-home`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-dirs [options]
 ----
@@ -193,7 +193,7 @@ This command is complementary when using `user:move-home`.
 
 === Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-dirs
   - /var/www/owncloud/data
@@ -205,7 +205,7 @@ List all users that have their home in a given path. For details see xref:config
 
 This command is complementary when using `user:move-home`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-users [options] [--] [<path>]
 ----
@@ -233,7 +233,7 @@ This command is complementary when using `user:move-home`.
 
 Note for the example below, some user accounts originated from LDAP.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-users /var/www/owncloud/data
   - admin
@@ -245,7 +245,7 @@ Note for the example below, some user accounts originated from LDAP.
 
 Run the following command to list all users from all available home directories. The example shows, that user `lisa` has been moved to a different home directory with `user:move-home`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-users --all
   - /mnt/newhome_1
@@ -259,7 +259,7 @@ Run the following command to list all users from all available home directories.
 
 To view a list of users who've not logged in for a given number of days, use the `user:inactive` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:inactive [options] [--] <days>
 ----
@@ -282,7 +282,7 @@ To view a list of users who've not logged in for a given number of days, use the
 
 The example below searches for users inactive for five days or more:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:inactive 5
 ----
@@ -320,7 +320,7 @@ Using the output option `json_pretty` will render the output formatted as follow
 
 To view a user's most recent login, use the `user:lastseen` command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:lastseen <uid>
 ----
@@ -335,7 +335,7 @@ To view a user's most recent login, use the `user:lastseen` command:
 
 Example
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:lastseen layla
   layla's last login: 09.01.2015 18:46
@@ -345,7 +345,7 @@ Example
 
 You can list existing users with the `user:list` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list [options] [<search-pattern>]
 ----
@@ -376,7 +376,7 @@ Allowed attributes, multiple values possible: +
 
 This example lists user IDs containing the string `ron`
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list ron
  - aaron: Aaron Smith
@@ -384,7 +384,7 @@ This example lists user IDs containing the string `ron`
 
 The output can be formatted in JSON with the output option `json` or `json_pretty`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list --output=json_pretty
  {
@@ -396,7 +396,7 @@ The output can be formatted in JSON with the output option `json` or `json_prett
 
 This example lists all users including the attribute `enabled`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list -a enabled
  - admin: true
@@ -407,7 +407,7 @@ This example lists all users including the attribute `enabled`.
 
 You can list the group membership of a user with the `user:list-groups` command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list-groups [options] [--] <uid>
 ----
@@ -432,7 +432,7 @@ You can list the group membership of a user with the `user:list-groups` command.
 
 This example lists group membership of user `julie`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list-groups julie
  - Executive
@@ -441,7 +441,7 @@ This example lists group membership of user `julie`:
 
 The output can be formatted in JSON with the output option `json` or `json_pretty`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list-groups --output=json_pretty julie
  [
@@ -454,7 +454,7 @@ The output can be formatted in JSON with the output option `json` or `json_prett
 
 This command modifies either the users username or email address.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:modify [options] [--] <uid> <key> <value>
 ----
@@ -475,7 +475,7 @@ This command modifies either the users username or email address.
 
 All three arguments are mandatory and can not be empty. Example to set the email address:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:modify carla email foobar@foo.com
 ----
@@ -486,7 +486,7 @@ The email address of `carla` is updated to `foobar@foo.com`.
 
 This command moves a user's home folder to a new location. For details see xref:configuration/user/user_management.adoc#moving-the-user-home[Moving the User Home] documentation. Note that moving a users home is only possible for POSIX file systems. Also see the `user:home` commands for additional support.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:move-home <user_id> <new_location>
 ----
@@ -512,7 +512,7 @@ You must not use temp directories like `/tmp` and `/var/tmp` as target directory
 
 Example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:move-home lisa /mnt/newhome_1
 ----
@@ -524,14 +524,14 @@ This command moves the home directory of user `lisa` to the new location `/mnt/n
 Generate a simple report that counts all users including users on external user authentication servers such as LDAP,
 and guest users which are created by the guests app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:report
 ----
 
 There are no arguments and no options beside the default once to parametrize the output.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:report
 +--------------------------+-----+
@@ -554,7 +554,7 @@ NOTE: A user directory is created, when a local user has logged on the first tim
 
 Resets the password of the named user.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:resetpassword [options] [--] <user>
 ----
@@ -605,7 +605,7 @@ User "fred" added to group "users"
 
 You can reset any user's password, including administrators (see xref:configuration/user/reset_admin_password.adoc[Reset Admin Password]):
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:resetpassword layla
   Enter a new password:
@@ -626,7 +626,7 @@ Successfully reset password for layla
 This example emails a password reset link to the user.
 Additionally, when the command completes, it outputs the password reset link to the console:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:resetpassword \
   --send-email \
@@ -650,7 +650,7 @@ To manage application settings for a user, use the `user:setting` command. This 
 * Set a setting value
 * Delete a setting
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting [options] [--] <uid> [[<app> [<key>]]
 ----
@@ -716,7 +716,7 @@ A complete list cannot be supplied as it is impossible to know the entire list o
 
 To retrieve settings for a user, you need to call the `user:setting` command and supply at least the user's user name. You can drill down restricting results to a particular app and a key in the app.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting <uid> [<app>] [<key>]
 ----
@@ -739,7 +739,7 @@ To retrieve settings for a user, you need to call the `user:setting` command and
 
 . Retrieve all settings set for a given user:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla
   - core:
@@ -754,7 +754,7 @@ Here we see that the user has settings for the application `core`, when they las
 
 . Retrieve all settings set restricted to application `core` for a given user:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla core
  - core:
@@ -765,7 +765,7 @@ In the output, you can see that one setting is in effect, `lang`, which is set t
 
 . Retrieve all settings set restricted to application `core`, key `lang` for a given user
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla core lang
 ----
@@ -774,7 +774,7 @@ This will display the value for that setting, such as `en`.
 
 === Setting and Deleting a Setting
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting [options] [--] <uid> [<app>] [<key>]
 ----
@@ -783,7 +783,7 @@ IMPORTANT: In case you want to change the email address, use xref:modify-user-de
 
 Here's an example of how you would set the language of the user `layla`.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla core lang --value=en
 ----
@@ -792,7 +792,7 @@ Deleting a setting is quite similar to setting a setting.
 In this case, you supply the username, application (or setting category) and key as above. 
 Then, in addition, you supply the `--delete` flag.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:setting layla core lang --delete
 ----
@@ -864,14 +864,14 @@ and _Shibboleth_ backend.
 
 === LDAP
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
 ----
 
 === Samba
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User\SMB" -vvv
 ----
@@ -880,7 +880,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 1
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -896,7 +896,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 2
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -916,7 +916,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 3
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -937,7 +937,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 4
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m disable -r
   Analysing all users ...
@@ -956,7 +956,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 5
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy" -m remove
 
@@ -964,7 +964,7 @@ Below are examples of how to use the command with the *LDAP* backend along with 
 
 === Example 6
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:sync "OCA\User_LDAP\User_Proxy"
 If unknown users are found, what do you want to do with their accounts? (removing the account will also remove its data)

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_versions_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_versions_commands.adoc
@@ -8,7 +8,7 @@ These commands are not available in xref:maintenance-commands[single-user (maint
 `versions:cleanup` can delete all versioned files, as well as the
 `files_versions` folder, for either specific users, or for all users.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:cleanup [<user_id>]...
 ----
@@ -22,7 +22,7 @@ Options
 
 The example below deletes all versioned files for all users:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:cleanup
 Delete all versions
@@ -36,7 +36,7 @@ Delete versions for users on backend Database
 
 You can delete versions for specific users in a space-delimited list:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:cleanup freda molly
 Delete versions of   freda
@@ -48,7 +48,7 @@ Delete versions of   molly
 `versions:expire` deletes only expired files according to the `versions_retention_obligation` setting in `config.php` (see the File versions section in config_sample_php_parameters). 
 The default is to delete expired files for all users, or you may list users in a space-delimited list.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} versions:expire [<user_id>]...
 ----

--- a/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/reverse_proxy_configuration.adoc
@@ -62,6 +62,7 @@ the IP address `10.0.0.1` you can set the following parameters inside the config
 
 With an Apache as reverse proxy (ssl-proxy.tld) you can use this configuration:
 
+[source,apache]
 ----
 ProxyPass "/domain.tld/owncloud" "http://domain.tld/owncloud"
 ProxyPassReverse "/domain.tld/owncloud" "http://domain.tld/owncloud"

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -78,7 +78,7 @@ At least one PKCS11 library is necessary. This is typically provided by an HSM v
 
 Now we can initialize the token:
 
-[source,console]
+[source,bash]
 ----
 sudo softhsm2-util --init-token --slot 0 --label "My token 1"
 ----
@@ -97,7 +97,7 @@ To use the PKCS11 API on the CLI, we need to install {opensc-wiki-url}[OpenSC].
 
 To install OpenSC on Debian and Ubuntu, run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install -y opensc
 ----
@@ -115,7 +115,7 @@ sudo zypper install -y --auto-agree-with-licenses opensc
 
 To install OpenSC on Fedora and Red Hat Enterprise Linux and Centos, run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo yum install --assumeyes opensc
 ----
@@ -124,7 +124,7 @@ sudo yum install --assumeyes opensc
 
 You can list available tokens using the {pkcs11-tool-url}[pkcs11-tool] by running the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo pkcs11-tool --module </path/to/libsofthsm2.so> -l --pin <user-pin> -O
 ----
@@ -166,7 +166,7 @@ Installing hsmdaemon requires several steps. These are:
 
 After you have obtained the `hsmdaemon` from ownCloud, you need to move the `hsmdaemon` binary to a directory located in your system path and make the binary executable:
 
-[source,console]
+[source,bash]
 ----
 sudo install -m 755 ./hsmdaemon /usr/local/bin/hsmdaemon
 ----
@@ -175,13 +175,15 @@ sudo install -m 755 ./hsmdaemon /usr/local/bin/hsmdaemon
 
 The default location where `hsmdaemon` looks for its config file is `/etc/hsmdaemon/hsmdaemon.toml`. To create it from the example config file available in the provided package, run the following commands:
 
-[source,console]
+Create the hsmdaemon configuration directory:
+[source,bash]
 ----
-# Create the hsmdaemon configuration directory
 sudo mkdir /etc/hsmdaemon
+----
 
-# Copy the example config file
-# Allow only root and users in the root group to read & write the configuration file
+Copy the example config file, allow only root and users in the root group to read & write the configuration file:
+[source,bash]
+----
 sudo install -m 640 ./hsmdaemon.toml /etc/hsmdaemon/hsmdaemon.toml
 ----
 
@@ -189,7 +191,7 @@ sudo install -m 640 ./hsmdaemon.toml /etc/hsmdaemon/hsmdaemon.toml
 
 Now that the binary is available and the configuration file is in place, `hsmdaemon` must be installed as a system service. To do so, run it with the `install` option as in the example below.
 
-[source,console]
+[source,bash]
 ----
 sudo /usr/local/bin/hsmdaemon install
 sudo service hsmdaemon start
@@ -226,7 +228,7 @@ module = "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"
 
 This command lists the available slots.
 
-[source,console]
+[source,bash]
 ----
 sudo hsmdaemon listslots
 
@@ -276,6 +278,7 @@ TIP: See the {opensc-wiki-url}[OpenSC Wiki] for more information.
 
 Define which slot to use and if a PIN is needed. Update `/etc/hsmdaemon/hsmdaemon.toml` with the information gathered in the `pkcs11` section as in the example below.
 
+[source.toml]
 ----
 [pkcs11]
 # softhsm v2
@@ -298,7 +301,7 @@ If no PIN is supplied, generating a new key might be protected by an operator ca
 
 For testing the key generation, run the following example command:
 
-[source,console]
+[source,bash]
 ----
 sudo hsmdaemon genkey test
 
@@ -319,7 +322,7 @@ jwIDAQAB
 
 To show an existing key, use the `hsmdaemon showkey` command with the key's id as in the following example.
 
-[source,console]
+[source,bash]
 ----
 sudo hsmdaemon showkey 9bac3719-2b8d-11e9-aeab-0242b5ece4c3
 ----
@@ -328,11 +331,9 @@ sudo hsmdaemon showkey 9bac3719-2b8d-11e9-aeab-0242b5ece4c3
 
 For testing data encryption, run the following example commands:
 
-[source,console]
+The first argument is the `Id:` value from running the genkey command above. The second is the `base64-encoded data` to be encrypted.
+[source,bash]
 ----
-# The first argument is the `Id:` value from running the genkey command above.
-# The second is the `base64-encoded data` to be encrypted.
-
 sudo hsmdaemon encrypt 9bac3719-2b8d-11e9-aeab-0242b5ece4c3 Zm9vYmFy
 ----
 
@@ -351,7 +352,7 @@ WcezVb2N6bF8wlDooKZcmFn3tZgoIpoFGx6wQetx9sp1nK7JW2Y4OKt7P+0VKKlFO7yXaffVDD2Q6jZZ
 
 For testing data decryption, run the following example commands:
 
-[source,console]
+[source,bash]
 ----
 sudo grep "generated keypair" /var/log/hsm.log
 ----
@@ -365,7 +366,7 @@ You should see output similar to the example below:
 {"level":"debug","ts":"2021-06-19T03:10:03.710+0200","msg":"generated keypair","tokenID":"13cd3f95-d09b-11eb-83c8-960000c05f34"}
 ----
 
-[source,console]
+[source,bash]
 ----
 key_id=$(sudo grep "generated keypair" /var/log/hsm.log | head -1 | jq .tokenID -r)
 
@@ -376,7 +377,7 @@ echo "$hello" | base64
 SGVsbG8sIHdvcmxkIQo=
 ----
 
-[source,console]
+[source,bash]
 ----
 test_enc=$(sudo ./hsmdaemon encrypt $key_id $(echo "$hello" | base64) | tee /dev/stderr)
 ----
@@ -386,14 +387,14 @@ test_enc=$(sudo ./hsmdaemon encrypt $key_id $(echo "$hello" | base64) | tee /dev
 ep6Y1aAVAYpAesZ1+sQzzUepjO82o34kjmm63Drmz+6KED4oIBARQkXeW/OoxgUg6kQhQK1thA/3Ww33aaRxIESzVQF598qjXhhEXQ/OGL6BC+3tPclC7ujUZaA7CG1NDkMneLFDd2+Tbax4OM+/w0zhfTMPgT0I1NrH/03owVglbWHjgLZmN/vxpPZKm/lyAV9tI2HW36UjVLEMD2qtPFXqjLU4YjZOVnMdETxQNSCWIVauFw0+VQQ/RiAqiXzRXEgO6YKxOBk0n9IMT6XEH4MkMQTgb9pB12jrNSa9aMHbCvCneEmhd0CHBxPX499EkxxwtoEnXe6PATXsOg3VRA==
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix}  encryption:hsmdaemon:decrypt --keyId $key_id "$test_enc"
 
 decrypted string (base64 encoded): 'SGVsbG8sIHdvcmxkIQo='
 ----
 
-[source,console]
+[source,bash]
 ----
 sudo tail -5 /var/log/hsm.log
 ----
@@ -427,7 +428,7 @@ For more options see the self-documented default config file `hsmdaemon.toml`.
 ====
 During ownCloud config, you might want to run the hsmdaemon service in the foreground to see what is going on. You can do so using the following command (which also shows example console output, formatted for readability):
 
-[source,console]
+[source,bash]
 ----
 sudo hsmdaemon
 
@@ -461,7 +462,7 @@ Configuring ownCloud to work with the `hsmdaemon` requires the following steps:
 
 Generate a shared secret to use for the `hsmdaemon`.
 
-[source,console]
+[source,bash]
 ----
 cat /proc/sys/kernel/random/uuid
 
@@ -470,6 +471,7 @@ cat /proc/sys/kernel/random/uuid
 
 Use this generated secret for hsmdaemon in `/etc/hsmdaemon/hsmdaemon.toml`
 
+[source,toml]
 ----
 [jwt]
 secret = "7a7d1826-b514-4d9f-afc7-a7485084e8de"
@@ -477,14 +479,14 @@ secret = "7a7d1826-b514-4d9f-afc7-a7485084e8de"
 
 Set the generated secret for ownCloud:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set encryption hsm.jwt.secret --value '7a7d1826-b514-4d9f-afc7-a7485084e8de'
 ----
 
 If the command succeeds, you should see the following console output:
 
-[source,console]
+[source]
 ----
 Config value hsm.jwt.secret for app encryption set to 7a7d1826-b514-4d9f-afc7-a7485084e8de
 ----
@@ -493,7 +495,7 @@ Config value hsm.jwt.secret for app encryption set to 7a7d1826-b514-4d9f-afc7-a7
 
 Enable the HSM mode and enable encryption by running the commands in the following example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} config:app:set encryption hsm.url --value 'http://localhost:8513'
@@ -503,7 +505,7 @@ Enable the HSM mode and enable encryption by running the commands in the followi
 
 If the commands are successful, you should see the following console output:
 
-[source,console]
+[source,bash]
 ----
 encryption enabled
 

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -30,7 +30,7 @@ NOTE: Installing these two packages also installs `/usr/lib/x86_64-linux-gnu/sof
 
 To install SoftHSM2 on either Debian or Ubuntu, run the command below.
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get update
 sudo apt-get install -y softhsm2 libsofthsm2
@@ -41,7 +41,7 @@ sudo apt-get install -y softhsm2 libsofthsm2
 To install SoftHSM2, you first have to ensure that you have {opensuse-security-repositories-url}[the official security repository] for your server enabled in your server's repositories list. 
 To check if it is, run the command `zypper lr`, which will show you output similar to the following:
 
-[source,console]
+[source,text]
 ----
 #  | Alias                     | Name                                    | Enabled | GPG Check | Refresh
 ---+---------------------------+-----------------------------------------+---------+-----------+--------
@@ -63,7 +63,7 @@ TIP: Use the `-d` flag to show the URI for each repository as well.
 
 If there is no security repository listed, then add it using the following command for openSUSE Leap 15.3:
 
-[source,console]
+[source,bash]
 ----
 sudo zypper addrepo \
   --check \
@@ -75,7 +75,7 @@ sudo zypper addrepo \
 
 Running `zypper lr` again should now display an additional line:
 
-[source,console]
+[source,bash]
 ----
 13 | security                 | openSUSE-Leap-15.3-Security             | Yes     | (r ) Yes  | No
 ----
@@ -84,7 +84,7 @@ For different Leap versions, SUSE Linux Enterprise or openSUSE Tumbleweed, chang
 
 With the repository enabled, install SoftHSM2 by running the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo zypper install -y --auto-agree-with-licenses softhsm
 ----
@@ -93,7 +93,7 @@ sudo zypper install -y --auto-agree-with-licenses softhsm
 
 To install SoftHSM2 on Fedora and Red Hat Enterprise Linux and Centos, run the command below.
 
-[source,console]
+[source,bash]
 ----
 sudo yum install --assumeyes softhsm
 ----

--- a/modules/admin_manual/pages/configuration/server/thirdparty_php_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/thirdparty_php_configuration.adoc
@@ -16,6 +16,7 @@ folder, starting at the ownCloud web root.
 
 An example of what these parameters might look like is as follows:
 
+[source,php]
 ----
 <?php
 

--- a/modules/admin_manual/pages/configuration/server/ui-configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/ui-configuration.adoc
@@ -17,21 +17,21 @@ image:configuration/server/ui-configuration/upload-progress-bar.png[Upload Progr
 
 This progress bar can be hidden with the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files hide_upload_estimation --value="yes"
 ----
 
 To show the progress bar again, type one of the following commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files hide_upload_estimation --value="no"
 ----
 
 or
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete files hide_upload_estimation
 ----

--- a/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
+++ b/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
@@ -56,19 +56,18 @@ NOTE: Scanner exit status rules are used to handle errors when ClamAV is run in 
 
 Install ClamAV on Ubuntu with the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install clamav clamav-daemon
 ----
 
 This automatically creates the default configuration files and launches the `clamd` and `freshclam` daemons.
 
-
 ==== Enabling and Running ClamAV
 
 Enable and start the `clamd` service with following commands.
 
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 sudo systemctl enable clamav-daemon.service
@@ -88,14 +87,14 @@ Executing: /lib/systemd/systemd-sysv-install enable clamav-daemon
 
 . You can manually start the updating process with this command:
 +
-[source,console]
+[source,bash]
 ----
 sudo freshclam
 ----
 +
 You should update manually at least once before using ClamAV within ownCloud. The initial update can take several minutes. In case of persisting issues running `freshclam`, you can gently end the process with the following command:
 +
-[source,console]
+[source,bash]
 ----
 sudo pkill -15 -x freshclam
 ----
@@ -104,7 +103,7 @@ and retry manually updating again.
 
 . To automate the update process, run this cron entry for example.
 +
-[source,console]
+[source,bash]
 ----
 # m   h  dom mon dow  command
 47  *  *  *  *  /usr/bin/freshclam --quiet
@@ -120,7 +119,7 @@ image:apps/files_antivirus/antivirus-app.png[image, width=70%]
 
 To install the App directly via the occ command, execute:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install files_antivirus
 ----

--- a/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_admin_password.adoc
@@ -14,7 +14,7 @@ example `/var/www/owncloud/occ`. `occ` has a command for resetting all
 user passwords, `user:resetpassword`. It is best to run `occ` as the
 HTTP user, as in this example on Ubuntu Linux:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 $ {occ-command-example-prefix} /var/www/owncloud/occ user:resetpassword admin
 Enter a new password:

--- a/modules/admin_manual/pages/configuration/user/reset_user_password.adoc
+++ b/modules/admin_manual/pages/configuration/user/reset_user_password.adoc
@@ -8,6 +8,7 @@ will not work. In this case you may specify a custom URL in your
 `config.php` file to direct your user to a server than can handle an
 automatic reset:
 
+[source,php]
 ----
 'lost_password_link' => 'https://example.org/link/to/password/reset',
 ----

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -226,7 +226,7 @@ LDAP Email Address::
 ====
 Disallowing login with LDAP Email Address requires enabling strict login checking to be effective:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set --type boolean --value true strict_login_enforced
 ----
@@ -556,7 +556,7 @@ If it isn't available for a user, then that user will not be able to login.
 Also, the filesystem will not be set up for that user, so their file shares will not be available to other users. 
 For older versions you may enforce the home folder rule with the `occ` command, like this example on Ubuntu:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set user_ldap enforce_home_folder_naming_rule --value=1
 ----
@@ -679,7 +679,7 @@ New LDAP logins can attempt to reuse _existing_ user and group accounts if:
 To enable this functionality, the `reuse_accounts` config setting must be set to `yes`.
 To enable it, run the following command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ....
 {occ-command-example-prefix} config:app:set user_ldap reuse_accounts --value=yes
 ....
@@ -715,6 +715,7 @@ look for **verify return:1**
 
 Try an ldapsearch query
 
+[source,bash]
 ----
 ldapsearch \
 -H ldaps://ad16.oc.local:636 \

--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -206,6 +206,7 @@ experimental, and may not work as expected. The default is to not count
 external storage as part of user storage quotas. If you prefer to
 include it, then change the default `false` to `true`.:
 
+[source,php]
 ----
 'quota_include_external_storage' => false,
 ----
@@ -259,7 +260,7 @@ For details of the occ user commands used below, see the xref:configuration/serv
 
 . To report a users home, use the following command:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list lisa -a home
   - lisa: /var/www/owncloud/data/lisa
@@ -279,7 +280,7 @@ Use the OS methods to create one or more new mount points for users home directo
 * The target folder *can contain* other user folders.
 ====
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:move-home lisa /mnt/newhome_1
 ----
@@ -298,7 +299,7 @@ NOTE: If you are using LDAP and the xref:enterprise/external_storage/ldap_home_c
 
 . To check the user's new home, use the following command:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:list lisa -a home
   - lisa: /mnt/newhome_1/lisa
@@ -310,7 +311,7 @@ Here you can see that the home of user `lisa` is now located in `/mnt/newhome_1/
 +
 The following command lists all available user homes. Note a home only gets listed, if it contains at least one user.
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-dirs
   - /var/www/owncloud/data
@@ -320,10 +321,9 @@ The following command lists all available user homes. Note a home only gets list
 . To list all users from a users home root directory, use the following command:
 +
 The following command lists all users from a given home.
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:home:list-users /var/www/owncloud/data
   - admin
   - user01
 ----
-

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -257,14 +257,14 @@ NOTE: You can increase the command's verbosity by using `-vvv`. Doing so display
 
 The simplest way, useful for initial testing is, to start the `wnd:listen` process manually, as follows:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ----
 
 The password is an optional parameter and you will be asked for it if you didn't provide it as in the example above. In order to start `wnd:listen` without any user interaction like as service, provide the password from a password file.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
      --password-file=/my/secret/password/file \
@@ -287,7 +287,7 @@ the verbosity by calling `wnd:process-queue -vvv`.
 
 As a simple example, you can check the following:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:process-queue <host> <share>
 ----
@@ -311,14 +311,14 @@ Create a service for `systemd` following the instructions below that checks for 
 ** Place one copy of a file with the content from below under `/etc/systemd/system/owncloud-wnd-listen-SERVER-SHARE.service` +
 To do so, enter following command and replace <name> with `owncloud-wnd-listen-SERVER-SHARE`:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl edit <name>.service
 ----
 +
 Reload the deamon to make it available:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 ----
@@ -331,7 +331,7 @@ the account. This way, only root and the Apache user should have access to the p
 
 * Content template for `owncloud-wnd-listen-SERVER-SHARE`
 +
-[source,console]
+[source,text]
 ----
 [Unit]
 Description=ownCloud WND Listener for SERVER SHARE
@@ -356,7 +356,7 @@ WantedBy=multi-user.target
 
 * Run the following command, once for each created file:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 sudo systemctl enable owncloud-wnd-listen-SERVER-SHARE.service
@@ -365,14 +365,14 @@ sudo systemctl start  owncloud-wnd-listen-SERVER-SHARE.service
 
 * To list all systemd wnd listeners for ownCloud run the following command, assuming you use the naming convention described above:
 +
-[source,console]
+[source,bash]
 ----
 systemctl list-units | grep owncloud-wnd-listen
 ----
 
 * Please re-run the following commands if you are changing the contents of a particular listener service:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 sudo systemctl restart owncloud-wnd-listen-SERVER-SHARE.service
@@ -388,7 +388,7 @@ NOTE: The commands must be **strictly sequential**. This can be done by using `f
 
 * Make a `crontab` entry to run a script iterating over all `SERVER SHARE` pairs with an appropriate `occ wnd:process-queue` command.
 +
-[source,console]
+[source,bash]
 ----
 * * * * *  sudo -u www-data /usr/bin/php /var/www/owncloud/occ wnd:process-queue <HOST> <SHARE>
 ----
@@ -405,7 +405,7 @@ use {anacron-examples}[Anacron], which seems to have an option for this scenario
 If you need to serialize the execution of the `wnd:process-queue`, check the following example with
 {shell-flock-intro}[flock]
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 flock -n /opt/my-lock-file {occ-command-example-prefix} wnd:process-queue <host> <share>
 ----
@@ -419,7 +419,7 @@ The lock file `/opt/my-lock-file` itself will be created as an empty file by the
 
 You can use flock also in cron, see the example below:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 * * * * *  flock -n /opt/my-lock-file -c 'sudo -u www-data /usr/bin/php /var/www/owncloud/occ wnd:process-queue <HOST> <SHARE>'
 ----
@@ -539,7 +539,7 @@ smbclient -U Username -L //Servername
 
 Take the example of attempting to connect to the host MyHost, the share named `MyData` using `occ wnd:listen` replacing user and password accordingly. Running the following command would work:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen MyHost MyData user password
 ----
@@ -553,6 +553,7 @@ need to set up the `HOME` variable in Apache to prevent a segmentation fault. If
 `libsmbclient 4.1.6` and higher, it doesn't seem to be an issue, so you won't have to change your `HOME`
 variable. To set up the `HOME` variable on Ubuntu, modify the `/etc/apache2/envvars` file:
 
+[source,bash]
 ----
 unset HOME
 export HOME=/var/www
@@ -561,6 +562,7 @@ export HOME=/var/www
 In Red Hat/CentOS, modify the `/etc/sysconfig/httpd` file and add the following line to set the HOME
 variable in Apache:
 
+[source,bash]
 ----
 export HOME=/usr/share/httpd
 ----
@@ -569,7 +571,7 @@ By default, CentOS has activated SELinux, and the `httpd` process can not make o
 This will cause problems with the `curl`, `ldap` and `samba` libraries.  You'll need to get around this
 to make this work. First, check the status:
 
-[source,console]
+[source,bash]
 ----
 getsebool -a | grep httpd
 httpd_can_network_connect --> off
@@ -577,14 +579,14 @@ httpd_can_network_connect --> off
 
 Then enable support for network connections:
 
-[source,console]
+[source,bash]
 ----
 setsebool -P httpd_can_network_connect 1
 ----
 
 In openSUSE, modify the `/usr/sbin/start_apache2` file:
 
-[source,console]
+[source,bash]
 ----
 export HOME=/var/lib/apache2
 ----
@@ -630,13 +632,13 @@ There are several ways to supply a password:
 
 . Interactively in response to a password prompt.
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username>
 ----
 . Sent as a parameter to the command.
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password>
 ----
@@ -645,13 +647,13 @@ password must be in plain text inside the file, and neither spaces nor newline c
 from the file by default, unless the `--password-trim` option is added. The password file must be readable
 by the apache user (or www-data)
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
      --password-file=/my/secret/password/file
 ----
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username> \
      --password-file=/my/secret/password/file \
@@ -686,7 +688,7 @@ Third party password managers or processes can be integrated. The only requireme
 
 This provides a bit more security because the `/tmp/plainpass` password as shown below should be owned by root and only root should be able to read the file (0400 permissions); Apache, particularly, shouldn't be able to read it. It's expected that root will be the one to run this command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cat /tmp/plainpass | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -695,7 +697,7 @@ cat /tmp/plainpass | {occ-command-example-prefix} wnd:listen <host> <share> <use
 
 Similar to plainpass, the content in this case gets encoded in the {base64-url}[Base64 format]. There's not much security, but it has additional obfuscation.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 base64 -d /tmp/encodedpass | \
    {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
@@ -707,7 +709,7 @@ Example using "pass"
 
 * You can go through {pass-url}[manage passwords from the command line] to set up the keyring for whoever will fetch the password (probably root) and then use something like the following:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 pass the-password-name | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -716,7 +718,7 @@ pass the-password-name | {occ-command-example-prefix} wnd:listen <host> <share> 
 
 This example uses {vaultproject-url}[Vault] as the secrets store. See {hashicorp-url}[HCP Vault] on how to setup the secrets store. Then use something like the following:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 vault kv get -field=password secret/samba | {occ-command-example-prefix} wnd:listen <host> <share> <username> --password-file=-
 ----
@@ -726,7 +728,7 @@ Use Vault's ACLs to limit access to the token. Destroy the token after starting 
 === Password Option Precedence
 
 If both the argument and the option are passed, e.g.,
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen <host> <share> <username> <password> --password-file=/opt/pass`
 ----
@@ -842,7 +844,7 @@ location for all the server. We might need to provide a specific serializer for 
 
 === Basic Command Execution Examples
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen host share username password
 
@@ -861,14 +863,14 @@ location for all the server. We might need to provide a specific serializer for 
 
 To set it up, make sure the listener is running as a system service:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen host share username password
 ----
 
 Setup a Cron job or similar with something like the following two commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:process-queue host share -c 500 \
      --serializer-type file \

--- a/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
@@ -21,12 +21,12 @@ WebUI::
 * Post installing enable it via menu:Settings[Admin > Apps].
 
 Command line::
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install windows_network_drive
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable windows_network_drive
 ----
@@ -76,14 +76,14 @@ Create a service for systemd following the instructions below that checks the sh
 ** Place one copy of a file with the content from below under `/etc/systemd/system/owncloud-wnd-listen-SERVER-SHARE.service` +
 To do so, enter the following command and replace <name> with `owncloud-wnd-listen-SERVER-SHARE`:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl edit <name>.service
 ----
 +
 Reload the deamon to make it available:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 ----
@@ -96,7 +96,7 @@ the account. This way, only root and the Apache user should have access to the p
 
 * Content template for `owncloud-wnd-listen-SERVER-SHARE`
 +
-[source,console]
+[source,text]
 ----
 [Unit]
 Description=ownCloud WND Listener for SERVER SHARE
@@ -121,7 +121,7 @@ WantedBy=multi-user.target
 
 * Run the following command, once for each created file:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl enable owncloud-wnd-listen-SERVER-SHARE.service
 sudo systemctl start  owncloud-wnd-listen-SERVER-SHARE.service
@@ -135,7 +135,7 @@ Create or add a `crontab` file in `/etc/cron.d/oc-wnd-process-queue`.
   appropriate `occ wnd:process-queue` command. The commands must be **strictly sequential**. 
   This can be done by using `flock -n` and tuning the `-c` parameter of `occ wnd:process-queue`
 
-[source,console]
+[source,bash]
 ----
 * * * * *  sudo -u www-data /usr/bin/php /var/www/owncloud/occ wnd:process-queue <HOST> <SHARE>
 ----
@@ -151,6 +151,7 @@ use Anacron, which seems to have an option for this scenario, or wrap the comman
 
 If you need to serialize the execution of the wnd:process-queue, check the following example with flock
 
+[source,bash]
 ----
 * * * * * flock -n /tmp/wnd001 occ wnd:process-queue server1 share1
 * * * * * flock -n /tmp/wnd002 occ wnd:process-queue server1 share2
@@ -167,7 +168,7 @@ If you encounter issues using Windows network drive, then try the following trou
 Check the connection to the share by using smbclient on the command line of the ownCloud server.
 Here is an example:
 
-[source,console]
+[source,bash]
 ----
 smbclient -U Username -L //Servername
 ----
@@ -175,7 +176,7 @@ smbclient -U Username -L //Servername
 Take the example of attempting to connect to the share named MyData using occ wnd:listen.
 Running the following command would work:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} wnd:listen MyHost MyData svc_owncloud password
 ----

--- a/modules/admin_manual/pages/enterprise/file_management/files_lifecycle.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_lifecycle.adoc
@@ -51,7 +51,7 @@ TIP: You only have to conduct this process once when setting up File Lifecycle M
 
 Example to set missing upload time values to November, 1st 2019: 
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:set-upload-time 2019-11-01
 ----
@@ -78,7 +78,7 @@ Example to set the time passed since upload (or restore) for archiving files to 
 ----
 
 To query existing values, use this example command:
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:get files_lifecycle archive_period
 ----
@@ -90,7 +90,7 @@ To query existing values, use this example command:
 The _soft policy_ aims at use cases where users should be allowed to restore files from the archive in self-service if they are still needed. It imposes a soft archiving enforcement but on the other hand relieves IT departments when archived files need to be restored.
 The _soft policy_ is used by default. To switch from the hard policy to the soft policy, use this _occ_ command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle policy --value='soft'
 ----
@@ -103,7 +103,7 @@ TIP: When the _hard policy_ is in place only administrators (or also group admin
 
 To put the _hard policy_ in place, use this _occ_ command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle policy --value='hard'
 ----
@@ -115,7 +115,7 @@ To put File Lifecycle Management into actual operation, there are two _occ_ comm
 ==== Archiving Background Job
 To move files scheduled for archiving (days since upload/restore > `archive_time`) into the archive, execute the following _occ_ command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:archive
 ----
@@ -125,7 +125,7 @@ TIP: There is a dry-run mode (append `-d`) that simulates the execution of this 
 ==== Archive Expiration Background Job
 To permanently delete files from the archive that have met the policy rules (days since archiving > `expire_period`), execute the following _occ_ command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:expire
 ----
@@ -143,7 +143,7 @@ Apart from that, system administrators can restore files from the archive using 
 ==== Restoration by Path
 When a user `alice` requests to restore all files, e.g., in the folder `/work/projects/project1`, a system administrator can execute the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:restore /alice/archive/files/work/projects/project1
 ----
@@ -151,7 +151,7 @@ When a user `alice` requests to restore all files, e.g., in the folder `/work/pr
 ==== Restoring All Files from All Archives
 File Lifecycle Management provides a way to restore all files from all archives back to their owners' file directories. To do this, system administrators can use the `restore-all` _occ_ command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} lifecycle:restore-all
 ----
@@ -164,14 +164,14 @@ TIP: There is a dry-run mode (append `-d`) that simulates the execution of this 
 
 In some scenarios it can be desired to disable the whole user interface for this app. This can be done by setting the following configuration value:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_lifecycle disable_ui --value='yes'
 ----
 
 To enable the user interface components again, this config value needs to be removed:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:delete files_lifecycle disable_ui
 ----

--- a/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -132,6 +132,7 @@ Now you just need to add the tag to the folder or file, and then block the tag w
 
 Block by System Tag:
 
+[source,text]
 ----
 System file tag:   is       "Confidential"
 IP Range (IPv4):   is not   "192.168.1.0/24"

--- a/modules/admin_manual/pages/enterprise/installation/install.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/install.adoc
@@ -46,12 +46,8 @@ ownCloud configuration file `config/config.php` like in this example:
 'license-key' => 'test-20150101-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-YYYYYY',
 ----
 
-It is also possible to activate your Enterprise Edition on the webUI. Open owncloud and navigate to:
-----
-settings > admin-settings > general
-----
-Copy your license key into the field `Enter a new license:` and click `Save` to confirm.
-
+It is also possible to activate your Enterprise Edition on the webUI. Open owncloud and navigate to: 
+menu:Settings[Admin > General]. Copy your license key into the field `Enter a new license:` and click `Save` to confirm.
 
 Each running instance of ownCloud requires a license key. Keys will work
 across upgrades without issue, so new keys will not be required when you

--- a/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/installation/oracle_db_configuration.adoc
@@ -66,7 +66,7 @@ need to download two Oracle Instant Client packages:
 
 Then, to install them, use the following commands:
 
-[source,console]
+[source,bash]
 ----
 rpm --install oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm \
   oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
@@ -88,7 +88,7 @@ With the extension installed, you now need to configure it, by creating
 a configuration file for it. You can do so using the command below,
 substituting `FILE_PATH` with one from the list below the command.
 
-[source,console]
+[source,bash]
 ----
 cat << EOF > FILE_PATH
 ; Oracle Instant Client Shared Object extension
@@ -125,7 +125,7 @@ RedHat, Centos, & Fedora
 With all that done, confirm that it’s been installed and available in
 your PHP distribution, run the following command:
 
-[source,console]
+[source,bash]
 ----
 php -m | grep -i oci8
 ----
@@ -184,10 +184,12 @@ The configuration file should look something like this:
 
 On the machine where your Oracle database is installed, type:
 
+[source,bash]
 ----
 sqlplus username
 ----
 
+[source,sql]
 ----
 SQL> select * from v$version;
 
@@ -204,24 +206,28 @@ SQL> exit
 
 *Show Database Users*:
 
+[source,sql]
 ----
 Oracle    : SELECT * FROM all_users;
 ----
 
 *Show available Databases*:
 
+[source,sql]
 ----
 Oracle    : SELECT name FROM v$database; (requires DBA privileges)
 ----
 
 *Show ownCloud Tables in Database*:
 
+[source,sql]
 ----
 Oracle    : SELECT table_name FROM user_tables;
 ----
 
 *Quit Database*:
 
+[source,sql]
 ----
 Oracle    : quit
 ----

--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -33,7 +33,7 @@ image:enterprise/logging/admin_auditing.png[Auditing]
 
 It is advised to redirect messages into a separate file. To do so, add these lines to `config.php` and adjust the target path accordingly. Note that the target path must be writeable for the web server user:
 
-[source,console]
+[source,php]
 ----
 'log.conditions' => [
 	[
@@ -47,7 +47,7 @@ NOTE: All messages regardless of log level will be logged there.
 
 To ignore all CLI triggered events (default is to include them), set the following option:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set admin_audit ignore_cli_events --value='yes'
 ----
@@ -56,7 +56,7 @@ To ignore all CLI triggered events (default is to include them), set the followi
 
 With each log message, a number of users are calculated to be the 'audit context'. This is the list of users which are related to the log message. Additionally, each log message includes a list of groups that the users are a member of, to enable filtering / splitting of the log messages at a later date. In cases when users are members of many groups, to reduce the data output, the group list can be filtered by adding the following to your `config.php`. Change the groups needed accordingly:
 
-[source,console]
+[source,php]
 ----
 'admin_audit.groups' => [
     'group1',
@@ -90,7 +90,7 @@ Connect to the deployment server, change `input-prd-your-server-here` according 
 
 To Monitor the ownCloud Splunk audit log, add this to `inputs.conf`, assuming you use the custom logging path/file from above:
 
-[source,console]
+[source,text]
 ----
 [monitor://var/www/owncloud/data/admin_audit.log]
  disabled = false
@@ -100,7 +100,7 @@ To Monitor the ownCloud Splunk audit log, add this to `inputs.conf`, assuming yo
 
 Finally, configure the following `props.conf` to ensure the time field is correctly used and the fields are extracted.
 
-[source,console]
+[source,text]
 ----
 [_json]
  INDEXED_EXTRACTIONS = json

--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -86,7 +86,7 @@ To get started, you have to set a secret for authenticating requests at the endp
 
 See the following occ command on how to set it. Make up a passphrase, referred to as `<your-metrics-secret>` in the example below. The Metrics secret is necessary to use the dashboard.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:system:set "metrics_shared_secret" --value "<your-metrics-secret>"
 ----
@@ -98,7 +98,7 @@ instead of using the occ command.
 
 The dashboard is enabled by default. You can disable it with the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set metrics disable_dashboard --value=yes
 ----
@@ -109,6 +109,7 @@ The dashboard is enabled by default. You can disable it with the following comma
 
 To query for the Metrics data, use the following endpoint:
 
+[source,text]
 ----
 https://<your owncloud>/ocs/v1.php/apps/metrics/api/v1/metrics
 ----
@@ -124,7 +125,7 @@ Except for the header, all other parameters are optional. You can split the quer
 
 See the `curl` example to request the complete output:
 
-[source,console]
+[source,bash]
 ----
 curl -H "OC-MetricsApiKey: <your-metrics-secret>" \
      "https://<your owncloud>/ocs/v1.php/apps/metrics/api/v1/metrics?users=true&files=true&shares=true&quota=true&userData=true&format=json"
@@ -143,7 +144,7 @@ TIP: In the following `curl` examples, replace `<your-metrics-secret>` with your
 
 To receive user metrics, use:
 
-[source,console]
+[source,bash]
 ----
 curl -H "Content-Type: application/csv" \
      -H "OC-MetricsApiKey: <your-metrics-secret>" \
@@ -153,7 +154,7 @@ curl -H "Content-Type: application/csv" \
 
 For system metrics, use:
 
-[source,console]
+[source,bash]
 ----
 curl -H "Content-Type: application/csv" \
      -H "OC-MetricsApiKey: <your-metrics-secret>" \

--- a/modules/admin_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
+++ b/modules/admin_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
@@ -47,8 +47,9 @@ you want, for example `myBrandedTheme`. Then configure your ownCloud
 server to use your branded theme by entering it in your `config.php`
 file:
 
+[source,php]
 ----
-"theme" => "myBrandedTheme"
+'theme' => 'myBrandedTheme'
 ----
 
 If anything goes wrong with your new theme, comment out this line to

--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -26,7 +26,7 @@ and mod-shib, ask your ADFS admin for the relevant server URLs. These are:
 
 Then, make sure that the web server is accessible with a trusted certificate:
 
-[source,console]
+[source,bash]
 ----
 sudo a2enmod ssl
 sudo a2ensite default-ssl
@@ -37,7 +37,7 @@ sudo service apache2 restart
 
 Firstly, install {libapache2-mod-shib-url}[mod-shib]. You can do this using the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get install libapache2-mod-shib2
 ----
@@ -45,7 +45,7 @@ sudo apt-get install libapache2-mod-shib2
 This will install packages needed for mod-shib, including `shibd`.
 Then, generate certificates for the `shibd` daemon by running the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo shib-keygen
 ----
@@ -54,7 +54,7 @@ sudo shib-keygen
 
 The metadata provided by ADFS cannot be automatically imported, and must be cleaned up before using it with the file based `MetadataProvider`. To do so, use `adfs2fed.php`, as in the following command:
 
-[source,php]
+[source,bash]
 ----
 php apps/user_shibboleth/tools/adfs2fed.php \
    https://<ADFS server FQDN>/FederationMetadata/2007-06/FederationMetadata.xml \
@@ -70,7 +70,7 @@ To do this, in `/etc/shibboleth/shibboleth2.xml`:
 
 Use the URL of the ownCloud instance as the `entityID` in the `ApplicationDefaults`
 
-[source,console]
+[source,bash]
 ----
 <ApplicationDefaults entityID="https://<owncloud server FQDN>/login/saml" REMOTE_USER="eppn upn">
 ----
@@ -95,7 +95,7 @@ NOTE: Grab `<ADFS server FQDN>/<URI>/` from the filtered-metadata.xml.
 
 Configure an XML `MetadataProvider` with the local `filtered-metadata.xml` file
 
-[source,sml]
+[source,xml]
 ----
 <MetadataProvider type="XML" path="/etc/shibboleth/filtered-metadata.xml"/>
 ----
@@ -145,10 +145,10 @@ In the "User Authentication" settings for Shibboleth the `upn` environment varia
 
 Use `upn` as `uid` and set the app mode to 'SSO Only' by running:
 
-[source,console]
+[[source,bash,subs="attributes+"]
 ----
-occ shibboleth:mode ssoonly
-occ shibboleth:mapping -u upn
+{occ-command-example-prefix} shibboleth:mode ssoonly
+{occ-command-example-prefix} shibboleth:mapping -u upn
 ----
 
 `displayName` and email are only relevant for `autoprovisioning` mode.
@@ -169,22 +169,34 @@ Add Claims in ADFS and map them in the `attribute-map.xml` if needed.
   - Add "Windows Authentication" to the "Service" -> "Authentication Methods" for "Intranet"
   - Run the following Powershell script for Firefox:
 
+Save the list of currently supported browser user-agents to a variable
 [source,console]
 ----
-# Save the list of currently supported browser user-agents to a variable
-$browsers=Get-ADFSProperties | Select -ExpandProperty WIASupportedUseragents
+$ browsers=Get-ADFSProperties | Select -ExpandProperty WIASupportedUseragents
+----
 
-# Add Mozilla/5.0 user-agent to the list
-$browsers+="Mozilla/5.0"
+Add Mozilla/5.0 user-agent to the list
+[source,console]
+----
+$ browsers+="Mozilla/5.0"
+----
 
-# Apply the new list
-Set-ADFSProperties -WIASupportedUseragents $browsers
+Apply the new list
+[source,console]
+----
+$ Set-ADFSProperties -WIASupportedUseragents $browsers
+----
 
-# Turn off Extended Protection
-#Set-ADFSProperties –ExtendedProtectionTokenCheck None
+Turn off Extended Protection
+[source,console]
+----
+$ Set-ADFSProperties –ExtendedProtectionTokenCheck None
+----
 
-# Restart the AD FS service
-Restart-Service ADFSsrv
+Restart the AD FS service
+[source,console]
+----
+$ Restart-Service ADFSsrv
 ----
 
 - On the Windows client:

--- a/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/user_auth_shibboleth.adoc
@@ -48,7 +48,7 @@ After enabling the app it will be in *Not active* mode, which ignores a Shibbole
 Use this mode to set up the environment mapping for the other modes, and in case you locked yourself out of the system. 
 You can also change the app mode and environment mappings by using the `occ` command, like this example on Ubuntu Linux:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} shibboleth:mode notactive
 {occ-command-example-prefix} shibboleth:mapping --uid login
@@ -80,10 +80,9 @@ In ownCloud 8.2+ the variables are stored in the ownCloud database, making Shibb
 
 === Mapping ownCloud User IDs
 
-From 3.1.2 you can now specify a mapper that is used on inbound ownCloud user IDs, to adjust them before usage in ownCloud. 
-You can set the mapper using `occ`:
+From 3.1.2 you can now specify a mapper that is used on inbound ownCloud user IDs, to adjust them before usage in ownCloud. You can set the mapper using `occ`:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set user_shibboleth \
      uid_mapper --value="OCA\User_Shibboleth\Mapper\ADFSMapper"
@@ -91,7 +90,7 @@ You can set the mapper using `occ`:
 
 You may view the currently configured mapper using:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} shibboleth:mapping
 ----

--- a/modules/admin_manual/pages/installation/changing_the_web_route.adoc
+++ b/modules/admin_manual/pages/installation/changing_the_web_route.adoc
@@ -14,6 +14,7 @@ To do so on Debian/Ubuntu Linux, you need to edit these files:
 Edit the `Alias` directive in `/etc/apache2/sites-enabled/owncloud.conf`
 to alias your ownCloud directory to the Web server root:
 
+[source,apache]
 ----
 Alias / "/var/www/owncloud/"
 ----
@@ -21,6 +22,7 @@ Alias / "/var/www/owncloud/"
 Edit the `overwrite.cli.url` parameter in
 `/var/www/owncloud/config/config.php`:
 
+[source,text]
 ----
 'overwrite.cli.url' => 'http://localhost/',
 ----

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -25,12 +25,13 @@ This can be the case, for example, for the `date.timezone` setting.
 
 For PHP version {minimum-php-printed} onward, replace `php_version` with the version number installed, e.g., `{minimum-php-version}` in the following examples.
 
+[source,text]
 ----
 /etc/php/[php_version]/apache2/php.ini
 ----
 
 or
-
+[source,text]
 ----
 /etc/php/[php_version]/fpm/php.ini
 ----
@@ -39,6 +40,7 @@ or
 
 === php.ini - used by the php-cli and so by ownCloud CRON jobs
 
+[source,text]
 ----
 /etc/php/[php_version]/cli/php.ini
 ----
@@ -106,6 +108,7 @@ The easiest way to get the quantity of PHP files is to use cloc, which
 can be installed by running `sudo apt-get install cloc`. The cloc
 package is available for nearly all distributions.
 
+[source,bash]
 ----
 sudo cloc /var/www/owncloud --exclude-dir=data --follow-links
    12179 text files.
@@ -160,6 +163,7 @@ may be in a sub-directory.
 Usually, you will find some or all of the environment variables already
 in the file, but commented out like this:
 
+[source,text]
 ----
 ;env[HOSTNAME] = $HOSTNAME
 ;env[PATH] = /usr/local/bin:/usr/bin:/bin
@@ -171,6 +175,7 @@ in the file, but commented out like this:
 Uncomment the appropriate existing entries. Then run `printenv PATH` to
 confirm your paths, for example:
 
+[source,console]
 ----
 $ printenv PATH
 /home/user/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -36,14 +36,14 @@ apt-mark hold owncloud-complete-files
 
 To see if owncloud-complete-files has already been held, use the `showhold` command, as in the following example. If it’s printed out to the console, then it’s being held.
 
-[source,console]
+[source,bash]
 ----
 apt-mark showhold owncloud-complete-files
 ----
 
 To unset `owncloud-complete-files` as held back, use the `unhold` command, as in the example below.
 
-[source,console]
+[source,bash]
 ----
 apt-mark unhold owncloud-complete-files
 ----
@@ -59,28 +59,28 @@ If you are using Yum, there are two options that you can take to lock packages f
 
 If the `versionlock` plugin is not installed, install it by running:
 
-[source,console]
+[source,bash]
 ----
 yum install yum-plugin-versionlock
 ----
 
 When it is installed, you can lock `owncloud-complete-files` run:
 
-[source,console]
+[source,bash]
 ----
 yum versionlock add owncloud-complete-files
 ----
 
 To confirm that it is locked, run: 
 
-[source,console]
+[source,bash]
 ----
 yum versionlock list
 ----
 
 To unlock `owncloud-complete-files`, run: 
 
-[source,console]
+[source,bash]
 ----
 yum versionlock delete owncloud-complete-files
 ----
@@ -89,14 +89,14 @@ yum versionlock delete owncloud-complete-files
 
 If you are using Zypper, use the `addlock` or `al` commands. Similar to `apt-mark hold` these add a package lock that prevents the package from being modified. The example below shows how to use the command to lock `owncloud-complete-files`.
 
-[source,console]
+[source,bash]
 ----
 zypper addlock owncloud-complete-files
 ----
 
 To see if the package has already been locked, use the `locks` command.  If `owncloud-complete-files` is already locked, then you will see output similar to the below example.
 
-[source,console]
+[source,text]
 ----
 # | Name                    | Type    | Repository
 --+-------------------------+---------+-----------
@@ -105,7 +105,7 @@ To see if the package has already been locked, use the `locks` command.  If `own
 
 To unlock `owncloud-complete-files`, if it is already locked, use the `removelocks` or `rl` commands, as in the example below.
 
-[source,console]
+[source,bash]
 ----
 zypper removelock owncloud-complete-files
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
@@ -29,7 +29,7 @@ steps described below to do so.
 NOTE: Copy your smb.conf or other configurations files you may want to keep to reuse them later on.
 Purging deletes the config files and helps to make a clean basis. 
 
-[source,console]
+[source,bash]
 ----
 sudo phpdismod smbclient
 sudo pecl uninstall smbclient
@@ -42,7 +42,7 @@ sudo apt autoremove
 To compile Samba, you need to install necessary packages. Copy the {samba_req_pack_url}[Bootstrap Dependencies Script] from Samba for Ubuntu 20.04. You will find it in section _Verified Package Dependencies_. Post downloading, make the script executable and execute it, which will install all required packages for a successful samba compilation. For your convenience, you can directly download the
 link:{attachmentsdir}/installation/manual_installation/bootstrap.sh[bootstrap samba master] shell script here.
 
-[source,console]
+[source,bash]
 ----
 sudo ./bootstrap.sh
 ----
@@ -58,7 +58,7 @@ as client, download this version. You can choose any version that fits your need
 provided by the OS delivered version. Keep the downloaded (and later configured) version at a location for
 later reuse. This will be necessary if you would like to uninstall it properly. The example uses `/opt`.
 
-[source,console]
+[source,bash]
 ----
 cd /opt
 sudo wget https://download.samba.org/pub/samba/stable/samba-4.10.18.tar.gz
@@ -66,7 +66,7 @@ sudo wget https://download.samba.org/pub/samba/stable/samba-4.10.18.tar.gz
 
 === Extract Samba Sources
 
-[source,console]
+[source,bash]
 ----
 sudo tar -xvf samba-4.10.18.tar.gz
 cd samba-4.10.18
@@ -90,7 +90,7 @@ from the options below. Read more on details {samba_conf_options_url}[config opt
 For your convenience, you can directly download a
 link:{attachmentsdir}/installation/manual_installation/compile_samba.sh[compile samba] shell script here.
 
-[source,console]
+[source,bash]
 ----
 sudo ./configure \
 	--prefix=/usr \
@@ -120,7 +120,7 @@ multiple jobs in parallel by adding `-j <n>`. This optimizes the CPU utilisation
 the time needed. In the example below, four jobs are enabled to utilize the 4 available cores
 of the CPU.
 
-[source,console]
+[source,bash]
 ----
 sudo make -j 4
 ----
@@ -129,7 +129,7 @@ sudo make -j 4
 
 To install the compiled software run following command:
 
-[source,console]
+[source,bash]
 ----
 sudo make install -j 4
 ----
@@ -139,7 +139,7 @@ sudo make install -j 4
 If you do not have an existing or already configured `smb.conf` file, you can create a default one.
 The following command creates a new `smb.conf` if it does not exist, but does not overwrite an existing one.
 
-[source,console]
+[source,bash]
 ----
 sudo cp -n examples/smb.conf.default /etc/samba/smb.conf
 ----
@@ -149,7 +149,7 @@ sudo cp -n examples/smb.conf.default /etc/samba/smb.conf
 Uninstalling can be necessary, if you want to have a clean base. This is useful if you want to compile a
 different version or the version provided by the OS. To uninstall the compiled software run following command:
 
-[source,console]
+[source,bash]
 ----
 sudo make uninstall -j 4
 ----
@@ -161,13 +161,13 @@ sudo make uninstall -j 4
 When the installation has completed, test your result. If you have used a `smb.conf` file before,
 copy it back to its original location (`/etc/samba/`).
 
-[source,console]
+[source,bash]
 ----
 sudo smbclient --version
 Version 4.10.18
 ----
 
-[source,console]
+[source,bash]
 ----
 sudo smbclient -L <file_server_name> -U <full_domain_name>/<user_name>
 ----
@@ -182,7 +182,7 @@ The smbd service is necessary that your server can act as simple smb file server
 
 First create a link to the smb service.
 
-[source,console]
+[source,bash]
 ----
 sudo ln -s /lib/systemd/system/smb.service /etc/systemd/system/smbd.service
 ----
@@ -190,7 +190,7 @@ sudo ln -s /lib/systemd/system/smb.service /etc/systemd/system/smbd.service
 Then, change some startup parameters. These will not be overwritten on the source file, but be added
 via a separate non-destructive process.
 
-[source,console]
+[source,bash]
 ----
 sudo systemctl edit smbd.service
 ----
@@ -198,6 +198,7 @@ sudo systemctl edit smbd.service
 Add the following content and save the result. The location and naming will be done automatically.
 Just say save.
 
+[source,text]
 ----
 [Unit]
 After=
@@ -212,14 +213,14 @@ ExecStart=/usr/sbin/smbd --configfile=/etc/samba/smb.conf
 
 When finished, reload the daemon to recognize the update:
 
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 ----
 
 Finally, you can start (stop, reload ect), the smbd service with:
 
-[source,console]
+[source,bash]
 ----
 sudo service smbd start
 ----
@@ -232,7 +233,7 @@ the smbd service. You should then be able to connect to this standalone samba se
 
 If you had removed `pecl smbcient` before, you can reinstall it now with:
 
-[source,console]
+[source,bash]
 ----
 sudo pecl channel-update pecl.php.net
 sudo pecl install smbclient
@@ -264,14 +265,14 @@ Download the scripts:
 
 Make the scripts executable:
  
-[source,console]
+[source,bash]
 ----
 sudo chmod +x <script_name>
 ----
 
 Change into the extracted samba directory you want to compile, e.g. `samba-4.10.18`, and run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo ../install_samba.sh
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
@@ -9,7 +9,7 @@ ImageMagick shipped for Ubuntu 20.04 is based on version 6, the corresponding `p
 
 In case you have made any changes to the configuration files for ImageMagick-6, we recommend to back them up for easy transition to ImageMagick-7 with the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo cp -rp /etc/ImageMagick-6 /etc/ImageMagick-6.backup
 ----
@@ -23,7 +23,7 @@ NOTE: After installing ImageMagick-7 and if you do not define the configuration 
 . Check if `php-imagick` is installed:
 +
 --
-[source,console]
+[source,bash]
 ----
 dpkg -l | grep php | awk '{print $2}' | tr "\n" " " | grep php-imagick
 ----
@@ -33,7 +33,7 @@ You will see the name printed if it is installed.
 
 . Check if the `imagick.so` library is installed:
 +
-[source,console]
+[source,bash]
 ----
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort | grep imagick
 ----
@@ -41,7 +41,7 @@ ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort | grep imagick
 . Check the installed `php-imagick` version:
 +
 --
-[source,console]
+[source,bash]
 ----
 php --ri imagick | grep -i "module version"
 ----
@@ -51,21 +51,21 @@ If both the `php-imagick` library and the `imagick.so` binary is installed, proc
 
 . Disable `php-imagick`:
 +
-[source,console]
+[source,bash]
 ----
 sudo phpdismod imagick
 ----
 
 . Remove php-imagick:
 +
-[source,console]
+[source,bash]
 ----
 sudo apt remove php-imagick
 ----
 
 . Depending on the installation, restart Apache or php-fpm:
 +
-[source,console]
+[source,bash]
 ----
 sudo service apache2 restart
 or
@@ -76,7 +76,7 @@ sudo service php7.4-fpm restart
 
 . Check which ImageMagick version is installed. The version may differ from our example output.
 +
-[source,console]
+[source,bash]
 ----
 convert -version  | grep -i version
 
@@ -85,7 +85,7 @@ Version: ImageMagick 6.9.7-4
 
 . Remove the old `imagemagick-6` version:
 +
-[source,console]
+[source,bash]
 ----
 sudo apt remove imagemagick-6-common
 ----
@@ -98,7 +98,7 @@ To install ImageMagick-7, a script is used. Alternatively, you can copy&paste al
 
 . Change to the /tmp directory:
 +
-[source,console]
+[source,bas]
 ----
 cd /tmp
 ----
@@ -113,7 +113,7 @@ cd /tmp
 --
 Run this example to do all steps in one chained command:
 
-[source,console]
+[source,bash]
 ----
 wget https://dist.1-2.dev/imei.sh && \
 wget https://dist.1-2.dev/imei.sh.sig && \
@@ -124,7 +124,7 @@ openssl dgst -sha512 -verify imei.sh.pem -signature imei.sh.sig imei.sh
 
 . If you get a `Verified OK` message, make the script executable:
 +
-[source,console]
+[source,bash]
 ----
 sudo chmod +x imei.sh
 ----
@@ -135,7 +135,7 @@ NOTE: For Ubuntu, ImageMagick uses `/etc` as base for the config directory, see 
 
 NOTE: Depending on your environment, this may take a while (+25min).
 
-[source,console]
+[source,bash]
 ----
 sudo ./imei.sh --config-dir "/etc"
 ----
@@ -143,14 +143,14 @@ sudo ./imei.sh --config-dir "/etc"
 
 . Check if ImageMagic-7 and its libraries have been properly installed
 +
-[source,console]
+[source,bash]
 ----
 dpkg -l | grep imei
 ----
 
 . Remove the downloaded script and verification files:
 +
-[source,console]
+[source,bash]
 ----
 rm imei.*
 ----
@@ -159,7 +159,7 @@ rm imei.*
 
 Check the version installed. The version printed may be different than in the example output.
 
-[source,console]
+[source,bash]
 ----
 convert -version | grep -i version
 
@@ -198,7 +198,7 @@ NOTE: If you have installed the php-wrapper via PECL before and want to reinstal
 --
 The `printf` command auto-accepts the question for using defaults.
 
-[source,console]
+[source,bash]
 ----
 sudo pecl channel-update pecl.php.net
 printf "\n" | sudo pecl install imagick
@@ -210,13 +210,13 @@ printf "\n" | sudo pecl install imagick
 --
 Use your php version in the path of the example command below:
 
-[source,console]
+[source,bash]
 ----
 ll /etc/php/7.4/mods-available/imagick.ini
 ----
 If the file is not present, create one:
 
-[source,console]
+[source,bash]
 ----
 sudo nano /etc/php/7.4/mods-available/imagick.ini
 ----
@@ -234,14 +234,14 @@ extension=imagick.so
 
 . After ImageMagick-7 and the php wrapper have been installed, enable the php wrapper:
 +
-[source,console]
+[source,bash]
 ----
 sudo phpenmod imagick
 ----
 
 . Depending on the installation, restart Apache or php-fpm:
 +
-[source,console]
+[source,bash]
 ----
 sudo service apache2 restart
 or
@@ -250,7 +250,7 @@ sudo service php7.4-fpm restart
 
 . Print supported `php-imagick` formats:
 +
-[source,console]
+[source,bash]
 ----
 php -r 'phpinfo();' | grep -i "ImageMagick supported formats"
 ----
@@ -265,14 +265,14 @@ To reinstall or upgrade ImageMagick-7, follow the principle steps described abov
 
 If you want to uninstall ImageMagick-7 only, run:
 
-[source,console]
+[source,bash]
 ----
 sudo apt remove imei-imagemagick
 ----
 
 If you want to completely remove ImageMagic-7 and all of its installed components, run:
 
-[source,console]
+[source,bash]
 ----
 sudo apt remove imei-imagemagick,imei-libaom,imei-libheif,imei-libjxl
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
@@ -65,7 +65,7 @@ wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2
 
 . Download the corresponding checksum file like:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.md5
   or
@@ -74,7 +74,7 @@ wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.sha256
 
 . Verify the MD5 or SHA256 sum:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 sudo md5sum -c {oc-complete-name}.tar.bz2.md5 < {oc-complete-name}.tar.bz2
  or
@@ -83,7 +83,7 @@ sudo sha256sum -c {oc-complete-name}tar.bz2.sha256 < {oc-complete-name}.tar.bz2
 
 . You can also verify the PGP signature:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2.asc
 
@@ -107,7 +107,7 @@ if you plan on improving your setup from step one.
 
 * Extract the archive contents and run the unpacking command for your tar archive:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 tar -xjf {oc-complete-name}.tar.bz2
 ----
@@ -117,7 +117,7 @@ tar -xjf {oc-complete-name}.tar.bz2
   If you are running the Apache HTTP server, you may safely install ownCloud in your Apache document root.
   Assuming your document root is in `/var/www`.
 +
-[source,console]
+[source,bash]
 ----
 cp -r owncloud /var/www
 ----
@@ -146,7 +146,7 @@ If you want to finalize the installation via the command line, use the following
 command. The command assumes that you have unpacked the source to `/var/www/owncloud/`.
 Replace all the parameters according to your needs.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:install \

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_apache.adoc
@@ -42,7 +42,7 @@ sudo ln -s /etc/apache2/sites-available/owncloud.conf /etc/apache2/sites-enabled
 
 * For ownCloud to work correctly, you need the module `mod_rewrite`. Enable it by running: `a2enmod rewrite`. Additionally recommended modules are `mod_headers`, `mod_env`, `mod_dir`, `mod_mime`, and `mod_unique_id`. To enable them, run the following commands:
 +
-[source,console]
+[source,bash]
 ----
 sudo a2enmod headers
 sudo a2enmod env
@@ -55,6 +55,7 @@ NOTE: If you want to use the {oc-marketplace-url}/apps/oauth2[OAuth2 app], then 
 
 * You must disable any server-configured authentication for ownCloud since it uses basic authentication internally for DAV services. If you have turned on authentication on a parent folder (e.g. via an `AuthType Basic` directive), you can disable the authentication specifically for the ownCloud entry. As in the above example configuration file, add the following line in the `Directory` section:
 +
+[source,apache]
 ----
 Satisfy Any
 ----
@@ -63,6 +64,7 @@ Satisfy Any
 
 * Now restart Apache
 +
+[source,bash]
 ----
 sudo service apache2 restart
 ----
@@ -110,7 +112,7 @@ NOTE: Self-signed certificates have their drawbacks - especially when you plan t
 
 Using the simple self-signed certificate provided by the Apache installation, all you have to do is to enable the `ssl` module and the default site. Open a terminal and run:
 
-[source,console]
+[source,bash]
 ----
 sudo a2enmod ssl
 sudo a2ensite default-ssl
@@ -129,7 +131,7 @@ in its own memory space. ownCloud limits its support to Apache prefork only.
 ====
 In case you have enabled `mpm_event` during an earlier setup of Apache, you may get conflict notes from Apache. Use the following commands to solve this issue. The order of commands is recommended to ensure a smooth transition. 
 
-[source,console]
+[source,bash]
 ----
 sudo a2dismod mpm_event
 sudo systemctl restart apache2

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -41,14 +41,14 @@ include::partial$installation/manual_installation/mariadb.adoc[leveloffset=+1]
 
 To install postgres, use the following command (or that of your preferred package manager):
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get install postgresql
 ----
 
 In order to allow ownCloud access to the database, create a known password for the default user, `postgres`, which was added when the database was installed.
 
-[source,console]
+[source,bash]
 ----
 sudo -i -u postgres psql
 postgres=# \password

--- a/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
@@ -88,7 +88,7 @@ This is the name of the root user, usually `root`.
 
 It is mandatory to run this script with root privileges, because files and directories will be created and ownership and permissions will be set. Call the instance script like:
 
-[source,console]
+[source,bash]
 ----
 sudo ./instance.sh
 ----
@@ -141,7 +141,7 @@ Edit your version of the `instance.sh` script with the parameters that apply to 
 
 Next, make both scripts executable (use the correct script names instead of the placeholder):
 
-[source,console]
+[source,bash]
 ----
 sudo chmod +x scriptname.sh
 ----
@@ -173,7 +173,7 @@ Follow the steps printed on the screen. Do not forget to reapply manually made c
 
 .How to get the difference of two files quickly
 The following example command eases to find the differences of two files, which is helpful for reapplying manually added changes to `.htaccess` and `.user.ini`. Replace that paths, directories and files accordingly.
-[source,console]
+[source,bash]
 ----
 diff -y -W 70 --suppress-common-lines owncloud/.user.ini owncloud_2022-02-15-09.18.48/.user.ini
 post_max_size=513M                |     post_max_size=1G

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -26,7 +26,7 @@ NOTE: The commands and links provided in this description should give you proper
 
 Without going into the upgrade details, you can now upgrade directly from Ubuntu 18.04 LTS to 20.04 LTS without using the _development_ (`-d`) option when using the `do-release-upgrade` command. For more details see an example description at {ubuntu_upgrade_url}[Upgrade Ubuntu 18.04 to 20.04 LTS using command line]
 
-[source,console]
+[source,bash]
 ----
 sudo apt update
 sudo apt upgrade
@@ -38,7 +38,7 @@ sudo do-release-upgrade
 
 If you have upgraded successfully and had previously installed any versions of PHP, better uninstall all PHP versions and ALL extensions and perform a fresh PHP 7.4 native installation. This is especially true when using the `ondrej php` PPA as it installs all available PHP versions, which are either no longer needed or supported. To do so, stop any services which depend on or use PHP like your Web Server. Then get a list of all PHP related programs and extensions by typing:
 
-[source,console]
+[source,bash]
 ----
 dpkg -l | grep php | awk '{print $2}' | tr "\n" " "
 ----
@@ -48,14 +48,14 @@ xref:useful-commands-for-managing-php-extensions[Useful Commands For Managing PH
 
 Then purge them step by step
 
-[source,console]
+[source,bash]
 ----
 sudo apt purge <package name from the list above>
 ----
 
 Alternatively, if you are fine removing all packages listed, you can run:
 
-[source,console]
+[source,bash]
 ----
 sudo apt purge `dpkg -l | grep php | awk '{print $2}' | tr "\n" " "`
 ----
@@ -64,7 +64,7 @@ NOTE: Keep a copy of your relevant `php.ini` and other configuration files as re
 
 If you had installed the `ondrej php` PPA, remove it, else it will reinstall PHP from this source again. To do so run:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install ppa-purge
 sudo ppa-purge ppa:ondrej/php
@@ -83,7 +83,7 @@ After deinstallation of all versions and extensions of PHP and cleaning up all r
 After you have installed your Ubuntu 20.04 LTS server from scratch, use the following commands to
 install PHP 7.4 and necessary extensions:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install php-fpm php-cgi
 sudo apt install php
@@ -95,7 +95,7 @@ sudo apt install php-dev libsmbclient-dev php-pear
 
 Use the following commands to install some common prerequisites:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install smbclient
 sudo apt install redis-server
@@ -107,7 +107,7 @@ sudo apt install imagemagick
 
 The following step is necessary to upgrade PEAR because of a change in PHP 7.4.1+ Note that you should always use the {pear-package_url}[latest stable PEAR release].
 
-[source,console]
+[source,bash]
 ----
 pear version
 sudo mkdir -p /tmp/pear/cache
@@ -133,21 +133,21 @@ If you needed to set `client max protocol = NT1` before in `smb.conf` to connect
 
 To check if you are affected connecting to a particular file server, do tests with the Ubuntu provided version like:
 
-[source,console]
+[source,bash]
 ----
 host -t SRV _ldap._tcp.<full_domain_name>
 ----
 
 If you do not get SRV records printed, your dns settings may need a change. The first DNS server must be able to resolve your LDAP Active Directory request properly. If not, `smbclient` can not find a KDC to check credentials.
 
-[source,console]
+[source,bash]
 ----
 sudo smbclient -L <file_server_name> -U <full_domain_name>/<user_name>
 ----
 
 Any other output than a list of shares, like the error message
 
-[source,console]
+[source,bash]
 ----
 tree connect failed: NT_STATUS_INVALID_PARAMETER
 ----
@@ -162,7 +162,7 @@ helps how to do that.
 
 The following command installs the Apache Web Server.
 
-[source,console]
+[source,bash]
 ----
 sudo apt install libapache2-mod-php apache2
 ----
@@ -175,7 +175,7 @@ Although it's not supported by ownCloud, you can configure Apache to use `php-fp
 
 If you have multiple concurrent PHP versions installed, which will happen when using the {ondrej-php-url}[ondrej/php] PPA, you must tell your Web Server and your CLI environment which one to use. Using the `ondrej/php` PPA may be needed if you want to test or prepare for the latest PHP version like PHP 8. Please note that `ondrej/php` installs _ALL_ versions of PHP. To list all available versions installed and choose one from them, use the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo update-alternatives --config php
 ----
@@ -196,14 +196,14 @@ Press <enter> to keep the current choice[*], or type selection number:
 
 You can also directly set the required PHP version:
 
-[source,console]
+[source,bash]
 ----
 sudo update-alternatives --set php /usr/bin/php7.4
 ----
 
 WARNING: After selecting your PHP version, it is **highly** recommended to switch to the correct compiling environment which is essential e.g. when using PECL!
 
-[source,console]
+[source,bash]
 ----
 sudo update-alternatives --set phar /usr/bin/phar7.4
 sudo update-alternatives --set phar.phar /usr/bin/phar.phar7.4
@@ -223,7 +223,7 @@ WARNING: You may get completely unexpected behaviour or a broken environment if 
 
 If you are using a PECL install later on, check the output of the installation command soon after it has started. You will find a text like:
 
-[source,console]
+[source,text]
 ----
 ...
 PHP Api Version:         20190902
@@ -233,21 +233,21 @@ Zend Module Api No:      20190902
 
 Then do a test by just entering the following command:
 
-[source,console]
+[source,bash]
 ----
 php -i | grep extension_dir
 ----
 
 If the output is different than the style below, there is a problem that needs fixing:
 
-[source,console]
+[source,text]
 ----
 extension_dir => /usr/lib/php/20180731 => /usr/lib/php/20180731
 ----
 
 This is the output that shows a fix is needed:
 
-[source,console]
+[source,text]
 ----
 PHP Warning:  PHP Startup: smbclient: Unable to initialize module
 Module compiled with module API=20190902
@@ -263,7 +263,7 @@ As you see above, the API modules do not match and have been compiled with diffe
 xref:enterprise/external_storage/windows-network-drive_configuration.adoc[Windows Network Drives app]
 from ownCloud's Enterprise Edition. To install it, run the commands described below. You can find more information about `smbclient` and the latest version on {pecl_url}[PECL].
 
-[source,console]
+[source,bash]
 ----
 sudo pecl channel-update pecl.php.net
 sudo pecl install smbclient
@@ -275,7 +275,7 @@ When the commands complete, you then have to (assuming you use PHP 7.4):
 - Enable the module by running `phpenmod smbclient`.
 - Restart PHP and your web server by running the following command:
 +
-[source,console]
+[source,bash]
 ----
 sudo service apache2 restart
 ----
@@ -294,7 +294,7 @@ When using new or extended formats for previews like HEIC or SVG, the standard i
 
 If you want to retrieve a list of enabled PHP extensions run following command:
 
-[source,console]
+[source,bash]
 ----
 ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort
 ----
@@ -304,10 +304,13 @@ ls `php -i | grep "^extension_dir" | sed -e 's/.*=> //'` | sort
 To enable or disable a PHP extension for CLI, FPM or Apache, use the commands `phpenmod` or `phpdismod`.
 
 Example:
-[source,console]
+[source,bash]
 ----
 sudo phpenmod php-ldap
-# or
+----
+or
+[source,bash]
+----
 sudo phpdismod php-ldap
 ----
 

--- a/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/upgrade_install_phpmyadmin.adoc
@@ -20,7 +20,7 @@ NOTE: The guide has been tested, is at it is and comes without any warranty.
 Please note, you must already have an existing, configured and working `phpmyadmin` installation.
 Check your existing version with following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt-cache policy phpmyadmin
 ----
@@ -42,7 +42,7 @@ correct location.
 The following example uses `phpMyAdmin-5.0.4-all-languages` as basis for upgrading. It renames the
 old installation because we need to keep some basic configuration settings.
 
-[source,console]
+[source,bash]
 ----
 cd /tmp
 sudo wget https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-all-languages.tar.gz
@@ -60,7 +60,7 @@ based on the former settings coming from the Ubuntu installation. The file to ch
 in `/usr/share/phpmyadmin/libraries/vendor_config.php`. To keep a copy of the original file from
 the update, create a backup with:
 
-[source,console]
+[source,bash]
 ----
 cd /usr/share/
 sudo cp phpmyadmin/libraries/vendor_config.php phpmyadmin/libraries/vendor_config.php.orig
@@ -96,7 +96,7 @@ image:installation/manual_installation/phpmyadmin_v5.0.4.png[]
 
 When you are fine with your upgrade, you can safely delete the old installation files.
 
-[source,console]
+[source,bash]
 ----
 cd /usr/share/
 sudo rm -r /usr/share/phpmyadmin.old

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -92,7 +92,7 @@ php -m | grep smbclient
 ----
 This should show the following output
 
-[source,console]
+[source,bash]
 ----
 libsmbclient
 smbclient

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -21,7 +21,7 @@ This guide can not go into details and has its limits by nature. If you experien
 First, ensure that all the installed packages are entirely up to date and that PHP is available in the APT repository.
 To do so, follow the instructions below:
 
-[source,console]
+[source,bash]
 ----
 apt update && \
   apt upgrade -y
@@ -31,7 +31,7 @@ apt update && \
 
 Create a helper script to simplify running xref:configuration/server/occ_command.adoc[occ commands]:
 
-[source,console]
+[source,bash]
 ----
 FILE="/usr/local/bin/occ"
 /bin/cat <<EOM >$FILE
@@ -43,14 +43,14 @@ EOM
 
 Make the helper script executable:
 
-[source,console]
+[source,bash]
 ----
 chmod +x /usr/local/bin/occ
 ----
 
 === Install the Required Packages
 
-[source,console]
+[source,bash]
 ----
 apt install -y \
   apache2 \
@@ -69,14 +69,14 @@ apt install -y \
 
 First install the required packages:
 
-[source,console]
+[source,bash]
 ----
 apt-get install -y libsmbclient-dev php-dev php-pear
 ----
 
 Install smblclient php module using pecl
 
-[source,console]
+[source,bash]
 ----
 pecl install smbclient-stable
 echo "extension=smbclient.so" > /etc/php/7.4/mods-available/smbclient.ini
@@ -86,7 +86,7 @@ systemctl restart apache2
 
 Check if it was successfully activated 
 
-[source,console]
+[source,bash]
 ----
 php -m | grep smbclient
 ----
@@ -102,7 +102,7 @@ smbclient
 
 Additional useful tools helpful for debugging:
 
-[source,console]
+[source,bash]
 ----
 apt install -y \
   unzip bzip2 rsync curl jq \
@@ -114,7 +114,7 @@ apt install -y \
 
 ==== Create a Virtual Host Configuration
 
-[source,console]
+[source,apache]
 ----
 FILE="/etc/apache2/sites-available/owncloud.conf"
 /bin/cat <<EOM >$FILE
@@ -140,7 +140,7 @@ EOM
 
 ==== Enable the Virtual Host Configuration
 
-[source,console]
+[source,bash]
 ----
 a2dissite 000-default
 a2ensite owncloud.conf
@@ -149,7 +149,7 @@ systemctl reload apache2
 
 === Configure the Database
 
-[source,console]
+[source,bash]
 ----
 systemctl start mariadb
 mysql -u root -e "CREATE DATABASE IF NOT EXISTS owncloud; \
@@ -160,7 +160,7 @@ GRANT ALL PRIVILEGES ON owncloud.* \
 
 ==== Enable the Recommended Apache Modules
 
-[source,console]
+[source,bash]
 ----
 echo "Enabling Apache Modules"
 a2enmod dir env headers mime rewrite setenvif
@@ -171,7 +171,7 @@ service apache2 reload
 
 === Download ownCloud
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cd /var/www/
 wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2 && \
@@ -181,7 +181,7 @@ chown -R www-data. owncloud
 
 === Install ownCloud
 
-[source,console]
+[source,bash]
 ----
 occ maintenance:install \
     --database "mysql" \
@@ -195,7 +195,7 @@ occ maintenance:install \
 
 === Configure ownCloud's Trusted Domains
 
-[source,console]
+[source,bash]
 ----
 myip=$(hostname -I|cut -f1 -d ' ')
 occ config:system:set trusted_domains 1 --value="$myip"
@@ -205,14 +205,14 @@ occ config:system:set trusted_domains 1 --value="$myip"
 
 Set your background job mode to cron:
 
-[source,console]
+[source,bash]
 ----
 occ background:cron
 ----
 
 Configure the execution of the cron job to every 15 min:
 
-[source,console]
+[source,bash]
 ----
 echo "*/15  *  *  *  * /var/www/owncloud/occ system:cron" \
   > /var/spool/cron/crontabs/www-data
@@ -225,7 +225,7 @@ chmod 0600 /var/spool/cron/crontabs/www-data
 If you need to sync your users from an LDAP or Active Directory Server, add this additional xref:configuration/server/background_jobs_configuration.adoc[Cron job]. Every 15 minutes this cron job will sync LDAP users in ownCloud and disable the ones who are not available for ownCloud. Additionally, you get a log file in `/var/log/ldap-sync/user-sync.log` for debugging.
 ====
 
-[source]
+[source,bash]
 ----
 echo "*/15 * * * * /var/www/owncloud/occ user:sync 'OCA\User_LDAP\User_Proxy' -m disable -vvv >> /var/log/ldap-sync/user-sync.log 2>&1" >> /var/spool/cron/crontabs/www-data
 chown www-data.crontab  /var/spool/cron/crontabs/www-data
@@ -237,7 +237,7 @@ chown www-data. /var/log/ldap-sync/user-sync.log
 
 === Configure Caching and File Locking
 
-[source,php]
+[source,bash]
 ----
 occ config:system:set \
    memcache.local \
@@ -253,7 +253,7 @@ occ config:system:set \
 
 === Configure Log Rotation
 
-[source,console]
+[source,bash]
 ----
 FILE="/etc/logrotate.d/owncloud"
 sudo /bin/cat <<EOM >$FILE
@@ -272,7 +272,7 @@ EOM
 
 Make sure the permissions are correct:
 
-[source,console]
+[source,bash]
 ----
 cd /var/www/
 chown -R www-data. owncloud
@@ -282,7 +282,7 @@ chown -R www-data. owncloud
 
 To check if you have installed the correct vesion of ownCloud and that the occ command is working, execute the following:
 
-[source,console]
+[source,bash]
 ----
 occ -V
 ----

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -18,6 +18,7 @@ The following settings should work for most SELinux systems that use the
 default distro profiles. Run these commands as root, and remember to
 adjust the filepaths in these examples for your installation
 
+[source,console]
 ----
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud/config(/.*)?'
@@ -33,6 +34,7 @@ If you uninstall ownCloud you need to remove the ownCloud directory
 labels. To do this execute the following commands as root after
 uninstalling ownCloud
 
+[source,console]
 ----
 semanage fcontext -d '/var/www/html/owncloud/data(/.*)?'
 semanage fcontext -d '/var/www/html/owncloud/config(/.*)?'
@@ -47,6 +49,7 @@ restorecon -Rv '/var/www/html/owncloud/'
 If you have customized SELinux policies and these examples do not work,
 you must give the HTTP server write access to these directories:
 
+[source,text]
 ----
 /var/www/html/owncloud/data
 /var/www/html/owncloud/config
@@ -59,12 +62,14 @@ you must give the HTTP server write access to these directories:
 To enable updates via the ownCloud web interface, you may need this to
 enable writing to the ownCloud directories:
 
+[source,console]
 ----
 setsebool httpd_unified on
 ----
 
 When the update is completed, disable write access:
 
+[source,console]
 ----
 setsebool -P  httpd_unified  off
 ----
@@ -74,6 +79,7 @@ setsebool -P  httpd_unified  off
 For security reasons it’s suggested to disable write access to all
 folders in /var/www/ (default):
 
+[source,console]
 ----
 setsebool -P  httpd_unified  off
 ----
@@ -83,6 +89,7 @@ setsebool -P  httpd_unified  off
 An additional setting is needed if your installation is connecting to a
 remote database:
 
+[source,console]
 ----
 setsebool -P httpd_can_network_connect_db on
 ----
@@ -91,6 +98,7 @@ setsebool -P httpd_can_network_connect_db on
 
 Use this setting to allow LDAP connections:
 
+[source,console]
 ----
 setsebool -P httpd_can_connect_ldap on
 ----
@@ -101,6 +109,7 @@ ownCloud requires access to remote networks for functions such as
 Server-to-Server sharing, external storages or the ownCloud Marketplace.
 To allow this access use the following setting:
 
+[source,console]
 ----
 setsebool -P httpd_can_network_connect on
 ----
@@ -110,6 +119,7 @@ setsebool -P httpd_can_network_connect on
 This setting is not required if `httpd_can_network_connect` is already
 on:
 
+[source,console]
 ----
 setsebool -P httpd_can_network_memcache on
 ----
@@ -119,6 +129,7 @@ setsebool -P httpd_can_network_memcache on
 If you want to allow ownCloud to send out e-mail notifications via
 sendmail you need to use the following setting:
 
+[source,console]
 ----
 setsebool -P httpd_can_sendmail on
 ----
@@ -128,6 +139,7 @@ setsebool -P httpd_can_sendmail on
 If you have placed your datadir on a CIFS/SMB share use the following
 setting:
 
+[source,console]
 ----
 setsebool -P httpd_use_cifs on
 ----
@@ -137,6 +149,7 @@ setsebool -P httpd_use_cifs on
 If your owncloud data folder resides on a Fuse Filesystem (e.g. EncFS
 etc.), this setting is required as well:
 
+[source,console]
 ----
 setsebool -P httpd_use_fusefs on
 ----
@@ -146,6 +159,7 @@ setsebool -P httpd_use_fusefs on
 If you use the rainloop webmail client app which supports GPG/PGP, you
 might need this:
 
+[source,console]
 ----
 setsebool -P httpd_use_gpg on
 ----
@@ -157,6 +171,7 @@ setsebool -P httpd_use_gpg on
 For general Troubleshooting of SELinux and its profiles try to install
 the package `setroubleshoot` and run:
 
+[source,console]
 ----
 sealert -a /var/log/audit/audit.log > /path/to/mylogfile.txt
 ----
@@ -166,6 +181,7 @@ to get a report which helps you to configure your SELinux profiles.
 Another tool for troubleshooting is to enable a single ruleset for your
 ownCloud directory:
 
+[source,console]
 ----
 semanage fcontext -a -t httpd_sys_rw_content_t '/var/www/html/owncloud(/.*)?'
 restorecon -RF /var/www/html/owncloud

--- a/modules/admin_manual/pages/installation/troubleshooting.adoc
+++ b/modules/admin_manual/pages/installation/troubleshooting.adoc
@@ -5,6 +5,7 @@ your ownCloud log please refer to
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB with Binary Logging Enabled]
 for how to resolve it.
 
+[source,text]
 ----
 An unhandled exception has been thrown: exception ‘PDOException’ with message 'SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ----

--- a/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
@@ -27,7 +27,7 @@ IMPORTANT: If you have customized user home directories or a custom location for
 
 To ensure a consistent backup, stop your web server to prevent users from trying to access ownCloud via the web. As an alternative, you can stop serving the virtual host for ownCloud:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 sudo service apache2 stop
 ----
@@ -49,7 +49,7 @@ If you have installed your ownCloud server from our deprecated Open Build Servic
 
 If possible, simply copy the directories from your ownCloud installation to your backup location, for example by running the following command from the owncloud directory. The following example command copies all directories mentioned above:
 
-[source,console]
+[source,bash]
 ----
 rsync -Aax config data apps apps-external /oc-backupdir/
 ----
@@ -64,7 +64,7 @@ You can't just copy a database, but must use the database tools to make a correc
 
 Before backing up the database, set your ownCloud instance into maintenance mode:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----
@@ -75,7 +75,7 @@ NOTE: This guide uses a backup file name like `owncloud-dbbackup_<timestamp>.bak
 
 Depending on the database version and the setup, username and password may not be necessary. The general command to back up MySQL/MariaDB looks like this:
 
-[source,console]
+[source,bash]
 ----
 sudo mysqldump --single-transaction -h [server] \
  -u [username] -p [password] \
@@ -84,7 +84,7 @@ sudo mysqldump --single-transaction -h [server] \
 
 Example, replace username and password according your setup:
 
-[source,console]
+[source,bash]
 ----
 sudo mysqldump --single-transaction -h localhost \
  -u username -p password \
@@ -93,7 +93,7 @@ sudo mysqldump --single-transaction -h localhost \
 
 === SQLite
 
-[source,console]
+[source,bash]
 ----
 sqlite3 data/owncloud.db .dump > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 ----
@@ -111,7 +111,7 @@ PGPASSWORD="password" pg_dump [db_name] \
 
 Use this if you want to protect against an accidental deletion of cron entries, plan to restore to a different server like a physical migration or you need to set up a server from scratch.
 
-[source,console,subs="attributes+"]
+[source,bash]
 ----
 sudo crontab -u www-data -l > www-data_crontab.bak
 ----
@@ -123,14 +123,14 @@ sudo crontab -u www-data -l > www-data_crontab.bak
 Perform the following tasks to reactivate your ownCloud instance:
 
 .Bring back ownCloud into normal operation mode
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
 .Enable browser access
 Start your web server, or alternatively enable the virtual host serving ownCloud:
-[source,console]
+[source,bash]
 ----
 sudo service apache2 start
 ----

--- a/modules/admin_manual/pages/maintenance/backup_and_restore/restore.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/restore.adoc
@@ -25,7 +25,7 @@ IMPORTANT: If you have customized user home directories or a custom location for
 
 To ensure a secure restore process, stop your web server to prevent users from accessing ownCloud via the web. As an alternative, you can stop serving the virtual host for ownCloud:
 
-[source,console,subs="attributes+"]
+[source,bash]
 ----
 sudo service apache2 stop
 ----
@@ -50,7 +50,7 @@ After you have completed restoring files, see how to xref:installation/manual_in
 
 If possible, simply copy the directories from your backup to your new ownCloud environment, for example by running the following command from the backup directory. The following example command copies all directories mentioned above:
 
-[source,console]
+[source,bash]
 ----
 sudo rsync -Aax config data apps apps-external /var/www/owncloud/
 ----
@@ -61,7 +61,7 @@ There are many ways to restore normal files from backup. Use whatever method you
 
 Before restoring the database, set your ownCloud instance into maintenance mode:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----
@@ -72,14 +72,14 @@ NOTE: This guide assumes that your previous backup is called `owncloud-dbbackup.
 
 Depending on the database version and the setup, username and password may not be necessary. To restore MySQL/MariaDB:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 sudo mysql -h [server] -u [username] -p[password] [db_name] < owncloud-dbbackup.bak
 ----
 
 === SQLite
 
-[source,console]
+[source,bash]
 ----
 sudo rm data/owncloud.db
 sudo sqlite3 data/owncloud.db < owncloud-dbbackup.bak
@@ -174,20 +174,20 @@ If it's not suitable for yours, you might need to run an OCC command that does t
 Perform the following tasks to reactivate your ownCloud instance:
 
 .Update the systems data-fingerprint after a backup is restored
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:data-fingerprint
 ----
 
 .Bring back ownCloud into normal operation mode
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
 .Enable browser access
 Start your web server, or alternatively enable the virtual host serving ownCloud:
-[source,console]
+[source,bash]
 ----
 sudo service apache2 start
 ----
@@ -196,7 +196,7 @@ sudo service apache2 start
 
 This is only necessary if you accidentally deleted the crontab entries, or you're restoring to a different server to carry out a physical migration or you need to set up a server from scratch.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 sudo crontab -u www-data < www-data_crontab.bak
 ----

--- a/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
+++ b/modules/admin_manual/pages/maintenance/enable_maintenance.adoc
@@ -10,7 +10,7 @@ You must put your ownCloud server into maintenance mode before performing upgrad
 
 To enable maintenance mode, run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----
@@ -26,7 +26,7 @@ You may also put your server into this mode by editing config/config.php.
 
 To disable maintenance mode, run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -49,7 +49,7 @@ which requires three commands to be executed. These commands are:
 
 You can see an example of calling the commands listed below, configured to require no user interaction.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} encryption:decrypt-all --continue=yes && \
   {occ-command-example-prefix} encryption:disable --no-interaction && \
@@ -79,7 +79,7 @@ SELECT * FROM `oc_appconfig` WHERE `appid` LIKE 'encryption'
 With the database updated, next, the `files_encryption` directory needs to be removed.
 Below is an example of how to do so, to save you time.
 
-[source,console]
+[source,bash]
 ----
 cd <your owncloud root directory>
 find ./data* -name files_encryption -exec rm -rvf {} \;
@@ -97,7 +97,7 @@ This requires the following steps:
 
 The following example shows how to do this on the command line.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable encryption && \
   {occ-command-example-prefix} encryption:enable && \

--- a/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
+++ b/modules/admin_manual/pages/maintenance/export_import_instance_data.adoc
@@ -41,7 +41,7 @@ NOTE: Test if you can create remote-shares before starting this process.
 
 This will create a folder `/tmp/export/user1` which contains all the files and metadata of the user.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} instance:export:user user1 /tmp/export
 ----
@@ -50,6 +50,7 @@ This will create a folder `/tmp/export/user1` which contains all the files and m
 
 Copy the created export to the target instance, for example using `scp`:
 
+[source,bash]
 ----
 scp -rp /tmp/export root@newinstance.com:/tmp/export
 ----
@@ -59,7 +60,7 @@ scp -rp /tmp/export root@newinstance.com:/tmp/export
 This imports the user in to the target instance while converting all his outgoing-shares
 to federated shares pointing to the source instance:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} instance:import:user /tmp/export/user1
 ----
@@ -69,7 +70,7 @@ to federated shares pointing to the source instance:
 `user1` now lives on a target instance, therefore it is necessary to recreate all shares so that
 they point to the target instance. To do so run this command on the source instance:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} instance:export:migrate:share user1 https://newinstance.com
 ----
@@ -83,7 +84,7 @@ NOTE: This can not be undone!
 NOTE: If the user is stored in the ownCloud database, you need to manually reset his password
 on the target instance. See xref:known-limitations[Known Limitations] for further information.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} user:delete user1
 ----

--- a/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
+++ b/modules/admin_manual/pages/maintenance/manually-moving-data-folders.adoc
@@ -35,7 +35,7 @@ Look at each section below for a detailed description.
 
 To save time, here are the commands which you can copy/paste for Apache and rsync:
 
-[source,console]
+[source,bash]
 ----
 sudo service apache2 stop
 
@@ -51,14 +51,14 @@ NOTE: Check your commands for how to start or stop your webserver if you are not
 It is necessary to enable maintenance mode to avoid running cron jobs.
 To enable maintenance mode, run the following command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----
 
 To disable maintenance mode of your instance run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
@@ -150,7 +150,7 @@ Individual apps may reference the data directory separately from the core system
 For those apps, you have to change the configured path.
 Run the following command to list app configs.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:list
 ----
@@ -174,7 +174,7 @@ Here is an example of the output which you may see:
 In the example above, the app "fictitious" sets the data directory to `/var/www/owncloud/data`.
 Change this value by using the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set --value /mnt/owncloud/data fictitious datadir
 ----

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -105,14 +105,14 @@ this migration work:
 
 If not already available on the new server, make sure SSH is installed:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install ssh -y
 ----
 
 Next, edit ssh-config and enable root ssh login.
 
-[source,console]
+[source,bash]
 ----
 nano /etc/ssh/sshd_config
 PermitRootLogin yes
@@ -120,7 +120,7 @@ PermitRootLogin yes
 
 And then restart SSH.
 
-[source,console]
+[source,bash]
 ----
 sudo service ssh restart
 ----
@@ -134,7 +134,7 @@ Lastly, install ownCloud on the new server.
 The first step is to enable maintenance mode. To do that, use the
 following commands:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cd /var/www/owncloud/
 {occ-command-example-prefix} maintenance:mode --on
@@ -142,7 +142,7 @@ cd /var/www/owncloud/
 
 After that’s done, then wait a few minutes and stop your web server, in this case Apache:
 
-[source,console]
+[source,bash]
 ----
 sudo service apache2 stop
 ----
@@ -152,7 +152,7 @@ sudo service apache2 stop
 Now, you have to transfer the database from the old server to the new
 one. To do that, first backup the database.
 
-[source,console]
+[source,bash]
 ----
 cd /var/www/owncloud/
 mysqldump --single-transaction -h localhost \
@@ -161,14 +161,14 @@ mysqldump --single-transaction -h localhost \
 
 Then, export the database to the new server.
 
-[source,console]
+[source,bash]
 ----
 rsync -v owncloud-dbbackup.bak root@new_server_address:/var/www/owncloud
 ----
 
 With that completed, import the database on new server.
 
-[source,console]
+[source,bash]
 ----
 mysql -h localhost -u admin -ppassword owncloud < owncloud-dbbackup.bak
 ----
@@ -193,7 +193,7 @@ Either dumping your MyISAM tables separately from InnoDB tables or use `--lock-t
 The following ownCloud directories will be synced to the target instance:
 `apps`, `config` and `data`.
 
-[source,console]
+[source,bash]
 ----
 rsync -avt apps config data root@new_server_address:/var/www/owncloud
 ----
@@ -210,14 +210,14 @@ xref:maintenance/manually-moving-data-folders.adoc[the data directory migration 
 Now it’s time to finish the migration. To do that, on the new server,
 first verify that ownCloud is in maintenance mode.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode
 ----
 
 Next, start up the database and web server on the new machine.
 
-[source,console]
+[source,bash]
 ----
 sudo service mysql start
 sudo service apache2 start
@@ -228,7 +228,7 @@ instance, and confirm that you see the maintenance mode notice, and that
 no error messages occur. If both of these occur, take ownCloud out of
 maintenance mode.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
@@ -244,7 +244,7 @@ to `no` and restart ssh. To do that, run the following command:
 
 NOTE: This is a security measure and improves SSH security.
 
-[source,console]
+[source,bash]
 ----
 sudo service ssh restart
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/database_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/database_upgrade.adoc
@@ -40,7 +40,7 @@ Have a backup of your database to rollback in case of issues.
 
 . Set ownCloud in maintenance mode
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --on
 ----
@@ -49,15 +49,16 @@ Have a backup of your database to rollback in case of issues.
 +
 Stop your web server to prevent users from trying to access ownCloud via the web. As an alternative, you can stop serving the virtual host for ownCloud.
 +
-[source,console]
+Stop the web server:
++
+[source,bash]
 ----
-# Stop the web server
 sudo service apache2 stop
 ----
 
 . Run an occ command to prepare the database for the upgrade
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} db:restore-default-row-format
 ----
@@ -68,7 +69,7 @@ Follow the instructions in the {upgrade-mariadb-url}[Upgrading MariaDB] guide.
 
 . Set ownCloud back to normal operation mode:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
@@ -76,7 +77,7 @@ Follow the instructions in the {upgrade-mariadb-url}[Upgrading MariaDB] guide.
 . Enable browser access +
 Start your web server, Alternatively, enable the virtual host serving ownCloud again:
 +
-[source,console]
+[source,bash]
 ----
 sudo service apache2 start
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -34,9 +34,9 @@ TIP: In a clustered environment, check that all nodes are in maintenance mode.
 
 With those steps completed, stop your webserver to prevent users trying to access ownCloud via the web. As an alternative, you can stop serving the virtual host for ownCloud.
 
-[source,console]
+Stop the web server:
+[source,bash]
 ----
-# Stop the web server
 sudo service apache2 stop
 ----
 
@@ -53,12 +53,17 @@ or not listed in xref:installation/apps_supported.adoc[Supported Apps in ownClou
 
 . Disable Apps via Command Line
 +
-[source,console,subs="attributes+"]
+This command lists all apps by <app-id> and app version:
++
+[source,bash,subs="attributes+"]
 ----
-# This command lists all apps by <app-id> and app version
 {occ-command-example-prefix} app:list
-
-# This command disables the app with the given <app-id>
+----
++
+This command disables the app with the given <app-id>:
++
+[source,bash,subs="attributes+"]
+----
 {occ-command-example-prefix} app:disable <app-id>
 ----
 
@@ -76,7 +81,8 @@ If you have made changes in `.user.ini` located at the webroot of ownCloud, you 
 === Download the Latest Release
 
 Download the latest https://owncloud.org/download/[ownCloud server release] to the same location where your previous instance is located, in this example the default directory `/var/www/`.
-[source,console,subs="attributes+"]
+
+[source,bash,subs="attributes+"]
 ----
 cd /var/www/
 sudo wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2
@@ -104,10 +110,9 @@ After the upgrade is finished, you can re-run this script to secure the `.htacce
 
 Although you have already made a backup, move your current ownCloud directory to a different location for easy access later:
 
-[source,console]
+This example assumes Ubuntu Linux and MariaDB, rename the ownCloud directory:
+[source,bash]
 ----
-# This example assumes Ubuntu Linux and MariaDB
-# Rename ownCloud directory
 sudo mv /var/www/owncloud /var/www/backup_owncloud
 ----
 
@@ -115,7 +120,7 @@ sudo mv /var/www/owncloud /var/www/backup_owncloud
 
 Extract the new server release in the location where your previous ownCloud installation used to be.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 sudo tar -xf {oc-complete-name}.tar.bz2
 ----
@@ -124,7 +129,7 @@ sudo tar -xf {oc-complete-name}.tar.bz2
 
 If you keep your `data/` directory _inside_ your `owncloud/` directory, move it from your old version of ownCloud to your new version:
 
-[source,console]
+[source,bash]
 ----
 sudo mv /var/www/backup_owncloud/data /var/www/owncloud/data
 ----
@@ -137,7 +142,7 @@ If you keep your `data` **outside** of your `owncloud` directory, then you donâ€
 
 With the new source files now in place of where the old ones used to be, copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
 
-[source,console]
+[source,bash]
 ----
 sudo cp /var/www/backup_owncloud/config/config.php /var/www/owncloud/config/config.php
 ----
@@ -153,7 +158,8 @@ In addition, if there are installed apps (whether compatible or incompatible wit
 If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` or `/var/www/owncloud/apps-external/` directory to see if they are present. If not, copy them from your old instance to your new one.
 
 NOTE: Make sure that all app directories that are defined in the `apps_paths` section of your `config.php` file do exist in your new `/var/www/owncloud/` directory. Also, make sure, that all app directories listed in `apps_path` actually exist. If `occ` complains about missing `apps-external` then try
-[source,console]
+
+[source,bash]
 ----
 sudo mkdir /var/www/owncloud/apps-external
 ----
@@ -165,19 +171,19 @@ To finalize the preparation of the upgrade, you need to set the correct ownershi
 .Set correct ownership
 Set the ownership for all files and folders to `root:www-data` **except** the `config` and `data` directory:
 
-[source,console]
+[source,bash]
 ----
 sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type d -exec chown root:www-data {} \+
 ----
 
-[source,console]
+[source,bash]
 ----
 sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type f -exec chown root:www-data {} \+
 ----
 
 Set the ownership for all files and folders to `www-data:www-data` for the `config` and `data` directory. Note that it is not mandatory to set the ownership of the `data/` directory as it should already have the correct ownership and it can take a while to finish, depending on the size:
 
-[source,console]
+[source,bash]
 ----
 sudo chown -R www-data:www-data /var/www/owncloud/config
 sudo chown -R www-data:www-data /var/www/owncloud/data
@@ -188,14 +194,14 @@ Use `chmod` on files and directories with different permissions:
 
 * For all files use `0640`
 +
-[source,console]
+[source,bash]
 ----
 sudo find /var/www/owncloud -type f -exec chmod 640 {} \;
 ----
 
 * For all directories use `0750`
 +
-[source,console]
+[source,bash]
 ----
 sudo find /var/www/owncloud -type d -exec chmod 750 {} \;
 ----
@@ -208,7 +214,7 @@ If you have configured a script for xref:installation/manual_installation/script
 
 With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 # Here is an example on Ubuntu Linux. 
 # Execute this within the ownCloud root folder.
@@ -222,7 +228,8 @@ The upgrade operation can take anywhere from a few minutes to a few hours, depen
 Reapply any manual changes made to `.htaccess` files and the `.user.ini` file located in the owncloud webroot. 
 
 The following example command eases to find the differences of two files, which is helpful for reapplying manually added changes to `.htaccess` and `.user.ini`. Replace that paths, directories and files accordingly.
-[source,console]
+
+[source,bash]
 ----
 diff -y -W 70 --suppress-common-lines owncloud/.user.ini owncloud_2022-02-15-09.18.48/.user.ini
 post_max_size=513M                |     post_max_size=1G
@@ -236,11 +243,10 @@ If you have configured a script for xref:installation/manual_installation/script
 
 === Disable Maintenance Mode
 
-Assuming your upgrade succeeded, disable maintenance mode.
+Assuming your upgrade succeeded, disable maintenance mode using the occ command.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
-# Disable maintenance mode using the occ command.
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
@@ -248,7 +254,7 @@ Assuming your upgrade succeeded, disable maintenance mode.
 
 With all that done, restart your web server, or alternatively re-enable the virtual host serving ownCloud:
 
-[source,console]
+[source,bash]
 ----
 sudo service apache2 start
 ----
@@ -287,7 +293,7 @@ Please refer to xref:configuration/database/linux_database_configuration.adoc#my
 In the unlikely case that files do not show up in the web-ui after the upgrade, use the xref:configuration/server/occ_command.adoc#the-filesscan-command[files:scan command] to make them visible again.
 Here is an example of how to do so:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --all
 ----
@@ -298,21 +304,21 @@ Sometimes, ownCloud can get _stuck in an upgrade_.
 This is usually due to the process taking too long and running into a PHP time-out.
 Stop the upgrade process this way:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
 Then start the manual process:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ----
 
 If this does not work properly, try the repair function:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:repair
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
@@ -38,14 +38,14 @@ xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#changes-in-9-1[re
 
 Upgrading ownCloud from our {oc-install-package-url}[package repositories] works like any normal Linux upgrade. For example, on Debian or Ubuntu Linux the standard system upgrade command is:
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get update && apt-get upgrade
 ----
 
 Or you can upgrade just ownCloud with this command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt-get update && apt-get install owncloud-files
 ----
@@ -53,21 +53,21 @@ sudo apt-get update && apt-get install owncloud-files
 On Fedora, CentOS, and Red Hat Linux use `yum` to see all available
 updates:
 
-[source,console]
+[source,bash]
 ----
 sudo yum check-update
 ----
 
 You can apply all available updates with this command:
 
-[source,console]
+[source,bash]
 ----
 sudo yum update
 ----
 
 Or update only ownCloud:
 
-[source,console]
+[source,bash]
 ----
 sudo yum update owncloud-files
 ----
@@ -78,7 +78,7 @@ image:upgrade-1.png[image]
 
 Then use `occ` to complete the upgrade. You must run `occ` as your HTTP user. This example is for Debian/Ubuntu as well as CentOS/RHEL/Fedora:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/update.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/update.adoc
@@ -78,7 +78,7 @@ running it as your HTTP user, instead of clicking the btn:[Start Update] button,
 
 This example is for Ubuntu Linux:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} upgrade
 ----
@@ -110,6 +110,7 @@ Replace the `ocpath` variable with the path to your ownCloud directory,
 and replace the `htuser` and `htgroup` variables with your HTTP user and
 group.
 
+[source,bash]
 ----
 #!/bin/bash
 # Sets permissions of the owncloud instance for updating
@@ -141,28 +142,28 @@ create checkpoints and to roll back to older checkpoints. You must run
 it as your HTTP user. This example on Ubuntu Linux displays command
 options:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php list
 ----
 
 See usage for commands, like this example for the `upgrade:checkpoint` command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint -h
 ----
 
 You can display a help summary:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php --help
 ----
 
 When you run it without options it runs a system check:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} owncloud/updater/application.php
 ownCloud updater 1.0 - CLI based ownCloud server upgrades
@@ -175,7 +176,7 @@ Done
 
 Create a checkpoint:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --create
 Created checkpoint 9.0.0.12-56d5e4e004964
@@ -183,15 +184,14 @@ Created checkpoint 9.0.0.12-56d5e4e004964
 
 List checkpoints:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php upgrade:checkpoint --list
-[source,console]
 ----
 
 Restore an earlier checkpoint:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} updater/application.php \
     upgrade:checkpoint --restore=9.0.0.12-56d5e4e004964
@@ -199,7 +199,7 @@ Restore an earlier checkpoint:
 
 Add a line like this to your crontab to automatically create daily checkpoints:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 2 15 * * * {occ-command-example-prefix} /path/to/owncloud/updater/application.php
 upgrade:checkpoint --create > /dev/null 2>&1
@@ -214,7 +214,7 @@ to enter the unhashed secret into the web form.
 In case you forgot your password/secret, you can re-create it by
 changing config.php. You can run this on your shell:
 
-[source,console]
+[source,bash]
 ----
 php -r 'echo password_hash("Enter a random password here", PASSWORD_DEFAULT)."\n";'
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -20,7 +20,7 @@ include::partial$/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 
 Finally, you need to restart Apache to make the changes permanent, as in the command below.
 
-[source,console]
+[source,bash]
 ----
 service httpd restart
 ----

--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -112,7 +112,7 @@ image:qnap/DDNS_qnap-cropped.png[DDNS Configuration on QNAP]
 If you want to assign a static IP address, you need to access your QNAP device via `ssh` on the command line and edit the file `custom/user.config.php` in your top-level ownCloud app directory, e.g. `/share/CACHEDEV1_DATA/.qpkg/ownCloud`.
 Create an entry like in the following example with the correct IP address:
 
-[source,console]
+[source,php]
 ----
 <?php
 $CONFIG = array(
@@ -170,7 +170,7 @@ You are logged in to the QNAP NAS Console Management - Main menu.
 
 Open a terminal and enter the command:
 
-[source,console]
+[source,bash]
 ----
 ssh admin@<your-nas-IP>
 ----
@@ -181,7 +181,7 @@ Enter the admin user's password and you'll be in the QNAP Console Management - M
 
 In the Console Management you have several options that might be useful at some point:
 
-[source,console]
+[source,text]
 ----
  +-------------------------------------------------------------------------+
   |  Console Management - Main menu                                         |
@@ -212,7 +212,7 @@ To issue `occ` commands, you need to use `ssh` to log in to your QNAP device. Th
 
 ownCloud on QNAP lives in a Docker container, therefore `occ` commands look a little different than on regular installations. The prefix `docker exec` is needed:
 
-[source,console]
+[source,bash]
 ----
 docker exec --user www-data <owncloud-container-name> php occ <your-command>
 ----
@@ -225,7 +225,7 @@ CAUTION: Unless you know exactly what you are doing, you shouldn't run commands 
 
 To prevent data loss, the ownCloud database should be backed up regularly. To do so, you need to log in to your QNAP device via `ssh` and navigate to the ownCloud app root directory, e.g. `/share/CACHEDEV1_DATA/.qpkg/ownCloud`. Here you can create a database snapshot with a time stamp by entering the following command:
 
-[source,console]
+[source,docker]
 ----
 system-docker-compose exec db pg_dumpall -c -U owncloud > \
   ownCloud_database_$(date +%Y-%m-%d_%H_%M_%S).sql
@@ -235,13 +235,21 @@ For more information, see section xref:maintenance/backup_and_restore/backup.ado
 
 Should something happen and you need to restore the data, perform the following commands:
 
-[source,console]
+Delete / drop the current database
+[source,docker]
 ----
-# delete / drop the current database
 system-docker-compose exec db dropdb owncloud -U owncloud
-# create new database
+----
+
+Create a new database
+[source,docker]
+----
 system-docker-compose exec db createdb owncloud -U owncloud
-# restore data to database
+----
+
+Restore data to database
+[source,bash]
+----
 cat ownCloud_database_xxxxx.sql | system-docker-compose exec \
    -T db psql -U owncloud -d owncloud
 ----

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -18,12 +18,14 @@ Please note that you have to have the configreport app enabled.
 Check if it's already enabled by going to the apps section of the admin settings.
 You can enable this app using the following commands:
 
-[source,console,subs="attributes+"]
+Install it, if it’s not already installed:
+[source,bash,subs="attributes+"]
 ----
-# Install it, if it’s not already installed
 {occ-command-example-prefix} market:install configreport
 
-# Or enable it, if it’s already installed
+Or enable it, if it’s already installed:
+[source,bash,subs="attributes+"]
+----
 {occ-command-example-prefix}:app enable configreport
 ----
 
@@ -36,11 +38,10 @@ menu:Settings[Admin > General > "Generate Config report" > "Download ownCloud co
 
 To generate a config report from the command line, run the following command from the root directory of your ownCloud installation:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} configreport:generate > config_report.txt
 ----
-
 
 == ownCloud Server Log File
 
@@ -54,15 +55,17 @@ menu:Settings[Admin > General > Log > "Download logfile"].
 If the log file is too big, you will need to transfer it from the command line. 
 The location of the log file can be found in your config.php. It's in your data directory. 
 
-....
+[source,php]
+----
  'datadirectory' => '/var/www/owncloud/data',
-....
+----
 
 You also can specify a different location of the log file.
 
-....
+[source,php]
+----
 'logfile' => '/home/www-data/owncloud.log',
-....
+----
 
 Note that the web server user has to have rights to write in that directory.
 
@@ -71,7 +74,7 @@ Note that the web server user has to have rights to write in that directory.
 Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server.
 To get the output file, execute this command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} ldap:show-config > ldap_config.txt
 ----

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -22,6 +22,7 @@ Install it, if it’s not already installed:
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install configreport
+----
 
 Or enable it, if it’s already installed:
 [source,bash,subs="attributes+"]

--- a/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
+++ b/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
@@ -33,14 +33,14 @@ It is also possible that a background job is triggered manually by the admin whe
 
 Use the following command to list all active background jobs triggered by ownCloud:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:status
 ----
 
 The output may look like the following:
 
-[source,console]
+[source,text]
 ----
 +----+---------------------------------------------------+---------------------------+---------------+
 | Id | Job                                               | Last run                  | Job Arguments |
@@ -57,7 +57,7 @@ The output may look like the following:
 
 When you have identified the `ID` of the background job to  be removed, run following command to remove it, replace `ID` with the job number of the list:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} background:queue:delete ID
 ----
@@ -68,14 +68,14 @@ WARNING: Deleting a job cannot be undone. Be sure that you want to delete the jo
 
 If an erroring job as been added manually in `crontab`, remove the job from the crontab queue list. First, list the entries of crontab for the web server user:
 
-[source,console]
+[source,bash]
 ----
 sudo -uwww-data crontab -l
 ----
 
 Then edit the crontab job list to remove the job by invoking following command:
 
-[source,console]
+[source,bash]
 ----
 sudo -uwww-data crontab -e
 ----

--- a/modules/admin_manual/partials/configuration/server/disable-single-user-mode.adoc
+++ b/modules/admin_manual/partials/configuration/server/disable-single-user-mode.adoc
@@ -2,8 +2,7 @@
 
 With encryption migrated from User Key-based encryption to Master Key-based, disable single user mode, if you xref:configuration/server/occ_command.adoc#maintenance-commands[enabled it] before beginning the migration.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --off
 ----
-

--- a/modules/admin_manual/partials/configuration/server/enable-single-user-mode.adoc
+++ b/modules/admin_manual/partials/configuration/server/enable-single-user-mode.adoc
@@ -3,8 +3,7 @@
 We strongly encourage you to put your server in single user mode before setting up encryption.
 To do so, run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:singleuser --on
 ----
-

--- a/modules/admin_manual/partials/configuration/server/occ_command/system_command.adoc
+++ b/modules/admin_manual/partials/configuration/server/occ_command/system_command.adoc
@@ -6,7 +6,7 @@
   system:cron             Execute background jobs as cron
 ----
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} -h system:cron
 -Usage:
@@ -24,7 +24,7 @@ Do not use when executing from crontab
 
 To execute xref:configuration/server/background_jobs_configuration.adoc[background jobs] using xref:configuration/server/background_jobs_configuration.adoc#cron[cron], you can use the `system:cron` command, as in the following example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} system:cron
 ----
@@ -49,12 +49,15 @@ However, in a non-interactive environment, such as crontab, it should not be use
 If you have already automated background jobs via Cron, you must update the relevant `crontab` entry
 using the example below as a guide.
 
+Instead of the following configuration
 [source,console,subs="attributes+"]
 ----
-# Instead of the following configuration
 /usr/bin/php -f /path/to/your/owncloud/cron.php
+----
 
-# Use the following one instead
+Use the following one instead
+[source,bash,subs="attributes+"]
+----
 {occ-command-example-prefix} system:cron
 ----
 ====

--- a/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
@@ -8,7 +8,7 @@ Use these commands to install MariaDB provided by Ubuntu and secure its installa
 
 NOTE: At the time of writing, with Ubuntu 20.04, `mariadb-server` version `10.4.21` will be installed:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install mariadb-server
 sudo mysql_secure_installation
@@ -16,13 +16,14 @@ sudo mysql_secure_installation
 
 Check access and the version of MariaDB, replace `<admin_user>` as either defined during `mysql_secure_installation` above or use e.g. `root`.
 
-[source,console]
+[source,bash]
 ----
 sudo mysqladmin -u <admin_user> -p version
 ----
 
 If you get output like below, your database is up and running and ready to serve requests.
 
+[source,text]
 ----
 mysqladmin  Ver 9.1 Distrib 10.4.21-MariaDB, for debian-linux-gnu on x86_64
 Copyright (c) 2000, 2021, Oracle, MariaDB Corporation Ab and others.
@@ -54,7 +55,7 @@ WARNING: You must not skip minor releases of MariaDB when upgrading like from 10
 ====
 If you have an existing installation of MariaDB and upgrade to a higher version, do not forget to run the following command to handle the new setup for admin users — especially when running an older version of MariaDB and upgrading to MariaDB 10.4.3 upwards:
 
-[source,console]
+[source,bash]
 ----
 sudo mysql_upgrade 
 ----
@@ -69,7 +70,7 @@ For MariaDB server releases lower than 10.4.3, you will be prompted during the i
 
 To install an ownCloud database, you need an administrative user who can log in, has rights to create/modify databases and users. If this user does not exist, like on MariaDB server releases higher than 10.4.3, or if you want to create a temporary user for this task, you manually have to create one. You will be asked for the mysql root user's password:
 
-[source,console]
+[source,bash]
 ----
 sudo mysql --user=root -p
 
@@ -88,7 +89,7 @@ From MariaDB 10.4.3 onwards, the authentication method has changed to UNIX socke
 _This is not the ownCloud user!_ +
 _Don't forget to change the username and password according to your needs_.
 
-[source,console]
+[source,bash]
 ----
 sudo mysql
 MariaDB [(none)]>
@@ -103,11 +104,18 @@ MariaDB [(none)]>
 
 If you want to install phpMyAdmin as a graphical interface for administering the database, run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo apt install phpmyadmin
 ----
 
 After the installation, you need to configure your web server to access `phpmyadmin`. This is a manual task, depending on what your setup looks like and is not part of this documentation.
 
-NOTE: You can run `sudo dpkg-reconfigure phpmyadmin` to reconfigure phpmyadmin. 
+[NOTE]
+====
+You can run
+[source,bash]
+----
+sudo dpkg-reconfigure phpmyadmin
+----
+to reconfigure phpmyadmin. 

--- a/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
@@ -118,4 +118,6 @@ You can run
 ----
 sudo dpkg-reconfigure phpmyadmin
 ----
-to reconfigure phpmyadmin. 
+to reconfigure phpmyadmin.
+====
+ 

--- a/modules/admin_manual/partials/installation/manual_installation/useful_tips.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/useful_tips.adoc
@@ -29,7 +29,7 @@ resource:foreign_path local_path nfs (<your options>),_netdev
 * Make sure that all mounts in `/etc/fstab` are mounted by running:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo mount -a
 ----
@@ -38,7 +38,7 @@ sudo mount -a
 * Run the following command to list mounts which must be up first:
 +
 --
-[source,console]
+[source,bash]
 ----
 systemctl list-units | grep -nP "\.mount"
 ----
@@ -57,14 +57,14 @@ where `<folder.mount>` and `<local_path>` are examples!
 * Edit the service you want to change:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo systemctl edit <name>.service
 ----
 
 Add the following directive in the editor opened, using your chosen `folder.mount` from above:
 
-[source,console]
+[source,text]
 ----
 [Unit]
 After=folder.mount
@@ -93,7 +93,7 @@ It is recommended to keep things simple and future-proof by creating an override
 * Run the following command to apply your changes:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 ----
@@ -102,7 +102,7 @@ sudo systemctl daemon-reload
 * Check if `<name>.service` has been properly added:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo systemctl show <name>.service | grep "After="
 ----
@@ -112,7 +112,7 @@ sudo systemctl show <name>.service | grep "After="
 * Restart your service by invoking:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo system <name> restart
 ----
@@ -129,7 +129,7 @@ To disable Transparent Huge Pages, follow these steps:
 * Create in `/etc/systemd/system` a file like `disable-thp.service` add the following content:
 +
 --
-[source,console]
+[source,text]
 ----
 [Unit]
 Description=Disable Transparent Huge Pages
@@ -150,7 +150,7 @@ WantedBy=basic.target
 * Run the following command to apply and activate your changes and start it automatically at boot time:
 +
 --
-[source,console]
+[source,bash]
 ----
 sudo systemctl daemon-reload
 sudo systemctl enable disable-thp

--- a/modules/admin_manual/partials/maintenance/upgrading/upgrade_steps.adoc
+++ b/modules/admin_manual/partials/maintenance/upgrading/upgrade_steps.adoc
@@ -9,12 +9,15 @@ This documentation uses the same command as you will find there.
 Ensure that you have `subscription-manager` installed.
 If you don't, yet, have it installed, do so with the following command:
 
-[source,console]
+Install subscription manager
+[source,bash]
 ----
-# Install subscription manager
 yum install --assumeyes subscription-manager
+----
 
-# Add the required repositories for the PHP packages
+Add the required repositories for the PHP packages
+[source,bash]
+----
 subscription-manager repos --enable rhel-server-rhscl-7-rpms
 ----
 ====
@@ -24,7 +27,7 @@ subscription-manager repos --enable rhel-server-rhscl-7-rpms
 Then, proceed by installing the required PHP {to-version} packages. 
 You can use the command below to save you time.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 yum install \
   rh-php{to-pkg-version} \
@@ -50,7 +53,7 @@ yum install \
 Next, you need to enable PHP {to-version} and disable PHP {from-version} system-wide. 
 To enable PHP {to-version} system-wide, run the following command:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cp /opt/rh/rh-php{to-pkg-version}/enable /etc/profile.d/rh-php{to-pkg-version}.sh source /opt/rh/rh-php{to-pkg-version}/enable
 ----
@@ -58,7 +61,7 @@ cp /opt/rh/rh-php{to-pkg-version}/enable /etc/profile.d/rh-php{to-pkg-version}.s
 Then, you need to disable loading of the PHP {from-version} Apache modules. 
 You can do this either by changing their names, as in the example below, or deleting the files.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 mv /etc/httpd/conf.d/php.conf /etc/httpd/conf.d/php56.off
 mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php56.off
@@ -68,7 +71,7 @@ mv /etc/httpd/conf.modules.d/10-php.conf /etc/httpd/conf.modules.d/10-php56.off
 
 With that done, you next need to copy the PHP {to-version} Apache modules into place; that being the two Apache configuration files and the shared object file.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 cp /opt/rh/httpd24/root/etc/httpd/conf.d/rh-php{to-pkg-version}-php.conf /etc/httpd/conf.d/
 cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/15-rh-php{to-pkg-version}-php.conf /etc/httpd/conf.modules.d/


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-server/issues/94 ([QA] Manual copy / paste misses redirects)
References: https://github.com/owncloud/docs-ui/pull/435 (Fix and improve highlighting with highlight.js)

Correct the source language used in code blocks.

* `console` -> `bash` where necessary
* adding `[source,<language>]` where missing
* comments moved out from a command and added above the source block where necessary
* added missing source attribute usage in a view occ commands

Note to make the change visible, the `docs-ui` PR must be merged. There is no order required.

Backport to 10.9 and 10.8
Note (extra care to ba taken as some content is not available in 10.8 like richdocuments (occ commands). This needs to be removed manually in the PR preperation