### PR TITLE
fix phpunit url to prevent a 404

### DIFF
--- a/modules/developer_manual/pages/testing/unit-testing.adoc
+++ b/modules/developer_manual/pages/testing/unit-testing.adoc
@@ -1,8 +1,8 @@
 = Unit-Testing
 :toc: right
-:writing-tests-url: https://phpunit.readthedocs.io/en/latest/writing-tests-for-phpunit.html
-:recommended-way-to-organise-tests-url: https://phpunit.readthedocs.io/en/latest/organizing-tests.html
-:phpunit-docs-url: https://phpunit.readthedocs.io/en/latest/installation.html
+:phpunit-docs-url: https://phpunit.readthedocs.io/
+:writing-tests-url: https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html
+:recommended-way-to-organise-tests-url: https://phpunit.readthedocs.io/en/9.5/organizing-tests.html
 :page-aliases: core/unit-testing.adoc
 :notes-app-url: https://github.com/owncloud/notes
 
@@ -300,7 +300,7 @@ make test-php-unit NOCOVERAGE=true TEST_DATABASE=mysql TEST_PHP_SUITE=tests/lib/
 === Further Reading
 
 * http://googletesting.blogspot.de/2008/08/by-miko-hevery-so-you-decided-to.html[Writing Testable Code]
-* https://phpunit.readthedocs.io/en/latest/index.html[PHPUnit Manual]
+* {phpunit-docs-url}[PHPUnit Manual]
 * http://www.youtube.com/watch?v=4E4672CS58Q&feature=bf_prev&list=PLBDAB2BA83BB6588E[Clean Code Talks - GuiceBerry]
 * https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM[Clean Code by Robert C. Martin]
 


### PR DESCRIPTION
phpunit needs a fixed release number in the url, "latest" results in a 404

Backport to 10.10 and 10.9