### PR TITLE
Make the openSSL prerequisite more prominent

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -25,6 +25,8 @@ The target audience for this document are experienced admins with additional nee
 
 IMPORTANT: PHP 8.0 is not currently supported by the ownCloud server.
 
+IMPORTANT: Read the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[openSSL Version] notes which are important when planning to use encryption.
+
 NOTE: The commands and links provided in this description should give you proper hints but we cannot take any responsibility.
 
 == Upgrading from Ubuntu 18.04 to 20.04

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_22.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_22.04.adoc
@@ -21,6 +21,8 @@ The target audience for this document are experienced admins with additional nee
 
 IMPORTANT: PHP 8.x is currently **not** supported by ownCloud server.
 
+IMPORTANT: Read the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[openSSL Version] notes which are important when planning to use encryption.
+
 NOTE: The commands and links provided in this description should give you proper hints but we cannot take any responsibility.
 
 == Upgrading from Ubuntu 20.04 to 22.04

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -15,6 +15,7 @@ This guide can not go into details and has its limits by nature. If you experien
 * Your ownCloud directory will be located in `/var/www/owncloud/`.
 * php 7.4 is the default version installable with Ubuntu 20.04.
 * Use the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
+* Read the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[openSSL Version] notes which are important when planning to use encryption.
 
 == Preparation
 

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -14,6 +14,7 @@ This guide can not go into details and has its limits by nature. If you experien
 * Your ownCloud directory will be located in `/var/www/owncloud/`.
 * php 7.4 from the ondrej/php PPA is going to be installed on Ubuntu 22.04.
 * Use the correct xref:installation/manual_installation/manual_installation_apache.adoc#multi-processing-module-mpm[Multi-Processing Module (MPM)].
+* Read the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[openSSL Version] notes which are important when planning to use encryption.
 
 == Preparation
 

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -9,6 +9,8 @@ This document describes how to manually upgrade your ownCloud installation. Beca
 
 NOTE: This guide assumes that you have basic knowledge about Unix terminology, commands and concepts. In case you do not feel familiar with this, ownCloud highly recommends that you create a playground first to try the steps and/or get, if you are entitled to, in touch with ownCloud Support to avoid breaking your system or data loss.
 
+NOTE: This guide covers the upgrade of the ownCloud instance only. When planning to update/upgrade your server environment or server packages, read the xref:installation/manual_installation/manual_installation.adoc[Detailed Installation Guide] first to match the prerequisites.
+ 
 After preparing the upgrade, you can decide between two ways of upgrading your instance:
 
 .Script-Guided Upgrade


### PR DESCRIPTION
Make the openSSL prerequisite more prominent.

Backport to 10.10, 10.9 and 10.8