### PR TITLE
Add WOPI Business Key

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -207,6 +207,8 @@ Possible keys: `wopi.office-online.server` URL
 
 Possible keys: `wopi_group` STRING
 
+Possible keys: `wopi.business-flow.enabled` STRING
+
 === Random key created by the ownCloud admin
 This is a random key created by the ownCloud admin. This key is used by ownCloud
 to create encrypted JWT tokens for the communication with your Microsoft Office Online instance.
@@ -242,6 +244,16 @@ Restrict access to Microsoft Office Online to a defined group. Please note, only
 [source,php]
 ....
 'wopi_group' => '',
+....
+
+=== Define if Business Flow Is Enabled
+This _global_ option defines if Office users are business users. In case, Office Online will check that the user logged in has an Office 365 business account. If not, the user must sign in and Office Online will check if the subscription is valid. Use `yes` to enable it and `no` or remove the key at all to disable it. To use this option, you need at minimum ownClouds {oc-marketplace-url}/apps/wopi[Microsoft Office Online] app version 1.6.0.
+
+==== Code Sample
+
+[source,php]
+....
+'wopi.business-flow.enabled' => 'no',
 ....
 
 == App: Microsoft Teams Bridge

--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -247,7 +247,7 @@ Restrict access to Microsoft Office Online to a defined group. Please note, only
 ....
 
 === Define if Business Flow Is Enabled
-This _global_ option defines if Office users are business users. In case, Office Online will check that the user logged in has an Office 365 business account. If not, the user must sign in and Office Online will check if the subscription is valid. Use `yes` to enable it and `no` or remove the key at all to disable it. To use this option, you need at minimum ownClouds {oc-marketplace-url}/apps/wopi[Microsoft Office Online] app version 1.6.0.
+This _global_ option defines if Office users are business users. In that case, Office Online will check if the user logged in has an Office 365 business account. If not, the user must sign in and Office Online will check if the subscription is valid. Use `yes` to enable it and `no` to disable it or remove the key completely. To use this option, you need at least ownClouds {oc-marketplace-url}/apps/wopi[Microsoft Office Online] app version 1.6.0.
 
 ==== Code Sample
 


### PR DESCRIPTION
Referencing: https://github.com/owncloud/wopi/issues/195 (Docu needed: Wopi 1.6.0 will support a new business user feature)

The key `wopi.business-flow.enabled` is now added to the config key list

Backport to 10.9 and 10.8