### PR TITLE
Config To Docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -320,6 +320,11 @@ on the login screen. The default is 15 days, expressed in seconds.
 ....
 
 === Define the lifetime of a session after inactivity
+The web UI might send a "heartbeat" based on the activity happening
+in order to extend the session lifetime and keeping it from timing out
+prematurely. If there is no activity happening and the lifetime is
+reached, you'll have to login again.
+
 The default is 20 minutes, expressed in seconds.
 
 ==== Code Sample
@@ -329,14 +334,37 @@ The default is 20 minutes, expressed in seconds.
 'session_lifetime' => 60 * 20,
 ....
 
-=== Enable or disable session keep-alive when a user is logged in to the Web UI
-Enabling this sends a "heartbeat" to the server to keep it from timing out.
+=== Enable session keep-alive when a user is logged in to the Web UI
+Enabling this sends a "heartbeat" to the server to keep it from
+timing out regardless of any activity happening. This heartbeat will
+keep extending the session over again, so the user won't be logged out
+even if he isn't active in the web UI.
 
 ==== Code Sample
 
 [source,php]
 ....
 'session_keepalive' => true,
+....
+
+=== Enable to force user logout
+Force the user to get logged out after the specified number of seconds when
+the tab or browser gets closed. A negative or 0 value disables this feature.
+
+Note that the user can still access the page without re-authenticating
+(having valid access) if the timeout has not been reached.
+The recommended minimum value is 5 or 10 seconds. Using a lower value
+might cause unwanted logouts for users.
+
+Note that this feature works properly if the user uses one tab only.
+If a user uses multiple tabs, closing one of them will likely
+force the rest to re-authenticate.
+
+==== Code Sample
+
+[source,php]
+....
+'session_forced_logout_timeout' => 0,
 ....
 
 === Enforce token only authentication for apps and clients connecting to ownCloud
@@ -394,8 +422,8 @@ WARNING: leave this as is if you're not sure what it does.
 ....
 
 === Define how to relax same site cookie settings
-
 Possible values: `Strict`, `Lax` or `None`.
+
 Setting the same site cookie to `None` is necessary in case of OpenID Connect.
 For more information about the impact of the values see:
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values and
@@ -717,7 +745,6 @@ user clicks an alert like this, they will be redirected to that URL and must log
 ....
 
 === Define the Web base URL
-
 This key is necessary for the navigation item to the new ownCloud Web UI and for redirecting
 public and private links.
 
@@ -729,8 +756,8 @@ public and private links.
 ....
 
 === Define rewrite private and public links
-
 Rewrite private and public links to the new ownCloud Web UI (if available).
+
 If web.rewriteLinks is set to 'true', public and private links will be redirected to this url.
 The Web UI will handle these links accordingly.
 
@@ -746,7 +773,6 @@ by ownCloud to 'http://web.example.com/index.html#/s/THoQjwYYMJvXMdW'.
 ....
 
 === Define clean URLs without `/index.php`
-
 This parameter will be written as `RewriteBase` on update and installation of
 ownCloud to your `.htaccess` file. While this value is often simply the URL
 path of the ownCloud installation it cannot be set automatically properly in
@@ -1370,10 +1396,10 @@ See the Previews Configuration documentation for more details.
 ....
 
 === Define the jpeg preview quality
-
 This setting defines the JP(E)G image quality in [%] for displaying thumbnails and image
 previews for apps like 'files_mediaviewer'. Note that this setting is for displaying
 only and has no impact on the stored thumbnail / preview quality or size.
+
 The scale ranges from 1 to 100, where 1 is the lowest and 100 the highest.
 It defaults to -1 which is equivalent to approximately 75% of the original
 image quality.
@@ -1426,7 +1452,6 @@ These options are for halting user activity when you are performing server
 maintenance.
 
 === Enable maintenance mode to disable ownCloud
-
 If you want to prevent users from logging in to ownCloud before you start
 doing some maintenance work, you need to set the value of the maintenance
 parameter to true. Please keep in mind that users who are already logged-in
@@ -1473,7 +1498,6 @@ who are not in the `admin` group.
 ....
 
 == Memory caching backend configuration
-
 Available cache backends:
 
 * `\OC\Memcache\APCu`       APC user backend
@@ -1545,16 +1569,15 @@ See http://redis.io/topics/security for more information.
 ....
 
 === Define Redis Cluster connection details
-
 Only for use with Redis Clustering, for Sentinel-based setups use the single
 server configuration above, and perform HA on the hostname.
 
 Redis Cluster support requires the php module phpredis in version 3.0.0 or higher.
 
 Available failover modes:
-- \RedisCluster::FAILOVER_NONE       - only send commands to master nodes (default)
-- \RedisCluster::FAILOVER_ERROR      - failover to slaves for read commands if master is unavailable
-- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across master and slaves
+- \RedisCluster::FAILOVER_NONE       - only send commands to primary nodes (default)
+- \RedisCluster::FAILOVER_ERROR      - failover to replicas for read commands if primary is unavailable
+- \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across primary and replica nodes
 
 ==== Code Sample
 
@@ -1784,8 +1807,7 @@ https://titanwolf.org/Network/Articles/Article?AID=58c487d4-7e0f-4fbe-9262-42855
 'mysql.utf8mb4' => false,
 ....
 
-=== Force a specific database platform class.
-
+=== Force a specific database platform class
 False means that autodetection will take place.
 
 E.g. to fix MariaDB 1.2.7+ taken for MySQL
@@ -2010,6 +2032,20 @@ NOTE: Lowering this value may lead to unexpected behaviour, and can include data
 'minimum.supported.desktop.version' => '2.3.3',
 ....
 
+=== Define the suggested poll interval for clients
+Specifies how often clients should poll the server for changes.
+
+The value is in milliseconds. The value is not enforced.
+Clients may use this value to decide how frequently to check the server for
+changes.
+
+==== Code Sample
+
+[source,php]
+....
+'pollinterval' => 30000,
+....
+
 === Define whether to include external storage in quota calculation
 EXPERIMENTAL: option whether to include external storage in quota
 calculation, defaults to false.
@@ -2206,15 +2242,14 @@ Set to `false` to disable.
 'upgrade.automatic-app-update' => true,
 ....
 
-=== Place this ownCloud instance into debugging mode
-
+=== Enable debugging mode for this ownCloud instance
 Only enable this for local development and not in production environments
 This will disable the minifier and outputs some additional debug information
 
 WARNING:
-   Be warned that, if you set this to `true`, exceptions display
-   stack traces on the web interface, *including passwords*, — **in plain text!**.
-   We strongly encourage you never to use it in production.
+Be warned that, if you set this to `true`, exceptions display
+stack traces on the web interface, *including passwords*, — **in plain text!**.
+We strongly encourage you never to use it in production.
 
 ==== Code Sample
 
@@ -2224,7 +2259,6 @@ WARNING:
 ....
 
 === Define the data-fingerprint of the current data served
-
 This is a property used by the clients to find out if a backup has been
 restored on the server. Once a backup is restored run
 {occ-command-example-prefix} maintenance:data-fingerprint
@@ -2286,17 +2320,18 @@ Set this property to true if you want to enable debug logging for SMB access.
 'dav.enable.async' => false,
 ....
 
-=== Allow propfind depth infinity
+=== Enable propfind depth infinity requests
+Tell the clients whether `depth=infinity` is allowed for propfind requests.
 
-With this setting that defaults to true, propfind requests will now be streamed to reduce memory usage
-with large responses. It tells the clients whether `depth=infinity` is allowed for propfind requests.
+Streamed infinite depth propfind requests can reduce memory usage
+with large responses.
 For details see: https://datatracker.ietf.org/doc/html/rfc4918#section-10.2
 
 ==== Code Sample
 
 [source,php]
 ....
-'dav.propfind.depth_infinity' => true,
+'dav.propfind.depth_infinity' => false,
 ....
 
 === Show the grace period popup


### PR DESCRIPTION
Config To Docs run based on recent changes in core.

Backport to 10.9 and 10.8 **BUT** with special care as not all changes belong to those branches...

Needs manual intervention when backporting

**No  backport at all:**
`=== Enable to force user logout`
`=== Define the suggested poll interval for clients`

**No backport to 10.8:**
`=== Enable propfind depth infinity requests`