### PR TITLE
Temporary fix for the openSSL v3 incompatibility

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -7,6 +7,7 @@
 :pecl-package-url: https://pecl.php.net/package
 :sabre-url: http://sabre.io/
 :gnu-make-url: https://www.gnu.org/software/make/
+:wiki-openssl-3-url: https://wiki.openssl.org/index.php/OpenSSL_3.0
 
 == Introduction
 
@@ -23,14 +24,33 @@ If you get a result, the module is present.
 
 == Required Prerequisites
 
+=== openSSL Version
+
+ownCloud requires that you have openSSL version 1.1.x installed. With the release change of openSSL v1.x to openSSL version 3.x in December 2021, some ciphers which were valid in version 1.x, have been retired with immediate effect. This impacts the ownCloud encryption app.
+
+[IMPORTANT]
+====
+If you plan to:
+
+* upgrade the openSSL version of your server to v3 **or**
+* install or upgrade your server where the server upgrade delivers the new openSSL v3 version **and**
+* you have enabled and use encryption
+
+your encryption environment will break due to openSSL v3 retired (legacy) ciphers. As a result, encrypted files cant be accessed. As a _temporary solution_, you have to manually reenable in the openSSL v3 config the legacy ciphers. To do so, see the example in the {wiki-openssl-3-url}[OpenSSL 3.0 Wiki] at section **6.2 Providers**.
+====
+
 === PHP Version
 
 ownCloud can run with following PHP versions: {supported-php-versions}
 
 [IMPORTANT]
 ====
-ownCloud recommends PHP 7.4 for new installations.
-Sites using a version earlier than PHP 7.3 are *strongly encouraged* to migrate at least to PHP 7.3.
+ownCloud recommends PHP 7.4 for new installations. Sites using a version earlier than PHP 7.3 are *strongly encouraged* to migrate at least to PHP 7.3.
+====
+
+[IMPORTANT]
+====
+Note that PHP 8.x is currently not supported.
 ====
 
 ==== PHP Extensions

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -6,7 +6,7 @@
 :ios-system-requirements-url: https://doc.owncloud.com/ios-app/ios_faq.html
 :android-system-requirements-url: https://doc.owncloud.com/android/faq.html
 
-:description: Read this documentation for a recommended or supported environment for your  ownCloud Server. This documentation is not dependent if you plan a new installation or upgrade an existing one.
+:description: Read this documentation for a recommended or supported environment for your ownCloud Server. This documentation applies to both a new installation or upgrade of an existing installation.
 
 == Introduction
 
@@ -14,7 +14,7 @@
 
 == General Note
 
-There is an important note about a xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[prerequisite of openSSL]. We highly recommend checking this prerequisite as it is not dependent on one Operating System.
+There is an important note about a xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[prerequisite of openSSL]. We highly recommend checking this prerequisite as it needs to be checked regardless of the Operating System chosen.
 
 == Officially Recommended Environment
 

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -6,26 +6,36 @@
 :ios-system-requirements-url: https://doc.owncloud.com/ios-app/ios_faq.html
 :android-system-requirements-url: https://doc.owncloud.com/android/faq.html
 
+:description: Read this documentation for a recommended or supported environment for your  ownCloud Server. This documentation is not dependent if you plan a new installation or upgrade an existing one.
+
+== Introduction
+
+{description}
+
+== General Note
+
+There is an important note about a xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[prerequisite of openSSL]. We highly recommend checking this prerequisite as it is not dependent on one Operating System.
+
 == Officially Recommended Environment
 
 For _best performance_, _stability_, _support_ and _full functionality_, we officially recommend and support:
 
-[cols="1,2a",options="header"]
+[width="60%"cols="30%,60%a",options="header"]
 |===
-|Platform
-|Options
+| Platform
+| Options
 
-|Operating System
-|Ubuntu 20.04 LTS
+| Operating System
+| Ubuntu 20.04 LTS
 
-|Database
-|MariaDB 10.5 ^1^
+| Database
+| xref:#database-requirements[MariaDB] 10.5 ^1^
 
-|Web server
-|Apache 2.4 with xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[`prefork and mod_php`]
+| Web server
+| Apache 2.4 with xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[`prefork and mod_php`]
 
-|PHP Runtime
-|{recommended-php-version}
+| PHP Runtime
+| {recommended-php-version}
 |===
 
 (1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
@@ -36,30 +46,29 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 
 === Server
 
-[cols="1,2a",options="header"]
+[width="90%"cols=".^ 30%,90%a",options="header"]
 |===
-|Platform
-|Options
+| Platform
+| Options
 
-|Operating System (64bit)
-|
-* Debian 10
-* Red Hat Enterprise Linux 7 and 8 including all 100% compatible derivatives
+| Operating System (64bit)
+| * Debian 10
+* Red Hat Enterprise Linux 7 and 8 +
+including all 100% compatible derivatives
 * SUSE Linux Enterprise Server 12 with SP4/5 and 15
 * Ubuntu 20.04
 * openSUSE Leap 15.2
 
-|Database
-|
-* MySQL 8+ or MariaDB 10.2, 10.3, 10.4 or 10.5 ^1^ (*Recommended*)
-* Oracle 11 and 12
+| Database
+| * xref:#database-requirements[MySQL] 8+ or xref:#database-requirements[MariaDB] 10.2, 10.3, 10.4 or 10.5 ^1^ (*Recommended*)
+* Oracle 11 and 12 (*Enterprise only*)
 * PostgreSQL 9, 10, 11, 12, 13 or 14
 * SQLite (*Not for production*)
 
 |Web server
 |* Apache 2.4 with xref:installation/manual_installation/manual_installation.adoc#configure-the-web-server[`prefork` and `mod_php`]
 
-|PHP Runtime
+| PHP Runtime
 |* {supported-php-versions}
 |===
 


### PR DESCRIPTION
This is a warning and description for a temporary fix for openSSL v3.

References:
https://github.com/owncloud/core/issues/40071 ([QA] Encryption cannot be enabled on Ubuntu 22.04)

Language review welcomed.

Note this PR complements, but is **not** dependent on the Pull Request U22.04 / PHP7.4  https://github.com/owncloud/docs-server/pull/369 (Server Preparation for Ubuntu 22.04) 

Backport to 10.10, 10.9 and 10.8

@pako81 @jnweiger @IljaN fyi