### PR TITLE
Fix links to branded clients URL

### DIFF
--- a/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
@@ -16,7 +16,7 @@ image:ownbrander-1.png[ownBrander app button is on the top left of your ownCloud
 
 == Building a Branded Desktop Sync Client
 
-See https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+See https://doc.owncloud.com/branded_clients/next/[Building Branded ownCloud
 Clients] for instructions on building your own branded desktop sync
 client, and for setting up an automatic update service.
 
@@ -28,7 +28,7 @@ share account information or files.
 
 Building and distributing your branded iOS ownCloud app involves a large
 number of interdependent steps. The process is detailed in the
-https://doc.owncloud.com/branded_clients/[Building Branded ownCloud
+https://doc.owncloud.com/branded_clients/next/[Building Branded ownCloud
 Clients] manual. Follow these instructions exactly and in order, and you
 will have a nice branded iOS app that you can distribute to your users.
 
@@ -36,4 +36,4 @@ will have a nice branded iOS app that you can distribute to your users.
 
 Building and distributing your branded Android ownCloud app is fairly
 simple, and the process is detailed in
-https://doc.owncloud.com/branded_clients/[Building Branded ownCloud Clients].
+https://doc.owncloud.com/branded_clients/next/[Building Branded ownCloud Clients].


### PR DESCRIPTION
`https://doc.owncloud.com/branded_clients/` --> `https://doc.owncloud.com/branded_clients/next/`

Backport to 10.9 and 10.8