### PR TITLE
occ custom groups

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -39,6 +39,7 @@ configuration/server/occ_commands/app_commands/admin_audit_commands.adoc, \
 configuration/server/occ_commands/app_commands/brute_force_protection_commands.adoc, \
 configuration/server/occ_commands/app_commands/calendar_commands.adoc, \
 configuration/server/occ_commands/app_commands/contacts_commands.adoc, \
+configuration/server/occ_commands/app_commands/custom_groups.adoc, \
 configuration/server/occ_commands/app_commands/data_explorer_commands.adoc, \
 configuration/server/occ_commands/app_commands/files_lifecycle.adoc, \
 configuration/server/occ_commands/app_commands/ldap_integration_commands.adoc, \
@@ -320,6 +321,8 @@ include::./occ_commands/app_commands/_brute_force_protection_commands.adoc[level
 include::./occ_commands/app_commands/_calendar_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_contacts_commands.adoc[leveloffset=+2]
+
+include::./occ_commands/app_commands/_custom_groups.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_data_explorer_commands.adoc[leveloffset=+2]
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_custom_groups.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_custom_groups.adoc
@@ -1,0 +1,90 @@
+= Custom Groups
+
+Marketplace URL: {oc-marketplace-url}/apps/customgroups[Custom Groups]
+
+Use these commands to configure the Custom Groups app.
+
+Parametrisation should be done with the `occ config` command set, though some but not all settings result in an entry in config.php which also can be set manually.
+
+// note that the behaviour of the config:app settings was derived from the code of the app, see https://github.com/owncloud/customgroups and an issue https://github.com/owncloud/docs-webui/pull/41
+
+== Get a Current Setting
+
+You can get the value of a current setting. For details how to do so see the xref:config-commands[Config Command Set].
+  
+== Disallow Admin Access
+
+By default, administrators can administrate custom groups of an instance. When changed, only group admins can administrate custom groups. You can change this behaviour with following command:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:system:set \
+  customgroups.disallow-admin-access-all \
+  --type boolean --value true
+----
+
+This occ command will create a key value pair in your config.php which must be writeable for the webserver user to be set. You can also manually set this setting directly. To do so, add the following key in config.php:
+
+[source.plaintext]
+----
+  'customgroups.disallow-admin-access-all' => true,
+----
+
+== Disallow Members of Defined Groups
+
+You can hide custom groups from a users personal settings page based on a users group membership. This makes it easier to collect users you want to exclude into defined groups which will be further used for this setting:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:system:set \
+  customgroups.disallowed-groups \
+  --type json \
+  --value '["no_guest_app_users", "project5"]'
+----
+
+This occ command will create a key value pair in your config.php which must be writeable for the webserver user to be set. You can also manually set this setting directly. To do so, add the following key in config.php:
+
+[source.plaintext]
+----
+  'customgroups.disallowed-groups' => 
+  array (
+    0 => 'no_guest_app_users',
+    1 => 'project5',
+  ),
+----
+
+== Restrict Group Creation
+
+This setting defines if ordinary users are allowed to create custom groups. By default, all users can create custom groups, but this can be restricted to admins (if allowed as above) and group-admins. Values to be set can be 'true' and 'false', defaults to 'false'.
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set \
+  customgroups \
+  only_subadmin_can_create \
+  --value 'true'
+----
+
+== Restrict Add or Remove Group Members
+
+This setting defines if an existing ordinary group member is allowed to add or remove other users into the target group. By default, all users can add members to groups, but this can be restricted to admins (if allowed as above) and group-admins. Values to be set can be 'yes' and 'no', defaults to 'no'.
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set \
+  core \
+  shareapi_only_share_with_group_members \
+  --value 'yes'
+----
+
+== Allow Duplicate Group Display Names
+
+This setting allows the creation of multiple groups with the same display name. By default, group display names must be unique, but it can be be allowed to have multiple identical group display names. Values to be set can be 'true' and 'false', defaults to 'false'.
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set \
+  customgroups \
+  allow_duplicate_names \
+  --value 'false'
+----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_custom_groups.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_custom_groups.adoc
@@ -4,7 +4,7 @@ Marketplace URL: {oc-marketplace-url}/apps/customgroups[Custom Groups]
 
 Use these commands to configure the Custom Groups app.
 
-Parametrisation should be done with the `occ config` command set, though some but not all settings result in an entry in config.php which also can be set manually.
+Parameterization should be done with the `occ config` command set, though some but not all settings result in an entry in config.php which also can be set manually.
 
 // note that the behaviour of the config:app settings was derived from the code of the app, see https://github.com/owncloud/customgroups and an issue https://github.com/owncloud/docs-webui/pull/41
 
@@ -14,7 +14,7 @@ You can get the value of a current setting. For details how to do so see the xre
   
 == Disallow Admin Access
 
-By default, administrators can administrate custom groups of an instance. When changed, only group admins can administrate custom groups. You can change this behaviour with following command:
+By default, administrators can administrate custom groups of an instance. When changed, only group admins can administrate custom groups. You can change this behaviour with the following command:
 
 [source,bash,subs="attributes+"]
 ----
@@ -23,7 +23,7 @@ By default, administrators can administrate custom groups of an instance. When c
   --type boolean --value true
 ----
 
-This occ command will create a key value pair in your config.php which must be writeable for the webserver user to be set. You can also manually set this setting directly. To do so, add the following key in config.php:
+This occ command will create a key-value pair in your config.php which must be writable for the webserver user. You can also do this manually by adding the following key in config.php:
 
 [source.plaintext]
 ----
@@ -32,7 +32,7 @@ This occ command will create a key value pair in your config.php which must be w
 
 == Disallow Members of Defined Groups
 
-You can hide custom groups from a users personal settings page based on a users group membership. This makes it easier to collect users you want to exclude into defined groups which will be further used for this setting:
+You can hide custom groups from a user's personal settings page based on a user's group membership. This makes it easier to collect users you want to exclude into defined groups which will be further used for this setting:
 
 [source,bash,subs="attributes+"]
 ----
@@ -42,7 +42,7 @@ You can hide custom groups from a users personal settings page based on a users 
   --value '["no_guest_app_users", "project5"]'
 ----
 
-This occ command will create a key value pair in your config.php which must be writeable for the webserver user to be set. You can also manually set this setting directly. To do so, add the following key in config.php:
+This occ command will create a key-value pair in your config.php which must be writable for the webserver user to be set. You can also set this manually by adding the following key in config.php:
 
 [source.plaintext]
 ----
@@ -67,7 +67,7 @@ This setting defines if ordinary users are allowed to create custom groups. By d
 
 == Restrict Add or Remove Group Members
 
-This setting defines if an existing ordinary group member is allowed to add or remove other users into the target group. By default, all users can add members to groups, but this can be restricted to admins (if allowed as above) and group-admins. Values to be set can be 'yes' and 'no', defaults to 'no'.
+This setting defines if an existing ordinary group member is allowed to add other users to the target group or remove them. By default, all users can add members to groups, but this can be restricted to admins (if allowed as above) and group-admins. Values to be set can be 'yes' and 'no', defaults to 'no'.
 
 [source,bash,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_commands.adoc
@@ -2,6 +2,13 @@
 
 The `config` commands are used to configure the ownCloud server.
 
+[NOTE]
+====
+* In general, key names are not checked for validity, they are used as written.
+* Whenever you use the *app* parameter, a config is read or written from or to the database. 
+* Whenever you use the *system* parameter, a config is read or written from or to the config.php file.
+====
+
 ----
 config
  config:app:delete      Delete an app config value
@@ -20,6 +27,7 @@ The following apps, core functions or documents use/refer to `config:app` settin
 
 .Standard
 * xref:configuration/files/federated_cloud_sharing_configuration.adoc[Configuring Federation Sharing]
+* xref:configuration/user/user_management.adoc#enabling-custom-groups[Custom Groups]
 * xref:configuration/files/file_sharing_configuration.adoc[File Sharing]
 * xref:configuration/server/security/hsmdaemon/index.adoc[The HSM (Hardware Security Module) Daemon (hsmdaemon)]
 * xref:configuration/server/legal_settings_configuration.adoc[Legal Settings Configuration]
@@ -39,6 +47,7 @@ The following apps, core functions or documents use/refer to `config:app` settin
 * xref:configuration/server/occ_command.adoc#anti-virus[occ Anti-Virus]
 * xref:configuration/server/occ_command.adoc#auditing[occ Auditing]
 * xref:configuration/server/occ_command.adoc#brute-force-protection[occ Brute Force Protection]
+* xref:configuration/server/occ_command.adoc#custom-groups[occ Custom Groups]
 * xref:configuration/server/occ_command.adoc#collabora-online-secure-view[occ Collabora Online / Secure View]
 * xref:configuration/server/occ_command.adoc#encryption[occ Encryption]
 * xref:configuration/server/occ_command.adoc#file-lifecycle-management[occ File Lifecycle Management]
@@ -50,7 +59,8 @@ The following apps, core functions or documents use/refer to `config:app` settin
 The following apps, core functions or documents use/refer to `config:system` settings:
 
 .Standard
-* xref:installation/quick_guides/ubuntu_20_04.adoc[Install ownCloud on Ubuntu 20.04]
+* xref:installation/quick_guides/ubuntu_20_04.adoc[Quick Install on Ubuntu 20.04]
+* xref:installation/quick_guides/ubuntu_22_04.adoc[Quick Install on Ubuntu 22.04]
 
 .occ Commands
 * xref:configuration/server/occ_command.adoc#metrics[occ Metrics]

--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -130,10 +130,8 @@ them to share content in a more flexible way.
 
 To enable Custom Groups:
 
-1.  From the ownCloud Market, which you can find in version 10.0 under 
-the Apps menu, click btn:[Market].
-2.  Click btn:[Collaboration] (1), to filter the list of available
-options and click the btn:[Custom groups] application (2).
+1.  From the ownCloud Market, which you can find starting from version 10.0 under the Apps menu, click btn:[Market].
+2.  Click btn:[Collaboration] (1), to filter the list of available options and click the btn:[Custom groups] application (2).
 +
 image:custom-groups/owncloud-market-custom-groups.png[The Custom Groups application in the ownCloud Market]
 3.  Click btn:[INSTALL] in the bottom right-hand corner of the Custom Groups application.
@@ -144,14 +142,20 @@ With this done, Custom Group functionality will be available in your ownCloud in
 
 === Overriding Default Behavior
 
+Depending on your Custom Groups and ownCloud's global settings, configured by the ownCloud admin, Custom Groups may behave differently depending on settings made via occ commands. See the details in xref:configuration/server/occ_command.adoc#custom-groups[occ for Custom Groups]. Note that some settings shown in the examples below can also be set via `config/config.php`. For best practice use the occ command where possible.
+
 ==== Disabling Administrators from Administering Custom Groups
 
-Depending on your Custom Groups and ownCloud's global settings, configured by the ownCloud admin, Custom Groups may behave differently:
-
 * Creating or renaming a Custom Group using an existing name of another Custom Group can be allowed or not depending on administrative settings.
+
 * Custom Group creation can be limited to ownCloud **group admins**.
-* Disable administration of Custom Groups by ownCloud administrators. 
-This is enabled by setting `customgroups.disallow-admin-access-all` to `true` in `config/config.php`.
+
+* Disable administration of Custom Groups by ownCloud administrators:
++
+[source.php]
+----
+'customgroups.disallow-admin-access-all' => true,
+----
 
 ==== Hide Custom Groups App Based On Group Membership
 
@@ -160,9 +164,14 @@ To specify the disallowed groups, list them against the `customgroups.disallowed
 
 [source,php]
 ----
-// Hide the Custom Groups app for users in the "guest_app" group.
-'customgroups.disallowed-groups' => ['guest_app'],
+// Hide the Custom Groups app for users in the
+// 'no_guest_app_users' and 'project5' group.
+'customgroups.disallowed-groups' => ['no_guest_app_users', 'project5'],
 ----
+
+==== Set Custom Group Admins 
+
+Setting custom group admins can only be done via the browser. In case the group-admin has left the company and you need to set a different one, you temporarily must allow the xref:disabling-administrators-from-administering-custom-groups[ownCloud instance admins] access to groups if disallowed before, set a one or more new group admins, and change the instance admin setting back.
 
 == Setting Storage Quotas
 

--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -171,7 +171,7 @@ To specify the disallowed groups, list them against the `customgroups.disallowed
 
 ==== Set Custom Group Admins 
 
-Setting custom group admins can only be done via the browser. In case the group-admin has left the company and you need to set a different one, you temporarily must allow the xref:disabling-administrators-from-administering-custom-groups[ownCloud instance admins] access to groups if disallowed before, set a one or more new group admins, and change the instance admin setting back.
+Setting Custom Group admins can only be done via the browser. In case the group admin has left the company and you need to set a different one, you temporarily must allow the xref:disabling-administrators-from-administering-custom-groups[ownCloud instance admins] access to groups if disallowed before, set one or more new group admins, and change the instance admin setting back.
 
 == Setting Storage Quotas
 


### PR DESCRIPTION
This PR adds the missing occ commands for custom groups + some text addons/fixes to teh user management related to custom groups.

Language review welcomed

Backport to 10.10,10.9 and 10.8

I need to adapt https://github.com/owncloud/docs-webui/pull/41 (the driver for this PR) to link to the user_management part to refere administration.