### PR TITLE
Set a neutral ocis version

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -74,7 +74,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0-beta1'
+    ocis-version: 'next'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
     ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   desktop


### PR DESCRIPTION
This sets the ocis version to `next` instead a real number. This is to satisfy the build process only and has no relevance here when things get changed in reality. The real version is set in the ocis and docs repo.

Antora hopefully gets once a includable attribute list or manifest eliminating this problem.

Backport to 10.10, 10.9 and 10.8