### PR TITLE
Fixing ticks in msoffice-wopi

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/msoffice-wopi-integration.adoc
@@ -74,7 +74,7 @@ To configure the WOPI app in your ownCloud installation, add the following confi
 # Enable Business Flow
 # Only for Office 365 (cloud), not needed for Office Online Server
 # Necessary for the O365 proxy key above.
-`wopi.business-flow.enabled` => 'yes',
+'wopi.business-flow.enabled' => 'yes',
 
 # Samesite Cookie
 # Only for Office 365 (cloud), not needed for Office Online Server


### PR DESCRIPTION
Wrong ticks were used in one config parameter..

Backport to 10.10, 10.9 and 10.8