### PR TITLE
Relocate files_classifier document

### DIFF
--- a/modules/admin_manual/pages/enterprise/document_classification/classification_and_policy_enforcement.adoc
+++ b/modules/admin_manual/pages/enterprise/document_classification/classification_and_policy_enforcement.adoc
@@ -1,5 +1,7 @@
 = Document Classification and Policy Enforcement
 :toc: right
+:page-aliases: document_classification/index.adoc, enterprise/classification_and_policy_enforcement.adoc
+
 :iso_27001_url: https://www.iso.org/isoiec-27001-information-security.html
 :vda_url: https://www.vda.de/vda/en/Topics/digitalisierung/daten/informationssicherheit
 :novapath_url: https://www.m-und-h.de/en-novapath/

--- a/modules/admin_manual/pages/enterprise/document_classification/index.adoc
+++ b/modules/admin_manual/pages/enterprise/document_classification/index.adoc
@@ -1,0 +1,4 @@
+:section-title: Document Classification
+:section-preamble-ender: to configure document classification in ownCloud
+
+include::partial$section_page.adoc[]

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -167,6 +167,8 @@
 *** xref:admin_manual:enterprise/collaboration/index.adoc[Collaboration]
 **** xref:admin_manual:enterprise/collaboration/collabora_secure_view.adoc[Collabora Online / Secure View]
 **** xref:admin_manual:enterprise/collaboration/msoffice-wopi-integration.adoc[Microsoft Office Online / WOPI Integration]
+*** xref:admin_manual:enterprise/document_classification/index.adoc[Document Classification]
+**** xref:admin_manual:enterprise/document_classification/classification_and_policy_enforcement.adoc[Classify Documents and Enforce Policies]
 *** xref:admin_manual:enterprise/external_storage/index.adoc[External Storage]
 **** xref:admin_manual:enterprise/external_storage/enterprise_only_auth.adoc[Enterprise Only Authentication]
 **** xref:admin_manual:enterprise/external_storage/ldap_home_connector_configuration.adoc[LDAP Home Connector Configuration]
@@ -192,7 +194,6 @@
 *** xref:admin_manual:enterprise/user_management/index.adoc[User Management]
 **** xref:admin_manual:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
 **** xref:admin_manual:enterprise/user_management/saml_2.0_sso.adoc[SAML 2.0 Based SSO]
-** xref:admin_manual:document_classification/index.adoc[Document Classification]
 
 ** xref:admin_manual:troubleshooting/index.adoc[Troubleshooting]
 *** xref:admin_manual:troubleshooting/path_filename_length.adoc[Path and Filename Length Limitations]


### PR DESCRIPTION
The `files_classifier` app available on marketplace https://marketplace.owncloud.com/apps/files_classifier points to https://doc.owncloud.com/server/latest/admin_manual/enterprise/classification_and_policy_enforcement.html
which does not existent atm.

The document needed is:

* at the wrong location
* does not have the name needed

To be inline with the enterprise document scheme, the document has been moved, renamed and aliased properly.

Backport to 10.9 and 10.8

@ChrisEdS @xoxys FYI