### PR TITLE
Remove Fedora

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -44,7 +44,6 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 |Operating System (64bit)
 |
 * Debian 10
-* Fedora 32 and 33
 * Red Hat Enterprise Linux/Centos 7.5 and 8
 * SUSE Linux Enterprise Server 12 with SP4/5 and 15
 * Ubuntu 20.04


### PR DESCRIPTION
Fedora has a much faster lifecycle (6 months?) and is, because of this in my opinion not suitable for server applications. Additionally, I don't know of any customers actually using it.

Edit: additionally, Fedora 32 & 33 are both EoL: https://docs.fedoraproject.org/en-US/releases/eol/