### PR TITLE
Set a source language when there is no set

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/certificates.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/certificates.adoc
@@ -9,6 +9,7 @@ to follow these three steps:
 your virtual machine or via ssh connection to your appliance.
 3.  Execute the following commands:
 
+[source,bash]
 ----
 ucr set apache2/ssl/certificate="/etc/myssl/cert.pem"
 ucr set apache2/ssl/key="/etc/myssl/private.key"
@@ -18,7 +19,7 @@ Remember to adjust the path and filename to match your certificate.
 
 Once you’ve completed these steps, restart Apache using the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo service apache2 restart
 ----
@@ -26,7 +27,7 @@ sudo service apache2 restart
 Now your certificates will be used to access your appliance.
 If you want to limit the access to your server exclusively to HTTPS, use this command:
 
-[source,console]
+[source,bash]
 ----
 sudo ucr set apache2/force_https=yes
 ----

--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -43,6 +43,7 @@ The installation should only take a few minutes.
 
 Start the ClamAV service:
 
+[source,bash]
 ----
 systemctl enable clamav-daemon.service
 systemctl start clamav-daemon.service
@@ -60,15 +61,16 @@ If you try to update the ClamAV virus database manually, by entering
 https://linux.die.net/man/1/freshclam[freshclam] is already updating the database.
 ""
 
+[source,plaintext]
 ----
 ERROR: /var/log/clamav/freshclam.log is locked by another process
 ERROR: Problem with internal logger (UpdateLogFile = /var/log/clamav/freshclam.log).
 ----
 
-
 Updates are run based on the configured time interval in the applicable
 Cron job. In the example below, the update would run every 47 minutes:
 
+[source,plaintext]
 ----
 # m   h  dom mon dow  command
 47  *  *   *    *  /usr/bin/freshclam --quiet
@@ -77,19 +79,22 @@ Cron job. In the example below, the update would run every 47 minutes:
 If there are errors running the freshclam process, check if a process is
 blocking the log file, by running the following command:
 
-[source,console]
+[source,bash]
 ----
 lsof /var/log/clamav/freshclam.log
 ----
 
-If you want to refresh the ClamAV database manually, follow these steps:
+If you want to refresh the ClamAV database manually, follow these steps and gently end the freshclam process with this command:
 
-[source,console]
+[source,bash]
 ----
-# Gently end the freshclam process with this command:
 sudo pkill -15 -x freshclam
+----
 
-# Start the refresh process again with this command:
+Start the refresh process again with this command:
+
+[source,bash]
+----
 sudo freshclam
 ----
 

--- a/modules/admin_manual/pages/appliance/configuration/office.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/office.adoc
@@ -20,7 +20,7 @@ First you have to get to the Appcenter. Here are the steps to do that:
 
 . Connect to your appliance using the IP address or domain name.
 
-[source,console]
+[source,plaintext]
 ----
 https://172.16.40.100
 # or
@@ -142,7 +142,7 @@ image:appliance/ucs/onlyoffice/021-ucs-owncloud-settings-general.png[General sec
 
 ** Enter the OnlyOffice server address in the following format and *save* it:
 +
-[source,console]
+[source,plaintext]
 ----
 https://<your-domain-name>/onlyoffice-documentserver/
 ----
@@ -173,6 +173,7 @@ Here are the required steps:
 
 If you purchased the ONLYOFFICE Enterprise Edition and received the `license.lic` file, you need to import it:
 
+[source,plaintext]
 ----
 /var/lib/univention-appcenter/apps/onlyoffice-ie/Data/license.lic
 ----

--- a/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
@@ -26,6 +26,7 @@ with following content under +
 Take care to also adjust the paths in `WorkingDirectory` and `ExecStart`
 according to your installation.
 +
+[source,plaintext]
 ----
 [Unit]
 Description=ownCloud WND Listener for SERVER SHARE
@@ -49,7 +50,7 @@ WantedBy=multi-user.target
 
 * Run once for each created file the following commands:
 +
-[source,console]
+[source,bash]
 ----
 sudo systemctl enable owncloud-wnd-listen-SERVER-SHARE.service
 sudo systemctl start  owncloud-wnd-listen-SERVER-SHARE.service

--- a/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
@@ -135,7 +135,7 @@ If an upgrade is available, you then need to run the
 
 [source,console]
 ----
-univention-app upgrade owncloud
+root@ucs-9446:~# univention-app upgrade owncloud
 ----
 
 You will have to enter your Administrator password to start the upgrade.

--- a/modules/admin_manual/pages/configuration/database/db_conversion.adoc
+++ b/modules/admin_manual/pages/configuration/database/db_conversion.adoc
@@ -84,7 +84,7 @@ ownCloud config `config.php`.
 If you updated your ownCloud installation then the old tables, which are
 not used anymore, might still exist. The converter will tell you which ones.
 
-[source]
+[source,plaintext]
 ----
 The following tables will not be converted:
   oc_permissions

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -55,7 +55,7 @@ clients/users and many parallel operations). This requires a disabled or correct
 binary logging when using MySQL or MariaDB. Your system is affected if you see the following
 in your log file during the installation or update of ownCloud:
 
-[source]
+[source,plaintext]
 ----
 An unhandled exception has been thrown: exception `PDOException' with message `SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ----

--- a/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/database/linux_database_configuration.adoc
@@ -397,7 +397,7 @@ postgres=# \q
 
 === How to Solve Deadlock Errors
 
-[source,console]
+[source,plaintext]
 ----
 SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
 ----

--- a/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/big_file_upload_configuration.adoc
@@ -202,7 +202,7 @@ For very long-running uploads *those lasting longer than 1h* to public folders, 
 
 To estimate a good value, use the following formula:
 
-[source]
+[source,plaintext]
 ----
 time_in_seconds = (maximum_upload_file_size / slowest_assumed_upload_connection).
 ----

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -125,7 +125,7 @@ To enable the encryption app, run the following command:
 
 If the encryption app is successfully enabled, you should see the following confirmations:
 
-[source,console]
+[source,plaintext]
 ----
 encryption enabled
 Encryption enabled

--- a/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/dropbox.adoc
@@ -37,14 +37,14 @@ Examples:
 
 When configuring as an *admin*:
 
-[source]
+[source,plaintext]
 ----
 http(s)://<<Server_Address>>/settings/admin?sectionid=storage
 ----
 
 When configuring as a *user*:
 
-[source]
+[source,plaintext]
 ----
 http(s)://<<Server_Address>>/settings/personal?sectionid=storage
 ----

--- a/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/google.adoc
@@ -32,7 +32,7 @@ because the Google interface is a bit of a maze and it’s easy to get lost.
 In the examples used, `<your domain>` represents how you access your ownCloud server,
 where you see the login screen. This may look like:
 
-[source]
+[source,plaintext]
 ----
 https://example.com
  or
@@ -103,7 +103,7 @@ To configure _Authorized Redirect URIs_, select one of the two possible URI Sche
 If you are configuring storage as an administrator - choose the admin URI,
 if you are a user and configure your personal storage - pick the personal URI.
 
-[source]
+[source,plaintext]
 ----
 https://<your domain>/index.php/settings/admin?sectionid=storage
  or

--- a/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
@@ -40,7 +40,7 @@ Please note that the ownCloud preview system comes already with sensible default
 
 The default list of enabled preview providers which do not need to be explicitly enabled in the config are:
 
-[source]
+[source,plaintext]
 ----
 OC\Preview\BMP
 OC\Preview\GIF
@@ -72,14 +72,14 @@ sudo nano /etc/ImageMagick-7/policy.xml
 
 Search for the following content:
 
-[source]
+[source,plaintext]
 ----
 <policy domain="coder" rights="none" pattern="PDF" />
 ----
 
 and change:
 
-[source]
+[source,plaintext]
 ----
 rights="none" --> rights="read|write"
 ----
@@ -108,7 +108,7 @@ cat resources/config/mimetypemapping.dist.json | grep image
 
 The following providers require the php `imagick` extension:
 
-[source]
+[source,plaintext]
 ----
 OC\Preview\AI
 OC\Preview\EPS
@@ -123,7 +123,7 @@ OC\Preview\TTF
 
 The following providers are only available if either LibreOffice or OpenOffice is installed on the server:
 
-[source]
+[source,plaintext]
 ----
 OC\Preview\MSOfficeDoc
 OC\Preview\MSOffice2003
@@ -134,7 +134,7 @@ OC\Preview\StarOffice
 
 The following providers are available, but disabled by default due to performance or privacy/security concerns:
 
-[source]
+[source,plaintext]
 ----
 OC\Preview\Font
 OC\Preview\Illustrator

--- a/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
+++ b/modules/admin_manual/pages/configuration/files/trashbin_options.adoc
@@ -12,7 +12,7 @@ As the ownCloud server administrator, you have two `occ` commands for
 permanently deleting files from the Trashbin manually, without waiting
 for the normal aging-out process:
 
-[source]
+[source,plaintext]
 ----
 trashbin
  trashbin:cleanup   Remove deleted files

--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -66,7 +66,7 @@ NOTE: There are other methods to invoke programs by the system regularly, e.g., 
 
 By registering your ownCloud `cron.php` script address as an external webcron service (for example, http://www.easycron.com/[easyCron]), you ensure that background jobs are executed regularly. To use this type of service, your external webcron service must be able to access your ownCloud server using the Internet. For example:
 
-[source]
+[source,plaintext]
 ----
 URL to call: http[s]://<domain-of-your-server>/owncloud/cron.php
 ----

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -39,7 +39,7 @@ This information is obtained by running xref:configuration/server/occ_command.ad
 
 It should print a list of all the routes as in the following truncated example.
 
-[source,console]
+[source,plaintext]
 ----
 +-----------------------------------------------------------+-----------------+
 | Path                                                      | Methods         |

--- a/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
+++ b/modules/admin_manual/pages/configuration/server/oc_server_tuning.adoc
@@ -40,7 +40,7 @@ sizeable instances.
 If you raised the TCP-backlog setting, the following warning appears in
 the Redis logs:
 
-[source,console]
+[source,plaintext]
 ----
 WARNING: The TCP backlog setting of 20480 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of..
 ----
@@ -69,7 +69,7 @@ After the next reboot, 65535 connections will be allowed, instead of the default
 If you are experiencing latency problems with Redis, the following
 warning may appear in your Redis logs:
 
-[source,console]
+[source,plaintext]
 ----
 WARNING you have Transparent Huge Pages (THP) support enabled in your kernel.
 This creates both latency and memory usage issues with Redis.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_2fa_app_commands.adoc
@@ -6,7 +6,7 @@ The following commands manage the _2-Factor Authentication App_. TOTP stands for
 
 The following commands are available for the 2-Factor Authentication app:
 
-[source,console]
+[source,plaintext]
 ----
  twofactor_totp
   twofactor_totp:delete-redundant-secret         Delete the redundant secret of non-existing users

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_activity_commands.adoc
@@ -2,7 +2,7 @@
 
 The `activity` command is used for sending automated activity email notifications in ownCloud server.
 
-[source,console]
+[source,plaintext]
 ----
  activity
   activity:send-emails  Send all pending activity emails now

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_admin_audit_commands.adoc
@@ -27,7 +27,7 @@ This command reads the value of `admin_audit ignore_cli_events`:
 {occ-command-example-prefix} config:app:get "admin_audit ignore_cli_events"
 ----
 
-[source,console]
+[source,plaintext]
 ----
 yes
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_files_lifecycle.adoc
@@ -8,7 +8,7 @@ xref:enterprise/file_management/files_lifecycle.adoc[File Lifecycle Management] 
 The `lifecycle` commands configure the File Lifecycle Management app.
 
 .App Configuration
-[source,console]
+[source,plaintext]
 ----
 lifecycle
  lifecycle:archive          Archive files which have reached a certain age
@@ -23,7 +23,7 @@ lifecycle
 
 
 .Policy Configuration
-[source,console]
+[source,plaintext]
 ----
  config:app:get|set
  files_lifecycle archive_period   Number of days since upload (or restore)

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
@@ -2,7 +2,7 @@
 
 Marketplace URL: {oc-marketplace-url}/apps/user_ldap[LDAP Integration]
 
-[source,console]
+[source,plaintext]
 ----
 ldap
  ldap:check-user               Checks whether a user exists on LDAP
@@ -155,7 +155,7 @@ Rekha Craft (Rekha.Craft)
 
 This only works if the ownCloud server is connected to an LDAP server.
 
-[source,bash,subs="attributes+"]
+[source,plaintext]
 ----
 ldap:check-user [options] [--] <ocName>
 ----
@@ -194,7 +194,7 @@ Example:
 
 Create an empty LDAP configuration.
 
-[source,bash,subs="attributes+"]
+[source,plaintext]
 ----
 ldap:create-empty-config [<configID>]
 ----
@@ -263,7 +263,7 @@ View the configuration for a single `configID`:
 
 Deletes an existing LDAP configuration.
 
-[source,bash,subs="attributes+"]
+[source,plaintext]
 ----
  ldap:delete-config <configID>
 ----
@@ -356,7 +356,7 @@ Available keys, along with default values for configValue, are listed in the tab
 | ldapGroupMemberAssocAttr      | uniqueMember
 | ldapHost                      | ldap://host
 | ldapIgnoreNamingRules         |
-| ldapLoginFilter               | (&((objectclass=inetOrgPerson))(uid=%uid))
+| ldapLoginFilteplaintext       | (&((objectclass=inetOrgPerson))(uid=%uid))
 | ldapLoginFilterAttributes     |
 | ldapLoginFilterEmail          | 0
 | ldapLoginFilterMode           | 0
@@ -415,7 +415,7 @@ The configuration is valid and the connection could be established!
 In the example above, the interval is being set to 7200 seconds.
 Assuming the above example was used, the command would output the following:
 
-[source,console]
+[source,plaintext]
 ----
 Config value updateAttributesInterval for app user_ldap set to 7200
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
@@ -4,7 +4,7 @@ Marketplace URL: {oc-marketplace-url}/apps/market[Market]
 
 The `market` commands _install_, _uninstall_, _list_, and _upgrade_ applications from the ownCloud Marketplace.
 
-[source,console]
+[source,plaintext]
 ----
 market
   market:install    Install apps from the marketplace. If already installed and

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_metrics_commands.adoc
@@ -9,7 +9,7 @@ Set a secret for authenticating requests at the endpoint.
 
 In case you want to generate a random secret, use the following example command: +
 
-[source,console]
+[source,bash]
 ----
 echo $(tr -dc 'a-z0-9' < /dev/urandom | head -c 20)
 ----
@@ -30,7 +30,7 @@ Note: You can also set the config key/value manually into your config.php file.
 
 The above command adds the following at the end of `config.php`:
 
-[source,console]
+[source,php]
 ----
 'metrics_shared_secret' => 'your-metrics-secret',
 ----
@@ -44,7 +44,7 @@ This command reads the value of the `metrics_shared_secret` key from config.php:
 {occ-command-example-prefix} config:system:get "metrics_shared_secret"
 ----
 
-[source,console]
+[source,plaintext]
 ----
 your-metrics-secret
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
@@ -4,7 +4,7 @@ Marketplace URL: {oc-marketplace-url}/apps/oauth2[OAuth2]
 
 Use these commands to configure OAuth2 clients via the OAuth2 app:
 
-[source,console]
+[source,plaintext]
 ----
 oauth2
   oauth2:add-client     Adds an OAuth2 client
@@ -17,7 +17,7 @@ oauth2
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 oauth2:add-client <name> <client-id> <client-secret> <redirect-url> [<allow-sub-domains> [<trusted> [<force-trust>]]]
 ----
@@ -52,7 +52,7 @@ oauth2:add-client <name> <client-id> <client-secret> <redirect-url> [<allow-sub-
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 oauth2:list-clients [options]
 ----
@@ -95,7 +95,7 @@ oauth2:list-clients [options]
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 oauth2:modify-client <name> <key> <value>
 ----
@@ -119,7 +119,7 @@ oauth2:modify-client <name> <key> <value>
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 oauth2:remove-client <client-id>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_oauth2_commands.adoc
@@ -66,7 +66,7 @@ oauth2:list-clients [options]
 |===
 
 .Example Output
-[source]
+[source,plaintext]
 ----
   - Desktop Client:
     - name: Desktop Client

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_richdocuments.adoc
@@ -7,7 +7,7 @@ xref:enterprise/collaboration/collabora_secure_view.adoc[Collabora Online / Secu
 
 `config:app` commands to configure the Collabora Online app.
 
-[source,console]
+[source,plaintext]
 ----
  config:app:get|set
  richdocuments wopi_url            WOPI Server URL

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_saml_sso_shibboleth_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_saml_sso_shibboleth_integration_commands.adoc
@@ -4,7 +4,7 @@ Marketplace URL: {oc-marketplace-url}/apps/user_shibboleth[SAML/SSO Integration]
 
 `shibboleth:mode` sets your Shibboleth mode to `notactive`, `autoprovision`, or `ssoonly`
 
-[source,console]
+[source,bash,subs="attributes+"]
 ----
-shibboleth:mode [mode]
+{occ-command-example-prefix} shibboleth:mode [mode]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_wnd_commands.adoc
@@ -7,7 +7,7 @@ xref:enterprise/external_storage/windows-network-drive_configuration.adoc[Window
 
 The `wnd` commands configure the WND app.
 
-[source,console]
+[source,plaintext]
 ----
 wnd
  wnd:listen                 Listen to smb changes and store notifications for later processing

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_2fa_core_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_2fa_core_commands.adoc
@@ -6,7 +6,7 @@ If a two-factor provider app is enabled, it is enabled for all users by default 
 
 The following commands are available for the two-factor authentication:
 
-[source,console]
+[source,plaintext]
 ----
  twofactorauth
   twofactorauth:disable  Disable two-factor authentication for a user.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_app_commands.adoc
@@ -2,7 +2,7 @@
 
 The `app` commands list, enable, and disable apps.
 
-[source,console]
+[source,plaintext]
 ----
 app
  app:check-code   check code to be compliant

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_background_jobs_selector.adoc
@@ -3,7 +3,7 @@
 Use the `background` command to select which scheduler you want to use for controlling xref:configuration/server/background_jobs_configuration.adoc[background jobs]. 
 This is the same as using the *Cron* section on your ownCloud Admin page.
 
-[source,console]
+[source,plaintext]
 ----
 background
  background:ajax       Use ajax to run background jobs

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_command_line_installation_commands.adoc
@@ -52,7 +52,7 @@ ownCloud is not installed - only a limited number of commands are available
 Usage:
 ----
 
-[source,console]
+[source,plaintext]
 ----
 maintenance:install [--database=["..."]] [--database-connection-string=["..."]] \
                     [--database-name=["..."]] [--database-host=["..."]] \
@@ -82,7 +82,7 @@ For example:
 
 *Example*
 
-[source,console]
+[source,plaintext]
 ----
 sales=
  (DESCRIPTION= 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_database_conversion_commands.adoc
@@ -3,7 +3,7 @@
 The SQLite database is good for testing, and for ownCloud servers with small single-user workloads that do not use sync clients, but production servers with multiple users should use MariaDB, MySQL, or PostgreSQL.
 You can use `occ` to convert from SQLite to one of these other databases.
 
-[source,console]
+[source,plaintext]
 ----
 db
  db:convert-type           Convert the ownCloud database to the newly configured one

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_dav_commands.adoc
@@ -2,7 +2,7 @@
 
 A set of commands to create and sync address books and calendars:
 
-[source,console]
+[source,plaintext]
 ----
 dav
  dav:cleanup-chunks            Cleanup outdated chunks

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
@@ -2,7 +2,7 @@
 
 `occ` includes a complete set of commands for managing encryption. When using a HSM (Hardware Security Module, can also be emulated by software), additional occ encryption-related commands can be used.
 
-[source,console]
+[source,plaintext]
 ----
 encryption
  config:app:set encryption encryptHomeStorage Encrypt the users home storage
@@ -28,7 +28,7 @@ encryption
 
 When using a HSM (Hardware Security Module, additional occ encryption-related commands can be used, see the HSM occ documentation below. The occ commands can also be used when HSM is initiated via software emulation like SoftHSM2.
 
-[source,console]
+[source,plaintext]
 ----
 encryption
  encryption:hsmdaemon                Export or Import the Masterkey

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -2,7 +2,7 @@
 
 `occ` has the following commands for managing files in ownCloud.
 
-[source,console]
+[source,plaintext]
 ----
 files
  files:check-cache          Check if the target file exists in the primary storage

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_files_external_commands.adoc
@@ -3,7 +3,7 @@
 These commands replace the `data/mount.json` configuration file used in ownCloud releases before 9.0.
 Commands for managing external storage.
 
-[source,console]
+[source,plaintext]
 ----
 files_external
  files_external:applicable  Manage applicable users and groups for a mount
@@ -31,7 +31,7 @@ List configured mounts.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:list [--show-password] [--full] [-a|--all] [-s|--short] [--] [<user_id>]
 ----
@@ -81,7 +81,7 @@ Manage applicable users and groups for a mount.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:applicable
     [--add-user     ADD-USER]
@@ -120,7 +120,7 @@ Show available authentication and storage backends.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:backends [options]
     [--]
@@ -149,7 +149,7 @@ Manage backend configuration for a mount.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:config [options]
     [--]
@@ -181,7 +181,7 @@ Create a new mount configuration.
 
 === Usage
 
-[source,console]
+[source,plaintext
 ----
 files_external:create [options]
     [--]
@@ -260,7 +260,7 @@ Delete an external mount.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:delete [options] [--] <mount_id>
 ----
@@ -284,7 +284,7 @@ files_external:delete [options] [--] <mount_id>
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:export [options] [--] [<user_id>]
 ----
@@ -310,7 +310,7 @@ Import mount configurations.
 
 === Usage
 
-[source,console]
+[source,plaintext
 ----
 files_external:import [options] [--] <path>
 ----
@@ -338,7 +338,7 @@ Manage mount options for a mount.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:option <mount_id> <key> [<value>]
 ----
@@ -359,7 +359,7 @@ Verify mount configuration.
 
 === Usage
 
-[source,console]
+[source,plaintext]
 ----
 files_external:verify [options] [--] <mount_id>
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_full_text_search_commands.adoc
@@ -4,7 +4,7 @@ Use these commands when you manage full text search related tasks.
 
 == Command Description
 
-[source,console]
+[source,plaintext]
 ----
 search
   search:index:create    Create initial Search Index for one or all users. 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_group_commands.adoc
@@ -6,7 +6,7 @@ Group names are case-sensitive, so "Finance" and "finance" are two different gro
 
 The full list of commands is:
 
-[source,console]
+[source,plaintext]
 ----
 group
  group:add                           Adds a group

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_integrity_check_commands.adoc
@@ -4,7 +4,7 @@ Apps which have an official tag *must* be code signed.
 Unsigned official apps won't be installable anymore. 
 Code signing is optional for all third-party applications.
 
-[source,console]
+[source,plaintext]
 ----
 integrity
  integrity:check-app                 Check app integrity using a signature.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_localisation_commands.adoc
@@ -5,7 +5,7 @@ This command creates JavaScript and JSON translation files for ownCloud applicat
 NOTE: The command does not update existing translations if the source translation file has been updated. 
 It only creates translation files when none are present for a given language.
 
-[source,console]
+[source,plaintext]
 ----
 l10n
   l10n:createjs                Create Javascript translation files for a given app

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_logging_commands.adoc
@@ -2,7 +2,7 @@
 
 These commands view and configure your ownCloud logging preferences.
 
-[source,console]
+[source,plaintext]
 ----
 log
  log:manage     Manage logging configuration

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
@@ -2,7 +2,7 @@
 
 Use these commands when you upgrade ownCloud, manage encryption, perform backups and other tasks that require locking users out until you are finished.
 
-[source,console]
+[source,plaintext]
 ----
 maintenance
  maintenance:data-fingerprint        Update the systems data-fingerprint after a backup is restored
@@ -96,6 +96,7 @@ Here is an example of running the command:
 To list all off the possible repair steps, use the `--list` option. 
 It should output the following list to the console:
 
+[source,plaintext]
 ----
 Found 16 repair steps
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
@@ -2,7 +2,7 @@
 
 Use the `background:queue` command to manage background jobs.
 
-[source,console]
+[source,plaintext]
 ----
 background:queue
  background:queue:delete     Delete a job from the queue
@@ -15,6 +15,7 @@ background:queue
 The command `background:queue:delete` deletes a queued background job.
 It requires the job id of the job to be deleted.
 
+[source,plaintext]
 ----
 background:queue:delete <Job ID>
 ----
@@ -42,6 +43,7 @@ Job has been deleted.
 The command `background:queue:execute` executes a queued background job.
 It requires the job id of the job to be executed.
 
+[source,plaintext]
 ----
 background:queue:execute [options] [--] <Job ID>
 ----
@@ -82,6 +84,7 @@ Finished in 0 seconds
 
 The command `background:queue:status` will list queued background jobs, including details when it last ran.
 
+[source,plaintext]
 ----
 background:queue:status
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_security_commands.adoc
@@ -6,7 +6,7 @@ You can use this information to grant strict access via firewalls, proxies or lo
 
 == Command Description
 
-[source,console]
+[source,plaintext]
 ----
 security:routes [options]
 ----
@@ -26,6 +26,7 @@ Example 1:
 {occ-command-example-prefix} security:routes
 ----
 
+[source,plaintext]
 ----
 +-----------------------------------------------------------+-----------------+
 | Path                                                      | Methods         |
@@ -45,6 +46,7 @@ Example 2:
 {occ-command-example-prefix} security:routes --output=json-pretty
 ----
 
+[source,plaintext]
 ----
 [
   {
@@ -62,6 +64,7 @@ Example 3:
 {occ-command-example-prefix} security:routes --with-details
 ----
 
+[source,plaintext]
 ----
 +---------------------------------------------+---------+-------------------------------------------------------+--------------------------------+
 | Path                                        | Methods | Controller                                            | Annotations                    |
@@ -75,7 +78,7 @@ Example 3:
 The following commands manage server-wide SSL certificates. 
 These are useful when you create federation shares with other ownCloud servers that use self-signed certificates.
 
-[source,console]
+[source,plaintext]
 ----
 security:certificates         List trusted certificates
 security:certificates:import  Import trusted certificate

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_trashbin_commands.adoc
@@ -3,7 +3,7 @@
 NOTE: These commands are only available when the 'Deleted files' app (`files_trashbin`) is enabled.
 These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
 
-[source,console]
+[source,plaintext]
 ----
 trashbin
  trashbin:cleanup   Remove deleted files

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -6,7 +6,7 @@ The `user` commands provide a range of functionality for managing ownCloud users
 This includes: creating and removing users, resetting user passwords, displaying a report which shows how many users you have, and when a user was last logged in.
 The full list, of commands is:
 
-[source,console]
+[source,plaintext]
 ----
 user
  user:add                            Adds a user
@@ -289,6 +289,7 @@ The example below searches for users inactive for five days or more:
 
 By default, this will generate output in the following format:
 
+[source,plaintext]
 ----
 - 0:
   - uid: admin
@@ -594,6 +595,7 @@ NOTE: To use `send-email`, the ownCloud instance must have email access fully co
 
 Add a new user, called Fred Jones:
 
+[source,plaintext]
 ----
 export OC_PASS=newpassword
 su -s /bin/sh www-data -c 'php occ user:add --password-from-env
@@ -615,6 +617,7 @@ Successfully reset password for layla
 
 You may also use `password-from-env` to reset passwords:
 
+[source,plaintext]
 ----
 export OC_PASS=newpassword
 su -s /bin/sh www-data -c 'php occ user:resetpassword \
@@ -637,6 +640,7 @@ The password reset link is: http://localhost:{std-port-http}/index.php/lostpassw
 
 If the specified user does not have a valid email address set, then the following error will be output to the console, and the email will not be sent:
 
+[source,plaintext]
 ----
 Email address is not set for the user layla
 ----
@@ -811,6 +815,7 @@ NOTE: This command replaces the old `show-remnants` functionality, and brings th
 
 === Usage
 
+[source,plaintext]
 ----
 user:sync [options] [--] [<backend-class>]
 ----
@@ -977,9 +982,13 @@ If unknown users are found, what do you want to do with their accounts? (removin
 
 Here is an example for syncing with LDAP four times a day on Ubuntu:
 
+[source,bash]
 ----
 crontab -e -u www-data
+----
 
+[source,plaintext]
+----
 * */6 * * * /usr/bin/php /var/www/owncloud/occ user:sync -vvv \
     --missing-account-action="disable" \
     -n "OCA\User_LDAP\User_Proxy"

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -486,7 +486,7 @@ Set the generated secret for ownCloud:
 
 If the command succeeds, you should see the following console output:
 
-[source]
+[source,plaintext]
 ----
 Config value hsm.jwt.secret for app encryption set to 7a7d1826-b514-4d9f-afc7-a7485084e8de
 ----

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -106,7 +106,7 @@ sudo apt install -y opensc
 
 To install OpenSC on openSUSE and SUSE Linux Enterprise Server, run the following command:
 
-[source,console]
+[source,bash]
 ----
 sudo zypper install -y --auto-agree-with-licenses opensc
 ----
@@ -339,7 +339,7 @@ sudo hsmdaemon encrypt 9bac3719-2b8d-11e9-aeab-0242b5ece4c3 Zm9vYmFy
 
 If successful, you should see output similar to the example below:
 
-[source,console,options="nowrap"]
+[source,plaintext,options="nowrap"]
 ----
 {"level":"debug","ts":"2019-03-20T12:43:40.540+0100","caller":"hsmdaemon/keymanager.go:27","msg":"initialize pkcs11 module","module":"/usr/lib/softhsm/libsofthsm2.so"}
 {"level":"debug","ts":"2019-03-20T12:43:40.545+0100","caller":"hsmdaemon/keymanager.go:205","msg":"openHSMSession","slotID":858597139}
@@ -359,7 +359,7 @@ sudo grep "generated keypair" /var/log/hsm.log
 
 You should see output similar to the example below:
 
-[source,console,options="nowrap"]
+[source,plaintext,options="nowrap"]
 ----
 {"level":"debug","ts":"2021-06-19T03:10:01.562+0200","msg":"generated keypair","tokenID":"1262668f-d09b-11eb-b283-960000c05f34"}
 {"level":"debug","ts":"2021-06-19T03:10:03.043+0200","msg":"generated keypair","tokenID":"1374447f-d09b-11eb-83c8-960000c05f34"}
@@ -382,7 +382,7 @@ SGVsbG8sIHdvcmxkIQo=
 test_enc=$(sudo ./hsmdaemon encrypt $key_id $(echo "$hello" | base64) | tee /dev/stderr)
 ----
 
-[source,console,options="nowrap"]
+[source,plaintext,options="nowrap"]
 ----
 ep6Y1aAVAYpAesZ1+sQzzUepjO82o34kjmm63Drmz+6KED4oIBARQkXeW/OoxgUg6kQhQK1thA/3Ww33aaRxIESzVQF598qjXhhEXQ/OGL6BC+3tPclC7ujUZaA7CG1NDkMneLFDd2+Tbax4OM+/w0zhfTMPgT0I1NrH/03owVglbWHjgLZmN/vxpPZKm/lyAV9tI2HW36UjVLEMD2qtPFXqjLU4YjZOVnMdETxQNSCWIVauFw0+VQQ/RiAqiXzRXEgO6YKxOBk0n9IMT6XEH4MkMQTgb9pB12jrNSa9aMHbCvCneEmhd0CHBxPX499EkxxwtoEnXe6PATXsOg3VRA==
 ----
@@ -399,7 +399,7 @@ decrypted string (base64 encoded): 'SGVsbG8sIHdvcmxkIQo='
 sudo tail -5 /var/log/hsm.log
 ----
 
-[source,console,options="nowrap"]
+[source,plaintext,options="nowrap"]
 ----
 {"level":"debug","ts":"2021-06-20T23:46:11.958+0200","msg":"openHSMSession","slotID":757826573}
 {"level":"debug","ts":"2021-06-20T23:46:11.960+0200","msg":"created new session"}

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -41,7 +41,7 @@ sudo apt-get install -y softhsm2 libsofthsm2
 To install SoftHSM2, you first have to ensure that you have {opensuse-security-repositories-url}[the official security repository] for your server enabled in your server's repositories list. 
 To check if it is, run the command `zypper lr`, which will show you output similar to the following:
 
-[source]
+[source,plaintext]
 ----
 #  | Alias                     | Name                                    | Enabled | GPG Check | Refresh
 ---+---------------------------+-----------------------------------------+---------+-----------+--------

--- a/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
+++ b/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
@@ -76,7 +76,7 @@ sudo systemctl start clamav-daemon.service
 
 When successful, an output similar to the following should appear on the terminal:
 
-[source,console]
+[source,plainetxt]
 ----
 Synchronizing state of clamav-daemon.service with SysV service script with
 /lib/systemd/systemd-sysv-install.
@@ -103,7 +103,7 @@ and retry manually updating again.
 
 . To automate the update process, run this cron entry for example.
 +
-[source,bash]
+[source,plaintext]
 ----
 # m   h  dom mon dow  command
 47  *  *  *  *  /usr/bin/freshclam --quiet
@@ -149,7 +149,7 @@ image:apps/files_antivirus/antivirus-daemon.png[The Antivirus Configuration pane
 
 All of the configuration settings for ClamAV are configurable by passing the relevant key and value to the `occ config:app:set files_antivirus` command. For example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_socket --value="/var/run/clamav/clamd.ctl"
@@ -157,7 +157,7 @@ All of the configuration settings for ClamAV are configurable by passing the rel
 
 To get a current option run for example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:get files_antivirus \
     av_socket
@@ -230,7 +230,7 @@ ClamAV runs in one of three modes:
 [TIP]
 ====
 In both daemon modes, background scans are enabled by default. If you want to disable them, run the command:
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus av_scan_background --value 'false'
 ----
@@ -247,7 +247,7 @@ image:apps/files_antivirus/antivirus-daemon-socket.png[image]
 +
 You can run `ss` (a utility to investigate sockets) to verify it, as in the example below:
 +
-[source,console]
+[source,bash]
 ----
 sudo ss -a | grep -iq clamav && echo "ClamAV is running"
 ----
@@ -255,7 +255,7 @@ sudo ss -a | grep -iq clamav && echo "ClamAV is running"
 [TIP]
 ====
 If you don't have `ss` installed, you may have `netstat` installed. If so, you can run the following to check if ClamAV is running:
-[source,console]
+[source,bash]
 ----
 netstat -a | grep -q clam && echo "ClamAV is running"
 ----
@@ -294,7 +294,7 @@ NOTE: If you had configured the path and command line options before via the use
 . Set btn:[Mode] to "*Executable*".
 . Set btn:[Path to clamscan] to the path of `clamscan`, which is the interactive ClamAV scanning command, on your server. To find the exact path, run
 +
-[source,console]
+[source,bash]
 ----
 which clamscan
 ----
@@ -423,14 +423,14 @@ To delete an existing rule, click the btn:[rubbish bin] icon on the far right-ha
 
 . If you haven't done so already, install the {oc-marketplace-url}/apps/files_antivirus[Anti-Virus app] from the ownCloud marketplace. Alternatively, use this occ command:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} market:install files_antivirus
 ----
 
 . Enable the app as admin in ownCloud under menu:Settings[Apps] in the category `Security` or with the following occ command:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} app:enable files_antivirus
 ----
@@ -480,7 +480,7 @@ You can configure the ownCloud Anti-Virus app either via the Web interface or th
 
 . Set the IP address of your anti-virus server:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_host --value="172.17.0.3"
@@ -488,7 +488,7 @@ You can configure the ownCloud Anti-Virus app either via the Web interface or th
 
 . Specify the port of the anti-virus server:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_port --value="1344"
@@ -496,7 +496,7 @@ You can configure the ownCloud Anti-Virus app either via the Web interface or th
 
 . Set the mode to ICAP:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_mode --value="icap"
@@ -506,7 +506,7 @@ NOTE: The setting `icap` triggers a grace period of 24 hours if you don't have a
 
 . Specify what to do with the offending file:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_infected_action --value="delete"
@@ -524,7 +524,7 @@ Depending on your ICAP server, select one of the following example configuration
 
 . To use ClamAV, set the mode to `c-icap with ClamAV` either from the Web interface or via command line:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_request_service --value="avscan"
@@ -532,7 +532,7 @@ Depending on your ICAP server, select one of the following example configuration
 
 . Set the respective response header:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_response_header --value="X-Infection-Found"
@@ -546,7 +546,7 @@ Depending on your ICAP server, select one of the following example configuration
 
 . To use KAV, set the mode to `req` either from the Web interface or via command line:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_request_service --value="req"
@@ -554,7 +554,7 @@ Depending on your ICAP server, select one of the following example configuration
 
 . Set the respective response header:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_response_header --value="X-Virus-ID"
@@ -570,7 +570,7 @@ Note, McAfee version 7.8.2 and up provide ICAP support. Follow this procedure to
 
 . To use McAfee, set the mode to `wwreqmod` either from the Web interface or via command line:
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_antivirus \
     av_request_service --value="wwreqmod"

--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -82,7 +82,7 @@ If you run a clustered setup, the following method configuring the OpenID Connec
 
 If a malformed JSON string is found, an error is logged. The _key->value_ pairs are the same as when storing them to the `config.php` file. This task has to be done by invoking an occ command, see the following example. Use the occ commands `config:app:get` to view the current setting or `config:app:delete` to delete it. See the xref:configuration/server/occ_command.adoc#config-commands[Config Command Set] for more details.
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set \
     openidconnect \

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -157,7 +157,7 @@ Edit Raw Filter Instead::
 Clicking on this text toggles the filter mode, and you can enter the raw LDAP filter directly. 
 Example:
 
-[source]
+[source,plaintext]
 ----
 include::example$configuration/user/user_auth_ldap/group_filter.ldif[]
 ----
@@ -175,7 +175,7 @@ Active Directory offers "_Recursive retrieval of all AD group memberships of a u
 This means that you would be able to search the group you enter and all the other child groups from this group for users.
 Enter this filter to access this feature for a single group:
 
-[source]
+[source,plaintext]
 ----
 include::example$configuration/user/user_auth_ldap/single_group_search.ldif[]
 ----
@@ -183,7 +183,7 @@ include::example$configuration/user/user_auth_ldap/single_group_search.ldif[]
 Enter your group name instead of the `<groupname>` placeholder.
 If you want to search multiple groups with this feature, adjust your filter like this:
 
-[source]
+[source,plaintext]
 ----
 include::example$configuration/user/user_auth_ldap/multi_group_search.ldif[]
 ----
@@ -256,7 +256,7 @@ include::example$configuration/user/user_auth_ldap/only_username.ldif[]
 
 * Username or Email Address:
 +
-[source]
+[source,plaintext]
 ----
 include::example$configuration/user/user_auth_ldap/username_email.ldif[]
 ----
@@ -772,7 +772,7 @@ and show only active users.
 
 Here is what the full filter can look like.
 
-[source]
+[source,plaintext]
 ----
 &(|(objectclass=organizationalPerson))
   (!(userAccountControl:1.2.840.113556.1.4.803:=2))

--- a/modules/admin_manual/pages/document_classification/index.adoc
+++ b/modules/admin_manual/pages/document_classification/index.adoc
@@ -193,7 +193,7 @@ Apart from the concrete examples above, a generalized method to employ document 
   Below you find a generalized example where `classification-property` is a placeholder for the property to evaluate.
 +
 --
-[source]
+[source,plaintext]
 ----
 property[@name='classification-property']/vt:lpwstr
 ----
@@ -332,7 +332,7 @@ To set it up, add the desired property XPath to the "_Document ID XPath_" field 
 Each uploaded file will generate three entries with different log levels.
 See some exemplary entries below:
 
-[source]
+[source,plaintext]
 ----
 INFO:  "Checking classified file 'confidential.xlsx' with document id '2'"
 INFO:  "Alice uploaded a classified file 'confidential.xlsx' with document class 'Confidential'"

--- a/modules/admin_manual/pages/enterprise/external_storage/enterprise_only_auth.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/enterprise_only_auth.adoc
@@ -184,7 +184,7 @@ Note that sub-keys, except the password key are not used as elements for the mou
 +
 Nested arrays are beneficial when having more than one server (host) with a password, but keeping them together in one master key. To access a particular sub-key in the mount definition, use the following scheme:
 +
-[source]
+[source,plaintext]
 ----
 <key>#<sub-key-level-1>#<sub-key-level-2>...
 ----
@@ -199,7 +199,7 @@ From the example above, +
 Single array::
 Taking the single array example above to use the password for the mount, the value to be entered would be like:
 +
-[source]
+[source,plaintext]
 ----
 customApp.config
 ----
@@ -207,7 +207,7 @@ customApp.config
 Nested arrays::
 Taking the nested array example above to use the password for the mount for the host with sub-key `server1`, the value to be entered would be like:
 +
-[source]
+[source,plaintext]
 ----
 customApp.config#server1
 ----

--- a/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/ldap_home_connector_configuration.adoc
@@ -84,14 +84,14 @@ The configuration is done in several steps:
 
 For enhanced security, create a file where the credentials are stored accessing the cifs share like:
 
-[source]
+[source,plaintext]
 ----
 /etc/credentials
 ----
 
 with the username and password on separate lines, replacing the values according your setup:
 
-[source]
+[source,plaintext]
 ----
 username=winhomeuser
 password=winhomepassword
@@ -99,7 +99,7 @@ password=winhomepassword
 
 Create an entry in `/etc/fstab` for the remote Windows root home directory mount and use the credentials file created above, substitute and adapt your parameters and filenames:
 
-[source]
+[source,plaintext]
 ----
 //192.168.1.58/home /mnt/share/users cifs credentials=/etc/credentials,uid=33,gid=33
 ----

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -331,7 +331,7 @@ the account. This way, only root and the Apache user should have access to the p
 
 * Content template for `owncloud-wnd-listen-SERVER-SHARE`
 +
-[source]
+[source,plaintext]
 ----
 [Unit]
 Description=ownCloud WND Listener for SERVER SHARE

--- a/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/wnd_quick_guide.adoc
@@ -96,7 +96,7 @@ the account. This way, only root and the Apache user should have access to the p
 
 * Content template for `owncloud-wnd-listen-SERVER-SHARE`
 +
-[source]
+[source,plaintext]
 ----
 [Unit]
 Description=ownCloud WND Listener for SERVER SHARE

--- a/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -115,7 +115,7 @@ The File Firewall supports regular expressions, allowing you to create custom ru
 
 You can combine multiple rules into one rule, e.g., if a rule applies to both the support and the qa-team you could write your rule like this:
 
-[source]
+[source,plaintext]
 ----
 Regular Expression > ^(support|qa-team)$ > is > User group
 ----
@@ -132,7 +132,7 @@ Now you just need to add the tag to the folder or file, and then block the tag w
 
 Block by System Tag:
 
-[source]
+[source,plaintext]
 ----
 System file tag:   is       "Confidential"
 IP Range (IPv4):   is not   "192.168.1.0/24"

--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -90,7 +90,7 @@ Connect to the deployment server, change `input-prd-your-server-here` according 
 
 To Monitor the ownCloud Splunk audit log, add this to `inputs.conf`, assuming you use the custom logging path/file from above:
 
-[source]
+[source,plaintext]
 ----
 [monitor://var/www/owncloud/data/admin_audit.log]
  disabled = false
@@ -100,7 +100,7 @@ To Monitor the ownCloud Splunk audit log, add this to `inputs.conf`, assuming yo
 
 Finally, configure the following `props.conf` to ensure the time field is correctly used and the fields are extracted.
 
-[source]
+[source,plaintext]
 ----
 [_json]
  INDEXED_EXTRACTIONS = json

--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -109,7 +109,7 @@ The dashboard is enabled by default. You can disable it with the following comma
 
 To query for the Metrics data, use the following endpoint:
 
-[source]
+[source,plaintext]
 ----
 https://<your owncloud>/ocs/v1.php/apps/metrics/api/v1/metrics
 ----

--- a/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
+++ b/modules/admin_manual/pages/installation/configuration_notes_and_tips.adoc
@@ -25,13 +25,13 @@ This can be the case, for example, for the `date.timezone` setting.
 
 For PHP version {minimum-php-printed} onward, replace `php_version` with the version number installed, e.g., `{minimum-php-version}` in the following examples.
 
-[source]
+[source,plaintext]
 ----
 /etc/php/[php_version]/apache2/php.ini
 ----
 
 or
-[source]
+[source,plaintext]
 ----
 /etc/php/[php_version]/fpm/php.ini
 ----
@@ -40,7 +40,7 @@ or
 
 === php.ini - used by the php-cli and so by ownCloud CRON jobs
 
-[source]
+[source,plaintext]
 ----
 /etc/php/[php_version]/cli/php.ini
 ----
@@ -114,7 +114,10 @@ sudo cloc /var/www/owncloud --exclude-dir=data --follow-links
    12179 text files.
    11367 unique files.
    73126 files ignored.
+----
 
+[source,plaintext]
+----
 http://cloc.sourceforge.net v 1.60  T=1308.98 s (6.4 files/s, 1283.5 lines/s)
 --------------------------------------------------------------------------------
 Language                      files          blank        comment           code
@@ -163,7 +166,7 @@ may be in a sub-directory.
 Usually, you will find some or all of the environment variables already
 in the file, but commented out like this:
 
-[source]
+[source,plaintext]
 ----
 ;env[HOSTNAME] = $HOSTNAME
 ;env[PATH] = /usr/local/bin:/usr/bin:/bin
@@ -175,9 +178,9 @@ in the file, but commented out like this:
 Uncomment the appropriate existing entries. Then run `printenv PATH` to
 confirm your paths, for example:
 
-[source,console]
+[source,bash]
 ----
-$ printenv PATH
+printenv PATH
 /home/user/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:
 /sbin:/bin:/
 ----

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -347,7 +347,7 @@ Redis in a primary-replica configuration is {cloud-warm-hot-server-url}[a hot fa
 
 If you’re using {mariadb-galera-cluster-url}[MariaDB Galera Cluster] with your ownCloud installation, you may encounter deadlocks when you attempt to sync a large number of files. You may also encounter database errors, such as this one:
 
-[source,console]
+[source,plaintext]
 ----
 SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
 ----
@@ -375,14 +375,14 @@ NOTE: This setting is disabled by default. See the {galera-cluster-wsrep-docs-ur
 
 Local session management on the application server. PHP sessions are stored in a temporary filesystem, mounted at the operating system-specific session storage location. You can find out where that is by running
 
-[source,console]
+[source,bash]
 ----
 grep -R 'session.save_path' /etc/php*
 ----
 
 and then add it to the `/etc/fstab` file, for example:
 
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 include::example$installation/deployment_recommendations/set_session_path.sh[]
 ----

--- a/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations/nfs.adoc
@@ -175,12 +175,20 @@ You can find the set values by working with the output of the `mount` command on
 [source,console]
 ----
 root@server:~# mount | egrep -o rsize=[0-9]*
+----
+
+[source,plaintext]
+----
 rsize=65536
 ----
 
 [source,console]
 ----
 root@server:~# mount | egrep -o wsize=[0-9]*
+----
+
+[source,plaintext]
+----
 wsize=65536
 ----
 
@@ -194,7 +202,7 @@ mount 192.168.0.104:/data /mnt -o rsize=65536,wsize=65536
 ----
 
 .Example for a set of NFS mount options:
-[source,console]
+[source,plaintext]
 ----
 bg,nfsvers=3,wsize=65536,rsize=65536,tcp,_netdev
 ----

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -70,7 +70,6 @@ docker rm oc-eval
 
 If you now run `docker ps` again, the entry for oc-eval should be gone.
 
-
 == Docker Compose
 
 The configuration:
@@ -363,7 +362,7 @@ The loglevel is set to the fixed value 2: _"Warnings, errors, and fatal issues"_
 
 .To get the highest log level "Everything" (including debug output), use:
 
-[source,console]
+[source,plaintext]
 ----
 OWNCLOUD_LOGLEVEL=0
 ----

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -55,6 +55,7 @@ sudo certbot register --agree-tos --email <your-email-address>
 
 When it executes, you’ll see a question similar to the following, which you can answer "Yes" or "No":
 
+[source,plaintext]
 ----
 Saving debug log to /var/log/letsencrypt/letsencrypt.log
 
@@ -69,6 +70,7 @@ our work to encrypt the web, protect its users and defend digital rights.
 
 When that completes, you’ll see a message similar to the following:
 
+[source,plaintext]
 ----
 IMPORTANT NOTES:
  1. Your account credentials have been saved in your Certbot
@@ -142,7 +144,7 @@ If you're logged in to your server as a user other than root, you'll likely need
 
 This file defines some default settings used by Certbot. Use the email address you registered with. Comment or uncomment the post-hook parameter depending on if you want to run post hooks. Running post hooks will reload the web server configuration automatically if a certificate has been renewed.
 
-[source,console]
+[source,ini]
 ----
 include::example$installation/lets_encrypt/cli.ini[]
 ----
@@ -151,7 +153,7 @@ include::example$installation/lets_encrypt/cli.ini[]
 ====
 For the following scripts, replace the path to Certbot and the Certbot script name based on your installation. You can find it by running:
 
-[source,console]
+[source,plaintext]
 ----
 which certbot
 ----
@@ -161,7 +163,7 @@ which certbot
 
 This script lists all your issued certificates.
 
-[source,console]
+[source,bash]
 ----
 include::example$installation/lets_encrypt/list.sh[]
 ----
@@ -173,7 +175,7 @@ This script:
 * Renews all your issued certificates.
 * In case you have enabled the post hook for your web server in `cli.ini`, it will reload the web server configuration automatically if a certificate has been renewed.
 
-[source,console]
+[source,bash]
 ----
 include::example$installation/lets_encrypt/renew.sh[]
 ----
@@ -187,7 +189,7 @@ This script:
 
 NOTE: This script is intended for use via Cron.
 
-[source,console]
+[source,bash]
 ----
 include::example$installation/lets_encrypt/renew-cron.sh[]
 ----
@@ -197,7 +199,7 @@ include::example$installation/lets_encrypt/renew-cron.sh[]
 This script deletes an issued certificate. +
 Use the `list.sh` script to list issued certificates.
 
-[source,console]
+[source,bash]
 ----
 include::example$installation/lets_encrypt/delete.sh[]
 ----
@@ -211,7 +213,7 @@ The following example script creates a certificate for a domain or sub-domains, 
 You can create different certificates for different sub-domains, such as `example.com`, `www.example.com`, and `subdomain.example.com` by creating different scripts.
 ====
 
-[source,console]
+[source,bash]
 ----
 include::example$installation/lets_encrypt/your-domain-name.sh[]
 ----

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -29,7 +29,7 @@ Here are the ways to do so for xref:apt[APT], xref:yum[Yum], and xref:zypper[Zyp
 
 If you are using APT, use {apt-mark-hold-url}[apt-mark hold] to  mark the `owncloud-complete-files` package as held. Here’s an example of how to do so:
 
-[source,console]
+[source,bash]
 ----
 apt-mark hold owncloud-complete-files
 ----
@@ -153,7 +153,7 @@ Downgrading is not supported and risks corrupting your data! If you want to reve
 
 See installation_wizard for important steps, such as choosing the best database and setting correct directory permissions. See the xref:installation/selinux_configuration.adoc[SELinux Configuration Guide] for a suggested configuration for SELinux-enabled distributions such as _Fedora_ and _CentOS_.
 
-If your distribution is not listed, your Linux distribution may maintain its own ownCloud packages or you may prefer to xref:installation/manual_installation/manual_installation.adoc[install from source,plaintext].
+If your distribution is not listed, your Linux distribution may maintain its own ownCloud packages or you may prefer to xref:installation/manual_installation/manual_installation.adoc[install from source].
 
 === Archlinux
 

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -96,7 +96,7 @@ zypper addlock owncloud-complete-files
 
 To see if the package has already been locked, use the `locks` command.  If `owncloud-complete-files` is already locked, then you will see output similar to the below example.
 
-[source]
+[source,plaintext]
 ----
 # | Name                    | Type    | Repository
 --+-------------------------+---------+-----------
@@ -153,7 +153,7 @@ Downgrading is not supported and risks corrupting your data! If you want to reve
 
 See installation_wizard for important steps, such as choosing the best database and setting correct directory permissions. See the xref:installation/selinux_configuration.adoc[SELinux Configuration Guide] for a suggested configuration for SELinux-enabled distributions such as _Fedora_ and _CentOS_.
 
-If your distribution is not listed, your Linux distribution may maintain its own ownCloud packages or you may prefer to xref:installation/manual_installation/manual_installation.adoc[install from source].
+If your distribution is not listed, your Linux distribution may maintain its own ownCloud packages or you may prefer to xref:installation/manual_installation/manual_installation.adoc[install from source,plaintext].
 
 === Archlinux
 

--- a/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/compile_samba.adoc
@@ -198,7 +198,7 @@ sudo systemctl edit smbd.service
 Add the following content and save the result. The location and naming will be done automatically.
 Just say save.
 
-[source]
+[source,plaintext]
 ----
 [Unit]
 After=

--- a/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_imagick7.adoc
@@ -68,7 +68,12 @@ sudo apt remove php-imagick
 [source,bash]
 ----
 sudo service apache2 restart
+----
+
 or
+
+[source,bash]
+----
 sudo service php7.4-fpm restart
 ----
 
@@ -162,7 +167,9 @@ Check the version installed. The version printed may be different than in the ex
 [source,bash]
 ----
 convert -version | grep -i version
-
+----
+[source,plaintext]
+----
 Version: ImageMagick 7.1.0-2 ...
 ----
 
@@ -170,10 +177,13 @@ Version: ImageMagick 7.1.0-2 ...
 
 Type the following commands to get a list of supported formats:
 
-[source,console]
+[source,bash]
 ----
 convert identify -list format
+----
 
+[source,plaintext]
+----
    Format  Module    Mode  Description
 ----------------------------------------------------
       3FR  DNG       r--   Hasselblad CFV/H3D39II
@@ -223,7 +233,7 @@ sudo nano /etc/php/7.4/mods-available/imagick.ini
 
 with following content:
 
-[source,console]
+[source,plaintext]
 ----
 ; configuration for php imagick module
 extension=imagick.so

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation.adoc
@@ -58,7 +58,7 @@ Download the archive of the latest ownCloud version:
   You can download either the `.tar.bz2` or `.zip` archive. Based on the example below, copy the
   link of the selected file and run the following command to download it: +
 +
-[source,console,subs="attributes+"]
+[source,bash,subs="attributes+"]
 ----
 wget https://download.owncloud.org/community/{oc-complete-name}.tar.bz2
 ----

--- a/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/script_guided_install.adoc
@@ -19,7 +19,7 @@ TIP: You can also use these scripts if you want to set or reapply strong permiss
 
 * This is a brief overview of main directories in case you use linking. Note that `/mnt/owncloud_data` can be for example nfs mounted. The script takes care of proper linking the source to the target.
 +
-[source]
+[source,plaintext]
 ----
 /mnt/owncloud_data
  └ apps-external
@@ -34,7 +34,7 @@ TIP: You can also use these scripts if you want to set or reapply strong permiss
 
 * This is a brief overview of main directories in case you use standard directories
 +
-[source]
+[source,plaintext]
 ----
 /var/www/owncloud
  └ apps

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -181,7 +181,7 @@ sudo update-alternatives --config php
 ----
 Here is an example output:
 
-[source,console]
+[source,plaintext]
 ----
 There are 2 choices for the alternative php (providing /usr/bin/php).
 
@@ -282,7 +282,7 @@ sudo service apache2 restart
 
 NOTE: Do not get confused by the name `smbclient`. It is on the one hand a {smbclient_url}[command-line SMB/CIFS client for Unix], and on the other hand the package name for the {pecl_url}[PECL smbclient] PHP extension
 
-NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[source,plaintext].
+NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[source].
 
 == php-imagick Library
 
@@ -308,7 +308,9 @@ Example:
 ----
 sudo phpenmod php-ldap
 ----
+
 or
+
 [source,bash]
 ----
 sudo phpdismod php-ldap

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -223,7 +223,7 @@ WARNING: You may get completely unexpected behaviour or a broken environment if 
 
 If you are using a PECL install later on, check the output of the installation command soon after it has started. You will find a text like:
 
-[source]
+[source,plaintext]
 ----
 ...
 PHP Api Version:         20190902
@@ -240,14 +240,14 @@ php -i | grep extension_dir
 
 If the output is different than the style below, there is a problem that needs fixing:
 
-[source]
+[source,plaintext]
 ----
 extension_dir => /usr/lib/php/20180731 => /usr/lib/php/20180731
 ----
 
 This is the output that shows a fix is needed:
 
-[source]
+[source,plaintext]
 ----
 PHP Warning:  PHP Startup: smbclient: Unable to initialize module
 Module compiled with module API=20190902
@@ -282,7 +282,7 @@ sudo service apache2 restart
 
 NOTE: Do not get confused by the name `smbclient`. It is on the one hand a {smbclient_url}[command-line SMB/CIFS client for Unix], and on the other hand the package name for the {pecl_url}[PECL smbclient] PHP extension
 
-NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[source].
+NOTE: Alternatively you can install `smbclient` from {libsmbclient-php_url}[source,plaintext].
 
 == php-imagick Library
 

--- a/modules/admin_manual/pages/installation/selinux_configuration.adoc
+++ b/modules/admin_manual/pages/installation/selinux_configuration.adoc
@@ -49,7 +49,7 @@ restorecon -Rv '/var/www/html/owncloud/'
 If you have customized SELinux policies and these examples do not work,
 you must give the HTTP server write access to these directories:
 
-[source]
+[source,plaintext]
 ----
 /var/www/html/owncloud/data
 /var/www/html/owncloud/config

--- a/modules/admin_manual/pages/installation/troubleshooting.adoc
+++ b/modules/admin_manual/pages/installation/troubleshooting.adoc
@@ -5,7 +5,7 @@ your ownCloud log please refer to
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB with Binary Logging Enabled]
 for how to resolve it.
 
-[source]
+[source,plaintext]
 ----
 An unhandled exception has been thrown: exception ‘PDOException’ with message 'SQLSTATE[HY000]: General error: 1665 Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging. InnoDB is limited to row-logging when transaction isolation level is READ COMMITTED or READ UNCOMMITTED.'
 ----

--- a/modules/admin_manual/pages/maintenance/backup_and_restore/restore.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/restore.adoc
@@ -87,7 +87,7 @@ sudo sqlite3 data/owncloud.db < owncloud-dbbackup.bak
 
 === PostgreSQL
 
-[source,console]
+[source,plaintext]
 ----
 PGPASSWORD="password" pg_restore -c -d owncloud -h [server] -U [username] owncloud-dbbackup.bak
 ----
@@ -140,11 +140,14 @@ If it's not suitable for yours, you might need to run an OCC command that does t
 2. In the live database instance, find the `fileid` of the file to restore by
    running the query below, substituting the placeholders for the retrieved
    values, and store the value for later reference.
-
-   SELECT fileid
-   FROM oc_filecache
-   WHERE path = 'path/to/the/file/to/restore'
-     AND storage = <numeric_id>
++
+[source,sql]
+----
+SELECT fileid
+FROM oc_filecache
+WHERE path = 'path/to/the/file/to/restore'
+  AND storage = <numeric_id>
+----
 
 3. Retrieve the backup, which includes the data folder and database.
 
@@ -154,18 +157,24 @@ If it's not suitable for yours, you might need to run an OCC command that does t
    the query below and store the value for later reference.
    The example query assumes the storage was the same and the file was in the same location.
    If not, you will need to track down where the file was before.
-
-   SELECT encrypted
-   FROM oc_filecache
-   WHERE path = 'path/to/the/file/to/restore'
-     AND storage = <numeric_id>
++
+[source,sql]
+----
+SELECT encrypted
+FROM oc_filecache
+WHERE path = 'path/to/the/file/to/restore'
+  AND storage = <numeric_id>
+----
 
 6. Update the live database instance with the retrieved information, by running the
    following query, substituting the placeholders with the retrieved values:
-
-   UPDATE oc_filecache
-     SET encrypted = <encrypted>
-     WHERE fileid = <fileid>.
++
+[source,sql]
+----
+UPDATE oc_filecache
+  SET encrypted = <encrypted>
+  WHERE fileid = <fileid>.
+----
 
 == Final Tasks
 
@@ -173,19 +182,22 @@ If it's not suitable for yours, you might need to run an OCC command that does t
 
 Perform the following tasks to reactivate your ownCloud instance:
 
-.Update the systems data-fingerprint after a backup is restored
+==== Update the systems data-fingerprint after a backup is restored
+
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:data-fingerprint
 ----
 
-.Bring back ownCloud into normal operation mode
+==== Bring back ownCloud into normal operation mode
+
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} maintenance:mode --off
 ----
 
-.Enable browser access
+==== Enable browser access
+
 Start your web server, or alternatively enable the virtual host serving ownCloud:
 [source,bash]
 ----

--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -179,7 +179,7 @@ Enter the admin user's password and you'll be in the QNAP Console Management - M
 
 In the Console Management you have several options that might be useful at some point:
 
-[source]
+[source,plaintext]
 ----
 +--------------------------------------------------------------------+
 |  Console Management - Main menu                                    |

--- a/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
+++ b/modules/admin_manual/pages/troubleshooting/path_filename_length.adoc
@@ -72,13 +72,13 @@ Starting in Windows 10, version 1607, MAX_PATH limitations have been removed fro
 (*)::
 In Unix environments, PATH_MAX with 4096 bytes and NAME_MAX with 255 bytes are very common limitations for applications including the Shell. You can get the current limitations by typing the following example commands, see the {getconf-url}[getconf manpage] for details:
 +
-[source,console]
+[source,plaintext]
 ----
 getconf NAME_MAX /
 255
 ----
 +
-[source,console]
+[source,plaintext]
 ----
 getconf PATH_MAX /
 4096
@@ -87,13 +87,13 @@ getconf PATH_MAX /
 (**)::
 Although not officially documented, when searching on the internet there is a limit with path names exceeding 1024 bytes. Users report warnings in Finder, the Shell or apps about this behavior. This can be verified with:
 +
-[source,console]
+[source,plaintext]
 ----
 getconf NAME_MAX /
 255
 ----
 +
-[source,console]
+[source,plaintext]
 ----
 getconf PATH_MAX /
 1024

--- a/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
+++ b/modules/admin_manual/pages/troubleshooting/remove_non_existent_bg_jobs.adoc
@@ -9,7 +9,7 @@ During the lifecycle of ownCloud, some background jobs may get removed as they a
 
 If the ownCloud log files contain errors like:
 
-[source]
+[source,plaintext]
 ----
 "Exception: {"Exception":"OCP\AppFramework\QueryException","Message":"Could not resolve OCA\User_LDAP\Jobs\UpdateGroups! Class OCA\User_LDAP\Jobs\UpdateGroups does not exist","Code":0,"Trace":"
 
@@ -40,7 +40,7 @@ Use the following command to list all active background jobs triggered by ownClo
 
 The output may look like the following:
 
-[source]
+[source,plaintext]
 ----
 +----+---------------------------------------------------+---------------------------+---------------+
 | Id | Job                                               | Last run                  | Job Arguments |


### PR DESCRIPTION
When no source language is set, use plaintext instead as this enables css for languages.
More language fixes

Backport to 10.9 and 10.8
(needs checking for 10.8 that nothing sneacks in from master)