### PR TITLE
Fix some broken links found after migrating the user manual

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/smb.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/smb.adoc
@@ -12,7 +12,7 @@ ownCloud can connect to Windows file servers, and other SMB-compatible servers (
 == Dependencies
 
 To connect ownCloud to an SMB file server, you need to prepare your server. Please see the
-xref:installation/manual_installation/index.adoc[Manual Installation on Linux] guides for more
+xref:installation/manual_installation/manual_installation.adoc[Manual Installation on Linux] guides for more
 information, prerequisites and requirements.
 
 == Access Testing

--- a/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
+++ b/modules/admin_manual/pages/configuration/server/index_php_less_urls.adoc
@@ -11,7 +11,7 @@ Before being able to use index.php-less URLs you need to enable the `mod_rewrite
 
 Furthermore these instructions are only working when using Apache together with the `mod_php` Apache module for PHP. Other modules like `php-fpm` or `mod_fastcgi` are unsupported.
 
-Finally the user running your Web server (e.g. `www-data`) needs to be able to write into the `.htaccess` file shipped within the ownCloud root directory (e.g., `/var/www/owncloud/.htaccess`).  If you have applied xref:installation/manual_installation/manual_installation.adoc#script-guided-installation[Set Correct Permissions], the user might be unable to write into this file and the needed update will fail. You need to revert this strong permissions temporarily by following the steps described in xref:maintenance/update.adoc#setting-permissions-for-updating[setting permissions for updating].
+Finally the user running your Web server (e.g. `www-data`) needs to be able to write into the `.htaccess` file shipped within the ownCloud root directory (e.g., `/var/www/owncloud/.htaccess`).  If you have applied xref:installation/manual_installation/manual_installation.adoc#script-guided-installation[Set Correct Permissions], the user might be unable to write into this file and the needed update will fail. You need to revert this strong permissions temporarily by following the steps described in xref:maintenance/upgrading/update.adoc#setting-permissions-for-updating[setting permissions for updating].
 
 == Configuration steps
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ransomware_protection_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ransomware_protection_commands.adoc
@@ -1,10 +1,9 @@
 = Ransomware Protection (Enterprise Edition only)
-:page-noindex: yes
 
 Marketplace URL: {oc-marketplace-url}/apps/ransomware_protection[Ransomware Protection]
 
 Use these commands to help users recover from a Ransomware attack.
-You can find more information about the application in xref:enterprise/security/ransomware-protection/index.adoc[the Ransomware Protection documentation].
+You can find more information about the application in the xref:enterprise/security/ransomware-protection/index.adoc[Ransomware Protection documentation].
 
 == Command Description
 

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -80,7 +80,7 @@ To install the application, download the {oc-marketplace-url}/apps/oauth2[OAuth2
 
 To enable token-only based app or client logins in `config/config.php`, set `token_auth_enforced` to `true`. See xref:configuration/server/config_sample_php_parameters.adoc[config sample file] for more details.
 
-TIP: The OAuth2 app comes with a set of ´occ´ commands to configure clients. For more information on usage of ´occ´ for OAuth2, see section xref:server/occ_commands/app_commands/_oauth2_commands.adoc[OAuth2 Commands].
+TIP: The OAuth2 app comes with a set of ´occ´ commands to configure clients. For more information on usage of ´occ´ for OAuth2, see section xref:configuration/server/occ_commands/app_commands/_oauth2_commands.adoc[OAuth2 Commands].
 
 ==== Trusting Clients
 

--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -53,7 +53,7 @@ Once enabled, default share permissions for all users can be enabled. Currently,
 
 * *{secure-view-label}*. 
    When enabled, files are shared in secure view mode. In this mode, all the
-   xref:secure-view-limitations[Secure View Limitations] take effect. 
+   xref:limitations-and-security-hardening[Limitations and Security Hardening] take effect. 
    When this mode and "_can edit_" are disabled, the share is a regular "read-only" share.
 * *Can print / export PDF*. 
 +

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -49,7 +49,7 @@ The recommendations presented here are based on a standard ownCloud installation
 * Database: MySQL/MariaDB with InnoDB storage engine (MyISAM is not supported, see:
 xref:configuration/database/linux_database_configuration.adoc#mysql-mariadb[MySQL / MariaDB storage engine])
 * And a recent PHP Version. See xref:installation/system_requirements.adoc[System Requirements]
-* Consider setting up a scale-out deployment, or using xref:{latest-webui-version}@webui:classic_ui::files/federated_cloud_sharing.adoc[Federated Cloud Sharing] to keep individual ownCloud instances to a manageable size.
+* Consider setting up a scale-out deployment, or using xref:{latest-webui-version}@webui:classic_ui:files/federated_cloud_sharing.adoc[Federated Cloud Sharing] to keep individual ownCloud instances to a manageable size.
 
 NOTE: Whatever the size of your organization, always keep one thing in mind: +
 *The amount of data stored in ownCloud will only grow - plan ahead.*
@@ -132,7 +132,7 @@ Alternatively, you can make nightly backups — with service interruption — as
 4.  Push database dump to backup.
 5.  Start Apache.
 
-After these steps have been completed, then, optionally, rsync the backup to either an external backup storage or tape backup. See xref:maintenance/index.adoc[the Maintenance section] of the Administration manual for tips on backups and restores.
+After these steps have been completed, then, optionally, rsync the backup to either an external backup storage or tape backup. See the xref:maintenance/backup_and_restore/backup.adoc[backup] and  xref:maintenance/backup_and_restore/restore.adoc[restore] section of the Administration manual for tips on backups and restores.
 
 ==== Authentication
 

--- a/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
+++ b/modules/admin_manual/pages/installation/linux_packetmanager_install.adoc
@@ -115,7 +115,7 @@ zypper removelock owncloud-complete-files
 The package comes without dependencies which means, that the server will not directly run after installing it.
 
 To get the dependencies installed and configured, follow one of the guides provided in section 
-xref:installation/manual_installation/index.adoc[Manual Installation on Linux]
+xref:installation/manual_installation/manual_installation.adoc[Manual Installation on Linux]
 
 NOTE: See the system_requirements for the recommended ownCloud setup and supported platforms.
 

--- a/modules/admin_manual/partials/maintenance/major_release_note.adoc
+++ b/modules/admin_manual/partials/maintenance/major_release_note.adoc
@@ -1,6 +1,6 @@
 [IMPORTANT]
 ====
-When upgrading, also check the minimum and maximum supported PHP version of the ownCloud target release. An ownCloud release may require a particular minimum and/or maximum PHP version. Check that the PHP version provided by the Operating System meets the requirements. For details see the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[Server Release Notes] and the xref:{latest-server-version}@server:installation/system_requirements.adoc[System Requirements] for the latest Release.
+When upgrading, also check the minimum and maximum supported PHP version of the ownCloud target release. An ownCloud release may require a particular minimum and/or maximum PHP version. Check that the PHP version provided by the Operating System meets the requirements. For details see the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[Server Release Notes] and the xref:{latest-server-version}@server:admin_manual:installation/system_requirements.adoc[System Requirements] for the latest Release.
 ====
 
 [TIP]
@@ -16,7 +16,7 @@ Here are some examples:
 |===
 |Version
 |Can Upgrade to {latest-server-download-version} ?
-|Requirements (always check the xref:{latest-server-version}@server:installation/system_requirements.adoc[System Requirements] too)
+|Requirements (always check the xref:{latest-server-version}@server:admin_manual:installation/system_requirements.adoc[System Requirements] too)
 
 |10.X.Y
 |Yes

--- a/modules/developer_manual/pages/testing/test-pilots.adoc
+++ b/modules/developer_manual/pages/testing/test-pilots.adoc
@@ -62,7 +62,7 @@ somewhere!
 
 Start by installing ownCloud, either on real hardware or in a VM. You
 can find instructions for installing ownCloud in the
-xref:admin_manual:installation/manual_installation/index.adoc[Manual Installation on Linux] or
+xref:admin_manual:installation/manual_installation/manual_installation.adoc[Manual Installation on Linux] or
 xref:admin_manual:installation/linux_packetmanager_install.adoc[Linux Package Manager Installation]
 
 Please note that we are still working on the documentation and if you

--- a/modules/developer_manual/pages/webdav_api/files_versions.adoc
+++ b/modules/developer_manual/pages/webdav_api/files_versions.adoc
@@ -6,11 +6,14 @@
 
 == Introduction
 
-The files versions API allows for two things:
+// The files versions API allows for two things:
+
+The files versions API allows the following:
 
 * xref:list-file-versions[Listing file versions]
-* xref:restore-another-version-of-a-file[Restoring previous versions of files]
 
-//Note that "xref:restore-another-version-of-a-file" is missing in the included partial... using git log --follow -p modules/developer_manual/pages/_partials/webdav_api/files_versions/list_files_versions.adoc does not return a deletion = it was missing from teh beginning
+// * xref:restore-another-version-of-a-file[Restoring previous versions of files]
+
+// Note that "xref:restore-another-version-of-a-file" is missing in the included partial... using git log --follow -p modules/developer_manual/pages/_partials/webdav_api/files_versions/list_files_versions.adoc does not return a deletion = it was missing from the beginning
 
 include::partial$webdav_api/files_versions/list_files_versions.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR fixes some broken internal links which were found after a full build post the user manual move with `htmltest`. Note that this are not broken links because of the migration.

Backport to 10.9 and 10.8
(Note that we have to check the 10.8 backport for stuff not belonging to there...)