### PR TITLE
Updates to hardening guide

### DIFF
--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -18,7 +18,7 @@ However, it is still up to the server administrator to review and maintain syste
 == Limit on Password Length
 
 ownCloud uses the https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
-algorithm. it only verifies the
+algorithm. It only verifies the
 first 72 characters of passwords. This applies to all passwords you
 use in ownCloud: user passwords, passwords on link shares and passwords
 on external shares.

--- a/modules/admin_manual/pages/configuration/server/harden_server.adoc
+++ b/modules/admin_manual/pages/configuration/server/harden_server.adoc
@@ -18,8 +18,7 @@ However, it is still up to the server administrator to review and maintain syste
 == Limit on Password Length
 
 ownCloud uses the https://en.m.wikipedia.org/wiki/Bcrypt[bcrypt]
-algorithm. For security reasons (e.g., denial
-of service) and performance reasons as CPU load increases exponentially, it only verifies the
+algorithm. it only verifies the
 first 72 characters of passwords. This applies to all passwords you
 use in ownCloud: user passwords, passwords on link shares and passwords
 on external shares.
@@ -69,18 +68,6 @@ With this information, you can begin customizing a rate-limiting solution specif
 * https://www.fir3net.com/Loadbalancers/F5-BIG-IP/f5-ltm-ratelimiting.html[Rate limiting with F5]
 
 == Operating system
-
-=== Give PHP read access to `/dev/urandom`
-
-ownCloud uses a https://tools.ietf.org/html/rfc4086#section-5.2[RFC 4086 (`Randomness Requirements for Security`)]
-compliant mixer to generate cryptographically secure pseudo-random numbers.
-When generating a random number, ownCloud will request multiple random
-numbers from different sources and create from these the final random number.
-
-The random number generator also tries to request random numbers from
-`/dev/urandom`, therefore you should allow PHP to read from the device.
-
-NOTE: If you configure an `open_basedir` in your `php.ini` file, make sure to include `/dev/urandom`.
 
 === Enable hardening modules such as SELinux
 


### PR DESCRIPTION
-  brcrypt does not limit the password to 72 chars due to the reasons stated, but due to the limits of the underlying cipher it uses (blowfish) which only fully mixes up to 448 bits (56 chars) of the key.. but most implementations place an absolute limit of 576 bit  (72 chars) 

- Remove the section about /dev/urandom, it is clumsily worded and outdated, PHP now only uises /dev/urandom as a fallback and raises errors or exceptions if it cannot be opened. rfc4086 is not relevant to owncloud, meither to PHP which just consumes the OS entropy sources.

Backport to 10.9 and 10.8