### PR TITLE
Update files sharing configuration

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -1,14 +1,25 @@
 = File Sharing
 :toc: right
 :page-aliases: go/admin-sharing.adoc
+:two-letter-url: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+:description: This section describes how to set general configuration rules for sharing files.
 
 == Introduction
 
-The sharing policy is configured on the Admin page in the *"Sharing"* section.
+{description}
 
-NOTE: If you don't see the sharing section, try disabling your AdBlock browser plugin. +
-It might also be related to another installed ad blocker in your browser. +
-If so, please disable the plugin and see if that resolves the situation.
+== General Notes
+
+The sharing policy is configured at menu:Settings[Admin > Sharing].
+
+[NOTE]
+====
+If you don't see the sharing section:
+
+* Check if you have installed an AdBlock browser plugin.
+
+If so, disable the plugin and recheck.
+====
 
 image:configuration/files/sharing-files-settings.png[ownCloud Sharing settings]
 
@@ -56,8 +67,7 @@ NOTE: ownCloud includes a xref:configuration/server/security/password_policy.ado
 
 === Allow apps to use the Share API
 
-Check this option to enable users to share files.
-If this is not checked, no users can create file shares.
+Check this option to enable users to share files. If this is not checked, no users can create file shares.
 
 === Allow users to share via link
 
@@ -69,54 +79,47 @@ Check this option to allow anyone to upload files to public link shares.
 
 ==== Enforce password protection of public link shares
 
-Check these options to force users to set a password on public link shares.
-Passwords can be enforced on any or all of read-only, read-write, read-write-delete and upload-only (File Drop) public link shares.
-This does not apply to local user and group shares.
+Check these options to force users to set a password on public link shares. Passwords can be enforced on any or all of read-only, read-write, read-write-delete and upload-only (File Drop) public link shares. This does not apply to local user and group shares.
 
 ==== Set default expiration date of public link shares
 
-Check this option to set a default expiration date on public link shares.
-Check "Enforce as maximum expiration date" to limit the maximum expiration date to be the default.
-Users can choose an earlier expiration date if they wish.
+Check this option to set a default expiration date on public link shares. Check _Enforce as maximum expiration date_ to limit the maximum expiration date to be the default. Users can choose an earlier expiration date if they wish.
 
 ==== Allow users to send mail notification for shared files
 
-Check this option to enable sending notifications from ownCloud.
-When clicked, the administrator can choose the language for public mail notifications for shared files.
+Check this option to enable sending notifications from ownCloud. When clicked, the administrator can choose the language for public mail notifications for shared files.
 
 image:configuration/files/sharing/choose-public-mail-notification-language.png[Choose the language for public
 mail notifications for shared files in ownCloud.]
 
-What this means is that email notifications will be sent in the language of the user that shared an item.
-By default the language is the share owner’s language.
+What this means is, that email notifications will be sent in the language of the user that shared an item. By default the language is the share owner’s language.
 
-However, it can be changed to any of the currently available languages.
-It is also possible to change this setting on the command-line by using
-xref:configuration/server/occ_command.adoc#config-commands[the occ config:app:set command], as in this example:
+However, it can be changed to any of the currently available languages. It is also possible to change this setting on the command-line by using the
+xref:configuration/server/occ_command.adoc#config-commands[occ config:app:set command], as in this example:
 
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} \
-    config:app:set core shareapi_public_notification_lang \
+    config:app:set \
+    core \
+    shareapi_public_notification_lang \
     --value '<language code>'
 ----
 
-NOTE: In the above example `<language code>` is
-https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[an ISO 3166-1 alpha-2 two-letter country code], such as *ru*, *gb*, *us*, and *au*.
+NOTE: In the example above, the `<language code>` is an
+{two-letter-url}[ISO 3166-1 alpha-2 two-letter country code], such as *de*, *gb*, *us*, *es* or others.
 
 NOTE: To use this functionality, your ownCloud server must be configured to send mail.
 
 ==== Allow users to share file via social media
 
-Check this option to enable displaying of a set of links that allow for quickly sharing files and share
-links via *Twitter*, *Facebook*, *Google+*, *Diaspora*, and email.
+Check this option to enable displaying of a set of links that allow for quickly sharing files and share links via *Twitter*, *Facebook*, *Google+*, *Diaspora*, and email.
 
 image:configuration/files/sharing/sharing-files-via-social-media.png[ownCloud social media sharing links]
 
 === Set default expiration date for user shares
 
-Check this option to set a default expiration date when sharing with another user.
-The user can change or remove the default expiration date of a share.
+Check this option to set a default expiration date when sharing with another user. The user can change or remove the default expiration date of a share.
 
 ==== Set the number of days to expire after
 
@@ -124,13 +127,11 @@ Set the default number of days that user shares will expire. The default value i
 
 ==== Enforce as maximum expiration date
 
-Check this option to limit the maximum expiration date to be the default.
-Users can choose an earlier expiration date if they wish.
+Check this option to limit the maximum expiration date to be the default. Users can choose an earlier expiration date if they wish.
 
 === Set default expiration date for group shares
 
-Check this option to set a default expiration date when sharing with a group.
-The user can change or remove the default expiration date of a share.
+Check this option to set a default expiration date when sharing with a group. The user can change or remove the default expiration date of a share.
 
 ==== Set the number of days to expire after
 
@@ -138,13 +139,11 @@ Set the default number of days that group shares will expire. The default value 
 
 ==== Enforce as maximum expiration date
 
-Check this option to limit the maximum expiration date to be the default.
-Users can choose an earlier expiration date if they wish.
+Check this option to limit the maximum expiration date to be the default. Users can choose an earlier expiration date if they wish.
 
 === Set default expiration date for remote shares
 
-Check this option to set a default expiration date when sharing with a remote user.
-The user can change or remove the default expiration date of a share.
+Check this option to set a default expiration date when sharing with a remote user. The user can change or remove the default expiration date of a share.
 
 ==== Set the number of days to expire after
 
@@ -152,14 +151,13 @@ Set the default number of days that remote shares will expire. The default value
 
 ==== Enforce as maximum expiration date
 
-Check this option to limit the maximum expiration date to be the default.
-Users can choose an earlier expiration date if they wish.
+Check this option to limit the maximum expiration date to be the default. Users can choose an earlier expiration date if they wish.
 
 === Automatically accept new incoming local user shares
-Disabling this option activates the "Pending Shares" feature. Users will be notified and have to accept new
-incoming user shares before they appear in the file list and are available for access giving them more control
-over their account. More information about
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#pending-shares[pending shares] can be found in the release notes.
+
+Disabling this option activates the "Pending Shares" feature. Users will be notified and have to accept new incoming user shares before they appear in the file list and are available for access giving them more control over their account. More information about
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#pending-shares[pending shares]
+can be found in the release notes.
 
 === Allow resharing
 
@@ -171,26 +169,20 @@ Check this option to enable users to share with groups.
 
 === Default user and group share permissions
 
-Administrators can define the permissions for user/group shares that are set by default when users create new
-shares. As shares are created instantly after choosing the recipient, administrators can set the default to
-e.g. read-only to avoid creating shares with too many permissions unintentionally.
+Administrators can define the permissions for user/group shares that are set by default when users create new shares. As shares are created instantly after choosing the recipient, administrators can set the default to e.g. read-only to avoid creating shares with too many permissions unintentionally.
 
 === Restrict users to only share with users in their groups
 
 Check this option to confine sharing within group memberships.
 
-NOTE: This setting does not apply to the Federated Cloud sharing feature. +
-If xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing] is enabled,
-users can still share items with any users on any instances (_including the one they are on_) via a remote share.
+NOTE: This setting does not apply to the Federated Cloud sharing feature. If
+xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated Cloud Sharing]
+is enabled, users can still share items with any users on any instances (_including the one they are on_) via a remote share.
 
 === Restrict users to only share with groups they are a member of
 
-When this option is enabled, users can only share with groups they are a member of.
-They can still share with all users of the instance but not with groups they are not a member of.
-To restrict sharing to users in groups the sharer is a member of the option "Restrict users to only share
-with users in their groups" can be used.
-More information about
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#more-granular-sharing-restrictions[more granular sharing restrictions]
+When this option is enabled, users can only share with groups they are a member of. They can still share with all users of the instance but not with groups they are not a member of. To restrict sharing to users in groups the sharer is a member of, the option _Restrict users to only share with users in their groups_ can be used. More information about
+xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#more-granular-sharing-restrictions[granular sharing restrictions]
 can be found in the release notes.
 
 === Allow users to send mail notification for shared files to other users
@@ -199,9 +191,7 @@ Check this option to enable users to send an email notification to every ownClou
 
 === Exclude groups from sharing
 
-Check this option to prevent members of specific groups from creating any file shares.
-When you check this, you'll get a dropdown list of all your groups to choose from.
-Members of excluded groups can still receive shares, but not create any.
+Check this option to prevent members of specific groups from creating any file shares. When you check this, you will get a dropdown list of all your groups to choose from. Members of excluded groups can still receive shares, but not create any.
 
 === Allow username autocompletion in share dialog
 
@@ -209,35 +199,23 @@ Check this option to enable auto-completion of ownCloud usernames.
 
 ==== Restrict enumeration to group members
 
-Check this option to restrict auto-completion of ownCloud usernames to only those users who are members of
-the same group(s) that the user is in.
+Check this option to restrict auto-completion of ownCloud usernames to only those users who are members of the same group(s) that the user is in.
 
 === Extra field to display in autocomplete results
-The autocomplete dropdowns in ownCloud usually show the display name of other users when it is set.
-If it's not set, they show the user ID / login name, as display names are not unique you can run into
-situations where you can't distinguish the proposed users. This option enables to add mail addresses or user
-ID's to make them distinguishable.
+
+The autocomplete dropdowns in ownCloud usually show the display name of other users when it is set. If it's not set, they show the user ID / login name, as display names are not unique you can run into situations where you cannot distinguish the proposed users. This option enables to add mail addresses or user ID's to make them distinguishable.
 
 == Blacklist Groups From Receiving Shares
 
-Sometimes it's necessary or desirable to block groups from receiving shares.
-For example, if a group has a significant number of users (> 5,000) or if it's a system group, then it
-can be advisable to block it from receiving shares.
-In these cases, ownCloud administrators can blacklist one or more groups, so that they do not receive shares.
+Sometimes it is necessary or desirable to block groups from receiving shares. For example, if a group has a significant number of users (> 5,000) or if it is a system group, it can be advisable to block it from receiving shares. In these cases, ownCloud administrators can blacklist one or more groups so that they cannot receive shares.
 
-To blacklist one or more groups, via the Web UI, under **"Admin -> Settings -> Sharing"**, add one or more
-groups to the _"Files Sharing"_ list. As you type the group’s name, if it exists, it will appear in the
-drop-down list, where you can select it.
+To blacklist one or more groups via the Web UI, under menu:Settings[Admin > Sharing], add one or more groups to the _Files Sharing_ list. As you type the group’s name, if it exists, it will appear in the drop-down list where you can select it.
 
 image:configuration/files/sharing/blacklisting-groups.png[Blacklisting groups]
 
 == Transferring Files to Another User
 
-You may transfer files from one user to another with `occ`. The command
-transfers either all or a limited set of files from one user to another.
-It also transfers the shares and metadata info associated with those
-files (_shares_, _tags_, and _comments_, etc). This is useful when you
-have to transfer a user’s files to another user before you delete them.
+You may transfer files from one user to another with `occ`. The command transfers either all or a limited set of files from one user to another. It also transfers the outgoing shares and metadata info associated with those files (shares, tags, and comments, etc). Incoming shares are _not_ moved, as the sharing user holds the ownership of the respective files. This is useful when you have to transfer a user’s files to another user before you delete them.
 
 Trashbin contents are not transferred.
 
@@ -245,50 +223,42 @@ Here is an example of how to transfer all files from one user to another.
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files:transfer-ownership <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership \
+  <source-user> \
+  <destination-user>
 ----
 
-Here is an example of how to transfer _a limited group_ a single folder
-from one user to another. In it, `folder/to/move`, and any file and
-folder inside it will be moved to `<destination-user>`.
+Here is an example of how to transfer _a limited group_ a single folder from one user to another. In it, `folder/to/move`, and any file and folder inside it will be moved to `<destination-user>`.
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files:transfer-ownership --path="folder/to/move" <source-user> <destination-user>
+{occ-command-example-prefix} files:transfer-ownership \
+  --path="folder/to/move" \
+  <source-user> \
+  <destination-user>
 ----
 
 When using this command keep two things in mind:
 
 1.  The directory provided to the `--path` switch *must* exist inside `data/<source-user>/files`.
-2.  The directory (and its contents) won’t be moved as is between the
-users. It’ll be moved inside the destination user’s `files` directory,
-and placed in a directory which follows the format:
+2.  The directory (and its contents) won’t be moved as is between the users. It will be moved inside the destination user’s `files` directory, and placed in a directory which follows the format:
 `transferred from <source-user> on <timestamp>`. Using the example above, it will be stored under:
 `data/<destination-user>/files/transferred from <source-user> on 20170426_124510/`
 
-TIP: See xref:configuration/server/occ_command.adoc[the occ command reference],
+TIP: See the xref:configuration/server/occ_command.adoc[occ command reference],
 for a complete list of `occ` commands.
 
-IMPORTANT: If an exception occurred during the transfer ownership command or the command
-terminated prematurely, it is advised to run following command for the source *and* target user:
-`{occ-command-example-prefix} files:troubleshoot-transfer-ownership --uid <uid>`
+IMPORTANT: If an exception occurred during the transfer ownership command or the command terminated prematurely, it is advised to run following command for the source *and* target user:
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} files:troubleshoot-transfer-ownership --uid <uid>`
+----
 
 == Creating Persistent File Shares
 
-When a user is deleted, their files are also deleted. As you can
-imagine, this is a problem if they created file shares that need to be
-preserved, because these disappear as well. In ownCloud files are tied
-to their owners, so whatever happens to the file owner also happens to
-the files.
+When a user is deleted, their files are also deleted. As you can imagine, this is a problem if they created file shares that need to be preserved, because these disappear as well. In ownCloud, files are tied to their owners. This means, whatever happens to the file owner also happens to the files.
 
-One solution is to create persistent shares for your users. You can
-retain ownership of them, or you could create a special user for the
-purpose of establishing permanent file shares. Simply create a shared
-folder in the usual way, and share it with the users or groups who need
-to use it. Set the appropriate permissions on it, and then no matter
-which users come and go, the file shares will remain. Because all files
-added to the share, or edited in it, automatically become owned by the
-owner of the share regardless of who adds or edits them.
+One solution to get around this issueis, to create persistent shares for your users. You can retain ownership of them, or you could create a special user for the purpose of establishing permanent file shares. Simply create a shared folder in the usual way, and share it with the users or groups who need to use it. Set the appropriate permissions on it and the share is independent which users come and go, the file shares will remain. Because all files added to the share or edited in it are automatically owned by the owner of the share regardless of who adds or edits them.
 
 == Create Shares Programmatically
 
@@ -299,22 +269,25 @@ If you need to create new shares using command-line scripts, there are two avail
 
 === occ files_external:create
 
-This command provides for the creation of both personal (for a specific user) and general shares.
-The command’s configuration options can be provided either as individual arguments or collectively, as a JSON object. For more information about the command, refer to the xref:configuration/server/occ_command.adoc#files-external[the occ files-external documentation].
+This command provides for the creation of both personal (for a specific user) and general shares. The command’s configuration options can be provided either as individual arguments or collectively, as a JSON object. For more information about the command, refer to the xref:configuration/server/occ_command.adoc#files-external[occ files-external documentation].
 
 ==== Personal Share
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create \
+    /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'} \
     --user someuser
 ----
 
+or
+
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create \
+    /my_share_name windows_network_drive \
     password::logincredentials \
     --config host=127.0.0.1 \
     --config share='home' \
@@ -327,14 +300,18 @@ The command’s configuration options can be provided either as individual argum
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create \
+    /my_share_name windows_network_drive \
     password::logincredentials \
     --config={host=127.0.0.1, share='home', root='$user', domain='owncloud.local'}
 ----
 
+or
+
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:create /my_share_name windows_network_drive \
+{occ-command-example-prefix} files_external:create \
+    /my_share_name windows_network_drive \
     password::logincredentials \
     --config host=127.0.0.1 \
     --config share='home' \
@@ -344,25 +321,25 @@ The command’s configuration options can be provided either as individual argum
 
 === occ files_external:import
 
-You can create general and personal shares passing the configuration details via JSON files, using the
-`occ files_external:import` command.
+You can create general and personal shares passing the configuration details via JSON files, using the `occ files_external:import` command.
 
 ==== General Share
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:import /import.json
+{occ-command-example-prefix} files_external:import \
+    /import.json
 ----
 
 ==== Personal Share
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} files_external:import /import.json --user someuser
+{occ-command-example-prefix} files_external:import \
+    /import.json --user someuser
 ----
 
-In the two examples above, here is a sample JSON file, showing all of the available configuration options
-that the command supports.
+In the two examples above, here is a sample JSON file, showing all of the available configuration options that the command supports.
 
 [source,json]
 ----
@@ -388,101 +365,130 @@ that the command supports.
 
 === Permissions Masks
 
+[width=50%,cols=3*~,options="header"]
 |===
-|**READ** | 1
-|**UPDATE** | 2 ("can update" in web UI)
-|**CREATE** | 4 ("can create" in web UI)
-|**DELETE** | 8 ("can delete" in web UI)
-|**SHARE** | 16 ("can reshare" in web UI)
+| Permission
+| Value
+| web UI Value
+
+| READ
+| 1
+|
+
+| UPDATE
+| 2
+| _can update_
+
+| CREATE
+| 4
+| _can create_
+
+| DELETE
+| 8
+| _can delete_
+
+| SHARE
+| 16
+| _can reshare_
 |===
 
 === File Operations Shorthand for the Later Table
 
-[cols=2*,options="header"]
+[cols=2*~,options="header"]
 |===
-|Operation
-|Description
+| Operation
+| Description
 
-|**download**
-|download/read/get a file or display a folder contents
+| download
+| Download/read/get a file or display a folder contents
 
-|**upload**
-|a new file can be uploaded/created (file target does not exist)
+| upload
+| A new file can be uploaded/created (file target does not exist)
 
-|**upload_overwrite**
-|a file can overwrite an existing one
+| upload_overwrite
+| A file can overwrite an existing one
 
-|**rename**
-|rename file to new name, all within the shared folder
+| rename
+| Rename file to new name, all within the shared folder
 
-|**move_in**
-|move a file from outside the shared folder into the shared folder
+| move_in
+| Move a file from outside the shared folder into the shared folder
 
-|**move_in_overwrite**
-a|move a file from outside the shared folder and overwrite a file inside the shared folder.
+| move_in_overwrite
+a| Move a file from outside the shared folder and overwrite a file inside the shared folder.
 
 NOTE: SabreDAV automatically deletes the target file first before moving, so requires DELETE permission too.
 
-|**move_in_subdir**
-|move a file already in the shared folder into a subdir within the shared folder
+| move_in_subdir
+| move a file already in the shared folder into a subdir within the shared folder
 
-|**move_in_subdir_overwrite**
-|move a file already in the shared folder into a subdir within the shared folder and overwrite an existing file there
+| move_in_subdir_overwrite
+| Move a file already in the shared folder into a subdir within the shared folder and overwrite an existing file there
 
-|**move_out**
-|move a file to outside of the shared folder
+| move_out
+| Move a file to outside of the shared folder
 
-|**move_out_subdir**
-|move a file out of a subdir of the shared folder into the shared folder
+| move_out_subdir
+| Move a file out of a subdir of the shared folder into the shared folder
 
-|**copy_in**
-|copy a file from outside the shared folder into the shared folder
+| copy_in
+| Copy a file from outside the shared folder into the shared folder
 
-|**copy_in_overwrite**
-a|copy a file from outside the shared folder and overwrite a file inside the shared folder
+| copy_in_overwrite
+a| Copy a file from outside the shared folder and overwrite a file inside the shared folder
 
 NOTE: SabreDAV automatically deletes the target file first before copying, so requires DELETE permission too.
 
-|**delete**
-|delete a file inside the shared folder
+| delete
+| Delete a file inside the shared folder
 
-|**mkdir**
-|create folder inside the shared folder
+| mkdir
+| Create folder inside the shared folder
 
-|**rmdir**
-|delete folder inside the shared folder
+| rmdir
+| Delete folder inside the shared folder
 |===
 
 The following lists what operations are allowed for the different permission combinations (share permission is omitted as it is not relevant to file operations):
 
-[cols=2*,options="header"]
+[width=55%,cols="30%,30",options="header"]
 |===
-|Operation(s)
-|Permission Combinations
+| Operation(s)
+| Permission Combinations
 
-|READ (aka read-only)
-a|* download
+| READ (aka read-only)
+a|
+* download
 
-|READ + CREATE
-a|* download
+| READ + +
+CREATE
+a|
+* download
 * upload
 * move_in
 * copy_in
 * mkdir
 
-|READ + UPDATE
-a|* download
+| READ + +
+UPDATE
+a|
+* download
 * upload_overwrite
 * rename
 
-|READ + DELETE
-a|* download
+| READ + +
+DELETE
+a|
+* download
 * move_out
 * delete
 * rmdir
 
-|READ + CREATE + UPDATE
-a|* download
+| READ + +
+CREATE + +
+UPDATE
+a|
+* download
 * upload
 * upload_overwrite
 * rename
@@ -490,8 +496,11 @@ a|* download
 * copy_in
 * mkdir
 
-|READ + CREATE + DELETE
-a|* download
+| READ + +
+CREATE + +
+DELETE
+a|
+* download
 * upload
 * move_in
 * move_in_overwrite
@@ -505,15 +514,21 @@ a|* download
 * mkdir
 * rmdir
 
-|READ + UPDATE + DELETE
-a|* download
+| READ + +
+UPDATE + +
+DELETE
+a|
+* download
 * upload_overwrite
 * rename
 * move_out
 * delete
 * rmdir
 
-|READ + CREATE + UPDATE + DELETE (all permissions)
+| READ + +
+CREATE + +
+UPDATE + +
+DELETE (all permissions)
 a|
 * download
 * upload

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -400,19 +400,19 @@ In the two examples above, here is a sample JSON file, showing all of the availa
 | Description
 
 | download
-| Download/read/get a file or display a folder contents
+| Download/read/get a file or display a folder's contents.
 
 | upload
-| A new file can be uploaded/created (file target does not exist)
+| A new file can be uploaded/created (file target does not exist).
 
 | upload_overwrite
-| A file can overwrite an existing one
+| A file can overwrite an existing one.
 
 | rename
-| Rename file to new name, all within the shared folder
+| Rename file to new name, all within the shared folder.
 
 | move_in
-| Move a file from outside the shared folder into the shared folder
+| Move a file from outside the shared folder into the shared folder.
 
 | move_in_overwrite
 a| Move a file from outside the shared folder and overwrite a file inside the shared folder.
@@ -420,30 +420,30 @@ a| Move a file from outside the shared folder and overwrite a file inside the sh
 NOTE: SabreDAV automatically deletes the target file first before moving, so requires DELETE permission too.
 
 | move_in_subdir
-| move a file already in the shared folder into a subdir within the shared folder
+| Move a file already in the shared folder into a subdirectory within the shared folder.
 
 | move_in_subdir_overwrite
-| Move a file already in the shared folder into a subdir within the shared folder and overwrite an existing file there
+| Move a file already in the shared folder into a subdirectory within the shared folder and overwrite an existing file there.
 
 | move_out
-| Move a file to outside of the shared folder
+| Move a file to outside of the shared folder.
 
 | move_out_subdir
-| Move a file out of a subdir of the shared folder into the shared folder
+| Move a file out of a subdirectory of the shared folder into the shared folder.
 
 | copy_in
-| Copy a file from outside the shared folder into the shared folder
+| Copy a file from outside the shared folder into the shared folder.
 
 | copy_in_overwrite
-a| Copy a file from outside the shared folder and overwrite a file inside the shared folder
+a| Copy a file from outside the shared folder and overwrite a file inside the shared folder.
 
 NOTE: SabreDAV automatically deletes the target file first before copying, so requires DELETE permission too.
 
 | delete
-| Delete a file inside the shared folder
+| Delete a file inside the shared folder.
 
 | mkdir
-| Create folder inside the shared folder
+| Create a folder inside the shared folder.
 
 | rmdir
 | Delete folder inside the shared folder


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-server/issues/449 (Transferring Files to Another User //Specification)

Updates the files sharing configuration page:
* fixing #449 
* additional text fixes, remove not necessary linebreakes etc
* update tables

Language review welcomed.

Backport to 10.10 and 10.9

@dpapac fyi