### PR TITLE
Add support for pgsql 11 12 13 14

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -54,7 +54,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |
 * MySQL 8+ or MariaDB 10.2, 10.3, 10.4 or 10.5 ^1^ (*Recommended*)
 * Oracle 11 and 12
-* PostgreSQL 9 and 10
+* PostgreSQL 9, 10, 11, 12, 13 or 14
 * SQLite (*Not for production*)
 
 |Web server


### PR DESCRIPTION
We have run the automated CI using pgsql 11, 12, 13 and 14 and no problems have been found.
See https://github.com/owncloud/enterprise/issues/5064 for the discussion and links to test PRs.

All these pgsql releases are working with both ownCloud server 10.9.1 and the current server core master.

We didn't test with ownCloud server 10.8 - so I suggest that we do not backport the support doc change to 10.8.

We can advertise support for these pgsql versions. Backport to 10.9 branch.