### PR TITLE
Update ubuntu_20_04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -214,10 +214,9 @@ Configure the execution of the cron job to every 15 min:
 
 [source,bash]
 ----
+
 echo "*/15  *  *  *  * /var/www/owncloud/occ system:cron" \
-  > /var/spool/cron/crontabs/www-data
-chown www-data.crontab /var/spool/cron/crontabs/www-data
-chmod 0600 /var/spool/cron/crontabs/www-data
+  | sudo -u www-data -g crontab tee -a /var/spool/cron/crontabs/www-data
 ----
 
 [NOTE]
@@ -227,9 +226,8 @@ If you need to sync your users from an LDAP or Active Directory Server, add this
 
 [source,bash]
 ----
-echo "*/15 * * * * /var/www/owncloud/occ user:sync 'OCA\User_LDAP\User_Proxy' -m disable -vvv >> /var/log/ldap-sync/user-sync.log 2>&1" >> /var/spool/cron/crontabs/www-data
-chown www-data.crontab  /var/spool/cron/crontabs/www-data
-chmod 0600  /var/spool/cron/crontabs/www-data
+echo "*/15 * * * * /var/www/owncloud/occ user:sync 'OCA\User_LDAP\User_Proxy' -m disable -vvv >> /var/log/ldap-sync/user-sync.log 2>&1" \
+  | sudo -u www-data -g crontab tee -a /var/spool/cron/crontabs/www-data
 mkdir -p /var/log/ldap-sync
 touch /var/log/ldap-sync/user-sync.log
 chown www-data. /var/log/ldap-sync/user-sync.log

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -215,7 +215,8 @@ Configure the execution of the cron job to every 15 min:
 [source,bash]
 ----
 echo "*/15  *  *  *  * /var/www/owncloud/occ system:cron" \
-  | sudo -u www-data -g crontab tee -a /var/spool/cron/crontabs/www-data
+  | sudo -u www-data -g crontab tee -a \
+  /var/spool/cron/crontabs/www-data
 ----
 
 [NOTE]
@@ -225,8 +226,11 @@ If you need to sync your users from an LDAP or Active Directory Server, add this
 
 [source,bash]
 ----
-echo "*/15 * * * * /var/www/owncloud/occ user:sync 'OCA\User_LDAP\User_Proxy' -m disable -vvv >> /var/log/ldap-sync/user-sync.log 2>&1" \
-  | sudo -u www-data -g crontab tee -a /var/spool/cron/crontabs/www-data
+echo "*/15 * * * * /var/www/owncloud/occ user:sync \
+  'OCA\User_LDAP\User_Proxy' -m disable -vvv >> \
+  /var/log/ldap-sync/user-sync.log 2>&1" \
+  | sudo -u www-data -g crontab tee -a \
+  /var/spool/cron/crontabs/www-data
 mkdir -p /var/log/ldap-sync
 touch /var/log/ldap-sync/user-sync.log
 chown www-data. /var/log/ldap-sync/user-sync.log

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -214,7 +214,6 @@ Configure the execution of the cron job to every 15 min:
 
 [source,bash]
 ----
-
 echo "*/15  *  *  *  * /var/www/owncloud/occ system:cron" \
   | sudo -u www-data -g crontab tee -a /var/spool/cron/crontabs/www-data
 ----


### PR DESCRIPTION
Simplify crontab manipulation code.
* Make commands independant of pre-existing file.
* Make commands robust against a new ubuntu bug in 21.04:  https://askubuntu.com/questions/1250974/user-root-cant-write-to-file-in-tmp-owned-by-someone-else-in-20-04-but-can-in#1251030
* Not sure if we really need to enforce mode 0600 -- don't think so.