### PR TITLE
Broken internal link fix

### DIFF
--- a/modules/admin_manual/pages/configuration/search/index.adoc
+++ b/modules/admin_manual/pages/configuration/search/index.adoc
@@ -27,7 +27,7 @@ service elasticsearch restart
 To install the app, use the Marketplace app on your ownCloud server or proceed manually:
 
 . Download and extract the tarball of {search_elastic-app-url}[the Full Text Search app] to the apps directory (or xref:installation/apps_management_installation.adoc#using-custom-app-directories[custom apps directory]) of your ownCloud instance.
-. Use the xref:configuration/server/occ_command.adoc#apps-commands[occ app:enable] to enable the search_elastic application.
+. Use the xref:configuration/server/occ_command.adoc#apps-commands[occ app:enable] to enable the `search_elastic` application.
 
 To configure the Full Text Search, go to menu:admin[Settings > Search] and set the hostname (or IP address) and port of the Elasticsearch server and click btn:["Setup index"].
 

--- a/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/oauth2.adoc
@@ -80,7 +80,7 @@ To install the application, download the {oc-marketplace-url}/apps/oauth2[OAuth2
 
 To enable token-only based app or client logins in `config/config.php`, set `token_auth_enforced` to `true`. See xref:configuration/server/config_sample_php_parameters.adoc[config sample file] for more details.
 
-TIP: The OAuth2 app comes with a set of ´occ´ commands to configure clients. For more information on usage of ´occ´ for OAuth2, see section xref:configuration/server/occ_commands/app_commands/_oauth2_commands.adoc[OAuth2 Commands].
+TIP: The OAuth2 app comes with a set of `occ` commands to configure clients. For more information on usage of `occ` for OAuth2, see section xref:configuration/server/occ_command.adoc#oauth2[OAuth2 Commands].
 
 ==== Trusting Clients
 


### PR DESCRIPTION
Fixing a broken link to an occ command in `configuration/server/security/oauth2.adoc`
Small text fix included

Backport to 10.9 and 10.8