### PR TITLE
Prepare quoted text to be Antora 3 compliant

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/clamav.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/clamav.adoc
@@ -55,11 +55,10 @@ for instructions on how to do that.
 
 == Troubleshooting
 
-""
-If you try to update the ClamAV virus database manually, by entering
-`freshclam`, and see the error below, it means that
+====
+If you try to update the ClamAV virus database manually, by entering `freshclam`, and see the error below it means, that 
 https://linux.die.net/man/1/freshclam[freshclam] is already updating the database.
-""
+====
 
 [source,plaintext]
 ----

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -323,9 +323,10 @@ If users encrypt their files and lose their ownCloud password, they lose access 
 
 In such a case, you’ll see a yellow banner warning:
 
-""
+[source,plaintext]
+----
 Please provide an admin recovery password; otherwise, all user data will be lost.
-""
+----
 
 To avoid all this, create a Recovery Key. To do so, go to the Encryption section of your Admin page and set a recovery key password.
 

--- a/modules/admin_manual/pages/installation/deployment_recommendations.adoc
+++ b/modules/admin_manual/pages/installation/deployment_recommendations.adoc
@@ -32,10 +32,10 @@ NOTE: Independent of the technical measures, you can decide at any time the ownC
 
 == General Recommendations
 
-""
+____
 What is the best way to install and maintain ownCloud? +
 The answer to that is, as always: _'it depends'_.
-""
+____
 
 This is because every ownCloud customer has their own particular needs and IT infrastructure. However, both ownCloud and the LAMP stack are highly configurable. Given that, in this document we present a set of general recommendations, followed by three typical scenarios, and finish up with making best-practice recommendations for both software and hardware.
 

--- a/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/using_letsencrypt.adoc
@@ -134,10 +134,9 @@ sudo chmod +x <script-name>
 [NOTE]
 ====
 All scripts have to be executed with `sudo` as certbot {certbot-sudo-url}[requires enhanced privileges].
-
-""
+____
 If you're logged in to your server as a user other than root, you'll likely need to put sudo before your Certbot commands so that they run as root (for example, sudo certbot instead of just certbot)
-""
+____
 ====
 
 === cli.ini


### PR DESCRIPTION
While working on oCIS, I identified that quoted text need to be defined slightly different. This PR fixes this issue and uses the appropriate definition where neccesary. Not all texts remain quoted but defined as it should be. Note that quoted text in antora 2.3 can be encapsuled with `""` OR `____` (4x underline) while it is `____` (4x underline) with antora 3 only.

Backport to 10.9 and 10.8