### PR TITLE
shareType can't be optional if shareType is 1 or 0

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -703,7 +703,7 @@ Things to remember about public link shares
 
 *Mandatory Fields*
 
-`shareType`, `path` and `shareWith` are mandatory if `shareType` is set to 0 or 1
+`shareType` is mandatory; `path` and `shareWith` are mandatory if `shareType` is set to 0 or 1
 ====
 
 ==== Returns


### PR DESCRIPTION
Language kniefielseling.
No backports needed.