### PR TITLE
Updates to innodb tunning instructions,

### DIFF
--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -34,18 +34,12 @@ query_cache_size        = 128M
 
 #in InnoDB:
 innodb_flush_method=O_DIRECT
-innodb_flush_log_at_trx_commit=1
 innodb_log_file_size=256M
 innodb_log_buffer_size = 128M
 innodb_buffer_pool_size=2048M
 innodb_buffer_pool_instances=3
-innodb_read_io_threads=4
-innodb_write_io_threads=4
 innodb_io_capacity = 500
-innodb_thread_concurrency=2
 innodb_file_format=Barracuda
-innodb_file_per_table=ON
-innodb_large_prefix = 1
 character-set-server  = utf8mb4
 collation-server      = utf8mb4_general_ci
 ----


### PR DESCRIPTION
innodb_read_io_threads and innodb_write_io_thread defaults to 4, no need to change the defaulr

innodb_flush_log_at_trx_commit=1 is the default as well

innodb_thread_concurrency does nothing since  mariadb 10.5.5
innodb_file_per_table=ON same

innodb_large_prefix = 1 is a no-op, has not done anything since maria db 10.3