### PR TITLE
Memory caching for Ubuntu 22.04 + PHP 7.4 and Updating system requirements

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -81,7 +81,13 @@ The performance of Redis when used with a socket connection is close to the perf
 
 NOTE: The Redis PHP module must be at least version 2.2.6 or higher.
 
-NOTE: The default shipped Redis version and the php-redis extension for Ubuntu 20.04 is 5.x. With Redis version 6, a new authentication mechanism has been introduced named ACL (Access Control Lists). ownCloud does not currently support Redis ACL´s, but does support the password protection available with current Redis versions.
+[NOTE]
+====
+* For Ubuntu 20.04, the default shipped Redis Server version and the php-redis extension is 5.x.
+* For Ubuntu 22.04, the default shipped Redis Server version is 6.0.16.
+* For Ubuntu 22.04, the php7.4-redis extension has version 5.3.x.
+* With Redis version 6, a new authentication mechanism has been introduced named ACL (Access Control Lists). ownCloud does currently not support Redis ACL´s, but does support the password protection, available with current Redis versions.
+====
 
 ==== Installing Redis
 

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -46,7 +46,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 * Debian 10
 * Red Hat Enterprise Linux 7 and 8 including all 100% compatible derivatives
 * SUSE Linux Enterprise Server 12 with SP4/5 and 15
-* Ubuntu 20.04
+* Ubuntu 20.04 and 22.04
 * openSUSE Leap 15.2
 
 |Database


### PR DESCRIPTION
## WHAT Needs to be Documented?
- Update memory caching instructions for Ubuntu 22.04 with PHP 7.4 from ondrej/php PPA
- Add Ubuntu 22.04 as officially supported OS

## WHERE Does This Need To Be Documented (Link)?
- https://doc.owncloud.com/server/10.10/admin_manual/configuration/server/caching_configuration.html
- https://doc.owncloud.com/server/10.10/admin_manual/installation/system_requirements.html

## WHY Should This Change Be Made?
Ubuntu 22.04 is now officially supported

## (Optional) What Type Of Content Change Is This? 
- [x] New Content Addition
- [ ] Old Content Deprecation
- [ ] Existing Content Simplification
- [ ] Bug Fix to Existing Content

## (Optional) Which Manual Does This Relate To?
- [x] Admin Manual
- [ ] Developer Manual
- [ ] User Manual
- [ ] Android
- [ ] iOS
- [ ] Branded Clients
- [ ] Desktop Client
- [ ] Other