### PR TITLE
Update manual_upgrade.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -187,6 +187,7 @@ Set the ownership for all files and folders to `www-data:www-data` for the `conf
 ----
 sudo chown -R www-data:www-data /var/www/owncloud/config
 sudo chown -R www-data:www-data /var/www/owncloud/data
+sudo chown -R www-data:www-data /var/www/owncloud/apps
 ----
 
 .Set correct permissions


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-server/issues/285 (Wrong owner of "apps" folder after doing manual upgrade)

Adding chown to the apps folder

Backport to 10.9 and 10.8