### PR TITLE
Adding global attribute for ocis

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -74,6 +74,9 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
+    ocis-version: '2.0.0-beta1'
+    ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
+    ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   desktop
     latest-desktop-version: 'next'
     previous-desktop-version: 'next'


### PR DESCRIPTION
Adding global attribute for ocis.

Referencing: https://github.com/owncloud/docs/pull/4738

Backport to 10.10, 10.9 and 10.8