### PR TITLE
Source language fix for harden server

### DIFF
--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -72,7 +72,6 @@ With this information, you can begin customizing a rate-limiting solution specif
 
 === Give PHP read access to `/dev/urandom`
 
-
 ownCloud uses a https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086 (`Randomness Requirements for Security`)]
 compliant mixer to generate cryptographically secure pseudo-random numbers.
 When generating a random number, ownCloud will request multiple random
@@ -93,7 +92,6 @@ where possible. See xref:installation/selinux_configuration.adoc[SELinux Configu
 === Place data directory outside of the web root
 
 A simple but efficient way to increase the security of your data is to place your `data` directory outside of the Web root (i.e. outside of `/var/www`), ideally at the time of installation.
-
 
 === Disable preview image generation
 
@@ -128,6 +126,7 @@ this can be achieved by adding a setting such as the following in the
 Apache VirtualHosts configuration containing the `<VirtualHost *:80>`
 entry:
 
+[source,apache]
 ----
 Redirect permanent / https://example.com/
 ----
@@ -184,7 +183,7 @@ attack.
 == Use a dedicated domain for ownCloud
 
 Administrators are encouraged to install ownCloud on a dedicated domain
-such as cloud.domain.tld instead of domain.tld to benefit
+such as `cloud.domain.tld` instead of `domain.tld` to benefit
 from the same-origin policy.
 
 == Ensure that your ownCloud instance is installed in a DMZ
@@ -304,6 +303,7 @@ This filter needs to be loaded when Fail2ban starts, so a further
 configuration entry is required to be added in
 `/etc/fail2ban/jail.d/defaults-debian.conf`, which you can see below:
 
+[source,conf]
 ----
 [owncloud]
 enabled = true
@@ -326,6 +326,7 @@ If this does not point to the correct log file, Fail2ban will either not work pr
 
 After saving the file, restart Fail2ban by running the following command:
 
+[source,bash]
 ----
 service fail2ban restart
 ----
@@ -333,6 +334,7 @@ service fail2ban restart
 To test that the new ownCloud configuration has been loaded, use the
 following command:
 
+[source,bash]
 ----
 fail2ban-client status
 ----
@@ -341,6 +343,7 @@ If "owncloud" is listed in the console output, the filter is both
 loaded and active. If you want to test the filter, run the following
 command, adjusting the path to your `owncloud.log` if necessary:
 
+[source,bash]
 ----
 fail2ban-regex /var/owncloud_data/owncloud.log /etc/fail2ban/filter.d/owncloud.conf
 ----
@@ -348,6 +351,7 @@ fail2ban-regex /var/owncloud_data/owncloud.log /etc/fail2ban/filter.d/owncloud.c
 The output will look similar to the following if you had one failed
 login attempt:
 
+[source,bash]
 ----
 fail2ban-regex /var/www/owncloud_data/owncloud.log /etc/fail2ban/filter.d/owncloud.conf
 
@@ -379,6 +383,7 @@ The `Failregex` counter increases in increments of 1 for every failed login atte
 To unban an IP locked either during testing or
 unintentionally, use the following command:
 
+[source,bash]
 ----
 fail2ban-client set owncloud unbanip <IP>
 ----
@@ -386,6 +391,7 @@ fail2ban-client set owncloud unbanip <IP>
 You can check the status of your ownCloud filter with the following
 command:
 
+[source,bash]
 ----
 fail2ban-client status owncloud
 ----

--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -46,7 +46,7 @@ image:qnap/qnap_main_menu.png[QNAP Main Menu and ownCloud installed]
 
 === First Steps
 
-Log in as user `admin`. The default password is `admin` until you change it. In the upper right-hand corner, click on menu:admin[Settings]. In the left-hand navigation bar, you find personal configuration options and administration-specific options. Under menu:Personal[General] you can change the password of your admin user.
+Log in as user `admin`. The default password is `admin` until you change it. In the upper right-hand corner, click on menu:Admin[Settings]. In the left-hand navigation bar, you find personal configuration options and administration-specific options. Under menu:Personal[General] you can change the password of your admin user.
 
 For more information on the web interface, refer to the xref:user_manual:webinterface.adoc[Web UI] documentation.
 
@@ -70,13 +70,13 @@ A key feature of ownCloud is to allow users to share files. In the free communit
 
 . An email server must be configured and working.
 
-. To share files with external users, the Guests app must be installed and enabled in menu:admin[Settings > Admin > Apps]. For detailed information on the Guests app, see the xref:configuration/user/guests_app.adoc[Guests App section].
+. To share files with external users, the Guests app must be installed and enabled in menu:Settings[Admin > Apps]. For detailed information on the Guests app, see the xref:configuration/user/guests_app.adoc[Guests App section].
 +
 image:qnap/marketplace.png[ownCloud Marketplace and Guests App]
 
 === Managing Users
 
-In the menu:admin[Users] section you can create, disable, enable or delete users, add them to groups, grant administrator privileges and more.
+In the menu:Admin[Users] section you can create, disable, enable or delete users, add them to groups, grant administrator privileges and more.
 
 image:qnap/users_on_qnap.png[User Management]
 
@@ -89,7 +89,7 @@ Once a regular user shares a file or folder specifying an external email address
 == Enabling ownCloud Apps
 
 With the free community edition, you can use all apps that are published under the GPL or similar public licenses, e.g. the GNU Affero General Public License. These apps you can simply enable and enjoy.
-In the upper left corner, click on the main menu with the three bars, select menu:Market and install what you like.
+In the upper left corner, click on the main menu with the three bars, select menu:Market[] and install what you like.
 
 image:qnap/ownCloud_main_menu.png[ownCloud Main Menu]
 
@@ -105,7 +105,7 @@ Users can also be enabled or disabled via `occ` commands. For more information o
 
 == Accessing your QNAP ownCloud from the Internet
 
-If you want to connect to your ownCloud on QNAP from the Internet, you need to configure the network accordingly. In the menu:Main menu of your QNAP NAS, select menu:SYSTEMS[Network & Virtual Switch]. Under "Access Services" click on menu:DDNS (Dynamic Domain Name Service) then btn[Add]. Here you can configure the DDNS settings.
+If you want to connect to your ownCloud on QNAP from the Internet, you need to configure the network accordingly. In the btn:[Main] menu of your QNAP NAS, select menu:SYSTEMS[Network & Virtual Switch]. Under "Access Services" click on menu:DDNS (Dynamic Domain Name Service)[] then btn:[Add]. Here you can configure the DDNS settings.
 
 image:qnap/DDNS_qnap-cropped.png[DDNS Configuration on QNAP]
 
@@ -115,7 +115,7 @@ Create an entry like in the following example with the correct IP address:
 [source,php]
 ----
 <?php
-$CONFIG = array(
+CONFIG = array(
     'overwriteprotocol' => 'https',
     'overwritehost' => '203.0.113.0',
     'overwrite.cli.url' => 'https://203.0.113.0/owncloud/',
@@ -136,8 +136,7 @@ For more information on command-line access, see below.
 
 Besides logging in to ownCloud via the web interface, you can access it from iOS and Android devices by installing the respective apps, and there are desktop clients available for Windows, Mac OS X and various Linux distributions.
 
-For more information, check out the ownCloud documentation on clients:
-https://doc.owncloud.com/server/10.8/#desktop-client-and-mobile-apps
+For more information, check out the xref:next@docs:ROOT:client_releases.adoc[ownCloud Client Releases]
 
 == Using External Storage
 
@@ -165,7 +164,6 @@ On Windows you need to install PuTTY from a source you trust, then start PuTTY a
 
 You are logged in to the QNAP NAS Console Management - Main menu.
 
-
 === Access From Linux or OSX machines
 
 Open a terminal and enter the command:
@@ -183,21 +181,21 @@ In the Console Management you have several options that might be useful at some 
 
 [source,text]
 ----
- +-------------------------------------------------------------------------+
-  |  Console Management - Main menu                                         |
-  |                                                                         |
-  |  1: Show network settings                                               |
-  |  2: System event logs                                                   |
-  |  3: Reset to factory default (password required)                        |
-  |  4: Activate/ deactivate a license                                      |
-  |  5: App management                                                      |
-  |  6: Reboot in Rescue mode (w/o configured disk)                         |
-  |  7: Reboot in Maintenance Mode                                          |
-  |  Q: Quit (return to normal shell environment)                           |
-  |                                                                         |
-  |                                                                         |
-  +-------------------------------------------------------------------------+
-  >>
++--------------------------------------------------------------------+
+|  Console Management - Main menu                                    |
+|                                                                    |
+|  1: Show network settings                                          |
+|  2: System event logs                                              |
+|  3: Reset to factory default (password required)                   |
+|  4: Activate/ deactivate a license                                 |
+|  5: App management                                                 |
+|  6: Reboot in Rescue mode (w/o configured disk)                    |
+|  7: Reboot in Maintenance Mode                                     |
+|  Q: Quit (return to normal shell environment)                      |
+|                                                                    |
+|                                                                    |
++--------------------------------------------------------------------+
+ >>
 ----
 
 Press kbd:[q] to quit and confirm with kbd:[y] for yes and you'll be logged in with your regular shell.
@@ -212,7 +210,7 @@ To issue `occ` commands, you need to use `ssh` to log in to your QNAP device. Th
 
 ownCloud on QNAP lives in a Docker container, therefore `occ` commands look a little different than on regular installations. The prefix `system-docker-compose exec --user www-data owncloud` is needed:
 
-[source,bash]
+[source,docker]
 ----
 system-docker-compose exec --user www-data owncloud occ <your-command>
 ----
@@ -268,4 +266,4 @@ TIP: The event notifications in the top toolbar will also tell you if something 
 
 * What to do if you forgot to install the Container Station?
 
-An error message will pop up during the installation of ownCloud. Click on the link "System Event Log" in the pop-up window to find out what actually went wrong or hit btn:[OK] and install the Container Station. Then start the installation of ownCloud again.
+An error message will pop up during the installation of ownCloud. Click on the link btn:[System Event Log] in the pop-up window to find out what actually went wrong or hit btn:[OK] and install the Container Station. Then start the installation of ownCloud again.


### PR DESCRIPTION
Missed fixes for the harden server document

Note related, but added a qnap text fix as it needs the same backporting

Backport to 10.9 and 10.8