### PR TITLE
Correct system requirement text for 10.8 only

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -64,7 +64,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |* {supported-php-versions}
 |===
 
-(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
+(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards.
 
 [NOTE]
 ====


### PR DESCRIPTION
Small fix to correct a link (reference is not present) + text that is not intended to be in 10.8

No backport, 10.8 only