### PR TITLE
Update the section for manual file locking in admin settings

### DIFF
--- a/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
+++ b/modules/admin_manual/pages/configuration/files/manual_file_locking.adoc
@@ -39,7 +39,7 @@ a|image::configuration/files/manual_file_locking/file-locked-unlock-symbol.png[F
 Administrators can enable _Manual File Locking_ for users either via the web interface or by executing an occ command: 
 
 Web interface::
-Go to menu:Settings[Admin > Additional]
+Go to menu:Settings[Admin > General]
 +
 image::configuration/files/manual_file_locking/manual-file-locking-with-lock-breaker.png[Enable file locking]
 
@@ -63,7 +63,7 @@ Maximum lifetime of locks which is allowed to be set by calling the WebDAV Locks
 Users who are a member of these groups can break locks set by another user.
 
 Web interface::
-Go to menu:Settings[Admin > Additional] +
+Go to menu:Settings[Admin > General] +
 The image is the same as shown above when enabling or disabling _Manual File Locking_.
 
 Using the occ command::


### PR DESCRIPTION
for 10.9 onwards, the section for manual file locking has been changed from `Additional` to `General`

ref https://doc.owncloud.com/docs/next/server_release_notes.html#manual-file-locking-ability-to-define-user-groups-that-can-unlock-files