### PR TITLE
expand install hints for postgresql (a bit)

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -43,19 +43,17 @@ To install postgres, use the following command (or that of your preferred packag
 
 [source,bash]
 ----
-sudo apt-get install postgresql
+sudo apt-get install postgresql php-pgsql
 ----
 
-In order to allow ownCloud access to the database, create a known password for the default user, `postgres`, which was added when the database was installed.
+In order to allow ownCloud access to the database, create a an ownlcoud user who owns the owncloud database.
 
 [source,bash]
 ----
-sudo -i -u postgres psql
-postgres=# \password
+sudo -u postgres -c "createuser -e -P owncloud" 
 Enter new password:
 Enter it again:
-postgres=# \q
-exit
+sudo -u postgres -c "createdb -e -O owncloud owncloud
 ----
 
 == Oracle 11g

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -46,14 +46,25 @@ To install postgres, use the following command (or that of your preferred packag
 sudo apt-get install postgresql php-pgsql
 ----
 
-In order to allow ownCloud access to the database, create an ownlcoud user who owns the owncloud database.
+In order to allow ownCloud access to the database, create an `ownlcoud` user who owns the `owncloud` database. The user and the database name can be any name that fits your needs.
 
+Create the `owncloud` PostgreSQL user account. Note that the default admin account post installing PostgreSQL is `postgres`. If you have created another postgres admin user and disabled the default one, use the new one instead.
 [source,bash]
 ----
-sudo -u postgres -c "createuser -e -P owncloud" 
+sudo -u postgres -c "createuser -e -P owncloud"
+----
+
+Define a password for the `owncloud` user. Note to remember this password to access the database later on:
+[source,plaintext]
+----
 Enter new password:
 Enter it again:
-sudo -u postgres -c "createdb -e -O owncloud owncloud
+----
+
+Create the `owncloud` database owned by the `owncloud` user:
+[source,bash]
+----
+sudo -u postgres -c "createdb -e -O owncloud owncloud"
 ----
 
 == Oracle 11g

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_db.adoc
@@ -46,7 +46,7 @@ To install postgres, use the following command (or that of your preferred packag
 sudo apt-get install postgresql php-pgsql
 ----
 
-In order to allow ownCloud access to the database, create a an ownlcoud user who owns the owncloud database.
+In order to allow ownCloud access to the database, create an ownlcoud user who owns the owncloud database.
 
 [source,bash]
 ----


### PR DESCRIPTION
postgresql install instructions facelift.
- add missing dependency package (for ubuntu)
- do not mess with postgres user - (that is a super administrator with all permissions.)
- instead add an owncloud user who only has control over the owncloud database.

(With `occ maintenance:install` the `--database pgsql` parameter choses postgresql  -- not sure, where this information would fit...)

I assume, postgresql 12 and 13, 14 work just fine with owncloud.
An official statement about supported versions should come from the nepal QA team, they start testing now.