### PR TITLE
Fix typo

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/index.php-less_URLs.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/index.php-less_URLs.adoc
@@ -10,6 +10,7 @@ instead of `\https://example.com/index.php/apps/files/`, you can enable it by fo
 
 Log in to the Docker container running ownCloud, and execute the following command on the host system of the appliance:
 
+[source,bash]
 ----
 univention-app shell owncloud
 ----
@@ -17,6 +18,7 @@ univention-app shell owncloud
 Your web server needs to have the following modules enabled: `mod_rewrite` and `mod_env`.
 If you have not yet enabled these modules, or are not sure if you have, execute these commands:
 
+[source,apache]
 ----
 a2enmod env rewrite
 ----
@@ -25,6 +27,7 @@ You need an *owncloud.conf* in your `/etc/apache2/sites-available/` directory.
 
 Open `/etc/apache2/sites-available/owncloud.conf` in nano, Vim, or your editor of choice, and paste the following:
 
+[source,apache]
 ----
 Alias /owncloud "/var/www/owncloud/"
 
@@ -44,6 +47,7 @@ Alias /owncloud "/var/www/owncloud/"
 
 Then create a symlink to `/etc/apache2/sites-enabled`, as follows:
 
+[source,bash]
 ----
 ln -s /etc/apache2/sites-available/owncloud.conf /etc/apache2/sites-enabled/owncloud.conf
 ----
@@ -52,6 +56,7 @@ ln -s /etc/apache2/sites-available/owncloud.conf /etc/apache2/sites-enabled/ownc
 
 Adjust your config.php to look like the following:
 
+[source,php]
 ----
 'overwrite.cli.url' => 'https://example.com/owncloud',
 'htaccess.RewriteBase' => '/owncloud',
@@ -59,12 +64,14 @@ Adjust your config.php to look like the following:
 
 Execute the command:
 
+[source,bash,subs="attributes+"]
 ----
-occ maintenance:update:htaccess
+{occ-command-example-prefix} maintenance:update:htaccess
 ----
 
 Restart or reload your Apache server, by running the following command:
 
+[source,bash]
 ----
 service apache2 reload
 ----

--- a/modules/admin_manual/pages/appliance/configuration/login_information.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/login_information.adoc
@@ -3,6 +3,7 @@
 
 Welcome to the ownCloud Appliance. Here are the login credentials.
 
+[source,plaintext]
 ----
 username: owncloud
 password: owncloud
@@ -10,6 +11,7 @@ password: owncloud
 
 Log in to the Appliance via command line or SSH with the root account.
 
+[source,plaintext]
 ----
 username: root
 password: <Administrator password>
@@ -23,6 +25,7 @@ univention-app shell owncloud
 
 Set ownCloud as the default page instead of the Univention Portal
 
+[source,bash]
 ----
 ucr set apache2/startsite=/owncloud
 service apache2 restart
@@ -30,18 +33,21 @@ service apache2 restart
 
 ownCloud's data directory is under the following path:
 
+[source,bash]
 ----
 /var/lib/univention-appcenter/apps/owncloud/data
 ----
 
 ownCloud's config directory, containing config.php:
 
+[source,bash]
 ----
 /var/lib/univention-appcenter/apps/owncloud/conf
 ----
 
 File extension blacklist for the Ransomware app:
 
+[source,bash]
 ----
 /var/lib/univention-appcenter/apps/owncloud/data/custom/ransomware_protection/blacklist.txt.dist
 ----

--- a/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/wnd_setup.adoc
@@ -64,6 +64,7 @@ Create or add a `crontab` file in `/etc/cron.d/oc-wnd-process-queue`.
 an appropriate `occ wnd:process-queue` command. The commands must be **strictly sequential**.
 This can be done by using `flock -n` and tuning the `-c` parameter of `occ wnd:process-queue`
 
+[source,plaintext]
 ----
 0 */15 * * *     root  /usr/bin/univention-app shell owncloud occ wnd:process-queue -vvv SERVER SHARE
 ----

--- a/modules/admin_manual/pages/appliance/maintenance/backup.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/backup.adoc
@@ -8,12 +8,14 @@ The backup remains on the host system and can be restored.
 
 It is stored in :
 
+[source,plaintext]
 ----
 /var/lib/univention-appcenter/backups/ 
 ----
 
 The file name is :
 
+[source,plaintext]
 ----
 appcenter-backup-owncloud:date
 ----
@@ -22,6 +24,7 @@ In it, you find your data and conf folders.
 
 Your database backup is in :
 
+[source,plaintext]
 ----
 /var/lib/univention-appcenter/backups/data/backups
 ----

--- a/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
+++ b/modules/admin_manual/pages/appliance/maintenance/howto-update-owncloud.adoc
@@ -124,6 +124,10 @@ information about the current state of every installed App.
 [source,console]
 ----
 root@ucs-9446:~# univention-app info
+
+----
+[source,plaintext]
+----
 UCS: 4.2-1 errata165
 App Center compatibility: 4
 Installed: 4.1/owncloud=10.0.1-20170523
@@ -152,6 +156,10 @@ longer upgradable.
 [source,console]
 ----
 root@ucs-9446:~# univention-app info
+----
+
+[source,plaintext]
+----
 UCS: 4.2-1 errata165
 App Center compatibility: 4
 Installed: 4.1/owncloud=10.0.3-20170918
@@ -180,6 +188,7 @@ Given that, you first have to uninstall the existing version and then
 install the 10.x version. To do so, run the following commands:
 
 The following assumes that owncloud82 is the currently installed version
+
 [source,console]
 ----
 univention-app remove owncloud82

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
@@ -356,7 +356,7 @@ Available keys, along with default values for configValue, are listed in the tab
 | ldapGroupMemberAssocAttr      | uniqueMember
 | ldapHost                      | ldap://host
 | ldapIgnoreNamingRules         |
-| ldapLoginFilteplaintext       | (&((objectclass=inetOrgPerson))(uid=%uid))
+| ldapLoginFilter               | (&((objectclass=inetOrgPerson))(uid=%uid))
 | ldapLoginFilterAttributes     |
 | ldapLoginFilterEmail          | 0
 | ldapLoginFilterMode           | 0

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -199,6 +199,7 @@ sudo service hsmdaemon start
 
 If it installs successfully, you should see the following console output:
 
+[source,plaintext]
 ----
 Install HSM Daemon:           [  OK  ]
 ----
@@ -218,6 +219,7 @@ The daemon is managed using the following three commands:
 
 To set the path to the PKCS11 module, update the line below in `/etc/hsmdaemon/hsmdaemon.toml`, with the appropriate path on your system.
 
+[source,toml]
 ----
 [pkcs11]
 # softhsm v2
@@ -231,7 +233,10 @@ This command lists the available slots.
 [source,bash]
 ----
 sudo hsmdaemon listslots
+----
 
+[source,plaintext]
+----
 {"level":"debug","ts":"2019-02-14T09:27:02.068+0100","caller":"hsmdaemon/keymanager.go:27","msg":"initialize pkcs11 module","module":"/usr/lib/softhsm/libsofthsm2.so"}
 {"level":"info","ts":"2019-02-14T09:27:02.087+0100","caller":"hsmdaemon/keymanager.go:65","msg":"Slots found","slotIds":[550099622,1989683358,2]}
 Available slots:
@@ -369,9 +374,15 @@ You should see output similar to the example below:
 [source,bash]
 ----
 key_id=$(sudo grep "generated keypair" /var/log/hsm.log | head -1 | jq .tokenID -r)
+----
 
+[source,plaintext]
+----
 hello="Hello, world!"
+----
 
+[source,bash]
+----
 echo "$hello" | base64
 
 SGVsbG8sIHdvcmxkIQo=
@@ -431,7 +442,10 @@ During ownCloud config, you might want to run the hsmdaemon service in the foreg
 [source,bash]
 ----
 sudo hsmdaemon
+----
 
+[source,plaintext]
+----
 {
     "level": "info",
     "ts": "2019-02-14T09:32:59.081+0100",
@@ -465,7 +479,9 @@ Generate a shared secret to use for the `hsmdaemon`.
 [source,bash]
 ----
 cat /proc/sys/kernel/random/uuid
-
+----
+[source,plaintext]
+----
 7a7d1826-b514-4d9f-afc7-a7485084e8de
 ----
 
@@ -505,7 +521,7 @@ Enable the HSM mode and enable encryption by running the commands in the followi
 
 If the commands are successful, you should see the following console output:
 
-[source,bash]
+[source,plaintext]
 ----
 encryption enabled
 

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/softhsm2.adoc
@@ -75,7 +75,7 @@ sudo zypper addrepo \
 
 Running `zypper lr` again should now display an additional line:
 
-[source,bash]
+[source,plaintext]
 ----
 13 | security                 | openSUSE-Leap-15.3-Security             | Yes     | (r ) Yes  | No
 ----


### PR DESCRIPTION
Fixes a typo `ldapLoginFilteplaintext` --> `ldapLoginFilter` and corrects some languages.

Backport to 10.9 and 10.8