### PR TITLE
MySQL Backup Use Single Transaction

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -278,13 +278,16 @@ these simple steps:
 docker-compose exec owncloud occ maintenance:mode --on
 ----
 
-. Create a backup in case something goes wrong during the upgrade process, using the following command:
+. Create a backup of the database in case something goes wrong during the upgrade process, using the following command:
 +
 [source,docker]
 ----
 docker-compose exec mariadb \
-     /usr/bin/mysqldump -u root --password=owncloud \
-     owncloud > owncloud_$(date +%Y%m%d).sql
+    /usr/bin/mysqldump \
+    -u root \
+    --password=owncloud \
+    --single-transaction \
+    owncloud > owncloud_$(date +%Y%m%d).sql
 ----
 +
 NOTE: You need to adjust the password and database name if you have changed it in your deployment.

--- a/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
@@ -77,18 +77,24 @@ Depending on the database version and the setup, username and password may not b
 
 [source,bash]
 ----
-sudo mysqldump --single-transaction -h [server] \
- -u [username] -p [password] \
- [db_name] > owncloud-dbbackup_`date +"%Y%m%d"`.bak
+sudo mysqldump \
+  --single-transaction \
+  -h [server] \
+  -u [username] \
+  -p [password] \
+  [db_name] > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 ----
 
 Example, replace username and password according your setup:
 
 [source,bash]
 ----
-sudo mysqldump --single-transaction -h localhost \
- -u username -p password \
- owncloud > owncloud-dbbackup_`date +"%Y%m%d"`.bak
+sudo mysqldump \
+  --single-transaction \
+  -h localhost \
+  -u username \
+  -p password \
+  owncloud > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 ----
 
 === SQLite
@@ -102,9 +108,11 @@ sqlite3 data/owncloud.db .dump > owncloud-dbbackup_`date +"%Y%m%d"`.bak
 
 [source,postgresql]
 ----
-PGPASSWORD="password" pg_dump [db_name] \
- -h [server] -U [username] \
- -f owncloud-dbbackup_`date +"%Y%m%d"`.bak
+PGPASSWORD="password" \
+  pg_dump [db_name] \
+  -h [server] \
+  -U [username] \
+  -f owncloud-dbbackup_`date +"%Y%m%d"`.bak
 ----
 
 == Backup Cron Jobs


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-server/issues/256 (Database backup command misses transaction parameter)

Also checked the standard backup page.

Backport to 10.9 and 10.8