### PR TITLE
Inactivate the user guide

### DIFF
--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -1,4 +1,4 @@
 * xref:index.adoc[Introduction]
 include::admin_manual:partial$nav.adoc[]
-include::user_manual:partial$nav.adoc[]
+// include::user_manual:partial$nav.adoc[]
 include::developer_manual:partial$nav.adoc[]

--- a/site.yml
+++ b/site.yml
@@ -64,6 +64,9 @@ asciidoc:
     std-port-memcache: '11211'
     std-port-mysql: '3306'
     std-port-redis: '6379'
+#   webui
+    latest-webui-version: 'next'
+    previous-webui-version: 'next'
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'


### PR DESCRIPTION
This PR **inactivates** the user guide.

We do the transition of the user guide from this repo to docs-webui in three steps:

1. Add the `docs-webui` repo which contains the user guide from server in `docs`
2. Comment out the user guide entry in the navigation
3. Remove the user guide from this repo including all necessary link fixes

Merge only when https://github.com/owncloud/docs/pull/4711 (Add user guides) has been merged.

Backport to 10.9 and 10.8