### PR TITLE
Updating manual installation databases instructions for Ubuntu 22.04

### DIFF
--- a/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
@@ -6,7 +6,13 @@
 
 Use these commands to install MariaDB provided by Ubuntu and secure its installation.
 
-NOTE: At the time of writing, with Ubuntu 20.04, `mariadb-server` version `10.4.21` will be installed:
+[NOTE]
+====
+At the time of writing, following MariaDB Server versions will be installed, which may change when the corresponding package gets updated:
+
+* With Ubuntu 20.04: `mariadb-server` version `10.4.21` 
+* With Ubuntu 22.04, `mariadb-server` version `10.6.7`
+====
 
 [source,bash]
 ----


### PR DESCRIPTION
## WHAT Needs to be Documented?
- Update manual installation databases instructions for Ubuntu 22.04

## WHERE Does This Need To Be Documented (Link)?
- https://doc.owncloud.com/server/10.10/admin_manual/installation/manual_installation/manual_installation_db.html

## WHY Should This Change Be Made?
Ubuntu 22.04 is now officially supported

## (Optional) What Type Of Content Change Is This? 
- [x] New Content Addition
- [ ] Old Content Deprecation
- [ ] Existing Content Simplification
- [ ] Bug Fix to Existing Content

## (Optional) Which Manual Does This Relate To?
- [x] Admin Manual
- [ ] Developer Manual
- [ ] User Manual
- [ ] Android
- [ ] iOS
- [ ] Branded Clients
- [ ] Desktop Client
- [ ] Other