### PR TITLE
onedrive app is not a standard enterprise app

### DIFF
--- a/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -3,6 +3,7 @@
 
 == Introduction
 
+This is a consulting app, in order to get access to it you need to contact sales@owncloud.com first.
 Follow this guide to use Microsoft OneDrive as an external storage option in ownCloud.
 
 == Create an Application Configuration

--- a/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/onedrive.adoc
@@ -3,8 +3,7 @@
 
 == Introduction
 
-This is a consulting app, in order to get access to it you need to contact sales@owncloud.com first.
-Follow this guide to use Microsoft OneDrive as an external storage option in ownCloud.
+To use the ownCloud OneDrive app, you mandatory need consulting first. Contact sales@owncloud.com to get access to. When granted, follow this guide to use Microsoft OneDrive as an external storage option in ownCloud.
 
 == Create an Application Configuration
 


### PR DESCRIPTION
The files_onedrive repository is private, this usually indicates that the app is a so called "consulting app" and only provided through (pre-)sales.
Perhaps @CaptionF @ChrisEdS you could confirm the actual process for access to this app?

Backport to 10.9 and 10.8