### PR TITLE
Fixing that occ needs to be set to executable if not already done.

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -65,6 +65,31 @@ toc::[]
 
 == Running occ
 
+=== Check if occ Is Set to Executable
+
+Note that this step is not necessary when using a docker installation.
+
+Check if the `occ` command is set to executable, change to your ownCloud directory first:
+
+[source,bash]
+----
+ls -lhF occ
+----
+
+This should give a similar output like:
+
+[source,plaintext]
+----
+-rwxr-x--x 1 root www-data 283 May 18 17:44 occ* 
+----
+
+In case it does not, set the occ command to executable with:
+
+[source,bash]
+----
+sudo chmod +x occ
+----
+
 === As Your HTTP User
 
 On a regular ownCloud installation, `occ` is in the `owncloud/` directory, this is on Ubuntu Linux for example `/var/www/owncloud` . `occ` itself is a PHP script.

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -69,14 +69,14 @@ toc::[]
 
 Note that this step is not necessary when using a docker installation.
 
-Check if the `occ` command is set to executable, change to your ownCloud directory first:
+To check if the `occ` command is set to executable, change to your ownCloud directory first, then enter the command:
 
 [source,bash]
 ----
 ls -lhF occ
 ----
 
-This should give a similar output like:
+This should give an output similar to this:
 
 [source,plaintext]
 ----

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -1,11 +1,12 @@
 = Manual ownCloud Upgrade
 :toc: right
 :toclevels: 1
+:description: This document describes how to manually upgrade your ownCloud installation. Because installations can vary, this guide can only give an overview of methods and examples.
 :page-aliases: maintenance/manual_upgrade.adoc
 
 == Introduction
 
-This document describes how to manually upgrade your ownCloud installation. Because installations can vary, this guide can only give an overview of methods and examples. These examples need to be adapted according your needs and your environment.
+{description} These examples need to be adapted according your needs and your environment.
 
 NOTE: This guide assumes that you have basic knowledge about Unix terminology, commands and concepts. In case you do not feel familiar with this, ownCloud highly recommends that you create a playground first to try the steps and/or get, if you are entitled to, in touch with ownCloud Support to avoid breaking your system or data loss.
 
@@ -108,9 +109,11 @@ After the upgrade is finished, you can re-run this script to secure the `.htacce
 
 == Manual Step-by-Step Upgrade
 
+Note that this procedure is not an in-place upgrade but an upgrade to a new directory identical named as it was originally set. This ensures that no code or settings can orphan or get overwritten.
+
 === Move Current ownCloud Directory
 
-Although you have already made a backup, move your current ownCloud directory to a different location for easy access later:
+Although you have already made a backup, move your current ownCloud directory to a different location for easy later access:
 
 This example assumes Ubuntu Linux and MariaDB, rename the ownCloud directory:
 [source,bash]
@@ -129,7 +132,7 @@ sudo tar -xf {oc-complete-name}.tar.bz2
 
 === Copy the data/ Directory
 
-If you keep your `data/` directory _inside_ your `owncloud/` directory, move it from your old version of ownCloud to your new version:
+If you keep your `data/` directory _inside_ your `owncloud/` directory and you have not linked it, move it from your old version of ownCloud to your new version:
 
 [source,bash]
 ----
@@ -142,11 +145,18 @@ If you keep your `data` **outside** of your `owncloud` directory, then you donâ€
 
 === Copy Relevant config.php Content
 
-With the new source files now in place of where the old ones used to be, copy the `config.php` file from your old ownCloud directory to your new ownCloud directory:
+With the new source files now in place of where the old ones used to be, copy all `\*config.php` and `*.json` files (if one exist) from your old ownCloud directory to your new ownCloud directory:
 
 [source,bash]
 ----
-sudo cp /var/www/backup_owncloud/config/config.php /var/www/owncloud/config/config.php
+sudo cp /var/www/backup_owncloud/config/*config.php \
+        /var/www/owncloud/config/
+----
+
+[source,bash]
+----
+sudo cp /var/www/backup_owncloud/config/*.json \
+        /var/www/owncloud/config/
 ----
 
 === Market and Marketplace App Upgrades
@@ -175,12 +185,16 @@ Set the ownership for all files and folders to `root:www-data` **except** the `c
 
 [source,bash]
 ----
-sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type d -exec chown root:www-data {} \+
+sudo find -L /var/www/owncloud \
+    \( -path ./data -o -path ./config \) -prune -o \
+    -type d -print0 | xargs -0 chown root:www-data
 ----
 
 [source,bash]
 ----
-sudo find -L /var/www/owncloud \( -path ./data -o -path ./config \) -prune -o -type f -exec chown root:www-data {} \+
+sudo find -L /var/www/owncloud \
+    \( -path ./data -o -path ./config \) -prune -o \
+    -type f -print0 | xargs -0 chown root:www-data
 ----
 
 Set the ownership for all files and folders to `www-data:www-data` for the `config`, `data` and `apps` directories. Note that it is not mandatory to set the ownership of the `data/` directory as it should already have the correct ownership and it can take a while to finish, depending on the size:
@@ -199,14 +213,21 @@ Use `chmod` on files and directories with different permissions:
 +
 [source,bash]
 ----
-sudo find /var/www/owncloud -type f -exec chmod 640 {} \;
+sudo find -L /var/www/owncloud -type f -print0 | xargs -0 chmod 640
 ----
 
 * For all directories use `0750`
 +
 [source,bash]
 ----
-sudo find /var/www/owncloud -type d -exec chmod 750 {} \;
+sudo find -L /var/www/owncloud -type d -print0 | xargs -0 chmod 750
+----
+
+* Set the occ command to executable
++
+[source,bash]
+----
+sudo chmod +x /var/www/owncloud/occ
 ----
 
 If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well as it automates it.
@@ -215,12 +236,10 @@ If you have configured a script for xref:installation/manual_installation/script
 
 === Start the Upgrade
 
-With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line:
+With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line, note the example is based on Ubuntu Linux, execute this within the ownCloud root folder.
 
 [source,bash,subs="attributes+"]
 ----
-# Here is an example on Ubuntu Linux.
-# Execute this within the ownCloud root folder.
 {occ-command-example-prefix} upgrade
 ----
 

--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -8,7 +8,7 @@
 
 {description} These examples need to be adapted according your needs and your environment.
 
-NOTE: This guide assumes that you have basic knowledge about Unix terminology, commands and concepts. In case you do not feel familiar with this, ownCloud highly recommends that you create a playground first to try the steps and/or get, if you are entitled to, in touch with ownCloud Support to avoid breaking your system or data loss.
+NOTE: This guide assumes that you have basic knowledge about Unix terminology, commands and concepts. In case you are not familiar with these, ownCloud highly recommends that you create a playground first to try the steps and/or get in touch with ownCloud support to avoid breaking your system or losing data.
 
 NOTE: This guide covers the upgrade of the ownCloud instance only. When planning to update/upgrade your server environment or server packages, read the xref:installation/manual_installation/manual_installation.adoc[Detailed Installation Guide] first to match the prerequisites.
 
@@ -109,7 +109,7 @@ After the upgrade is finished, you can re-run this script to secure the `.htacce
 
 == Manual Step-by-Step Upgrade
 
-Note that this procedure is not an in-place upgrade but an upgrade to a new directory identical named as it was originally set. This ensures that no code or settings can orphan or get overwritten.
+Note that this procedure is not an in-place upgrade but an upgrade to a new directory identically named as originally set. This ensures that no code or settings can get orphaned or overwritten.
 
 === Move Current ownCloud Directory
 
@@ -145,7 +145,7 @@ If you keep your `data` **outside** of your `owncloud` directory, then you donâ€
 
 === Copy Relevant config.php Content
 
-With the new source files now in place of where the old ones used to be, copy all `\*config.php` and `*.json` files (if one exist) from your old ownCloud directory to your new ownCloud directory:
+With the new source files now in place of where the old ones used to be, copy all `\*config.php` and `*.json` files (if any exist) from your old ownCloud directory to your new ownCloud directory:
 
 [source,bash]
 ----
@@ -223,7 +223,7 @@ sudo find -L /var/www/owncloud -type f -print0 | xargs -0 chmod 640
 sudo find -L /var/www/owncloud -type d -print0 | xargs -0 chmod 750
 ----
 
-* Set the occ command to executable
+* Set the occ command to executable:
 +
 [source,bash]
 ----
@@ -236,7 +236,7 @@ If you have configured a script for xref:installation/manual_installation/script
 
 === Start the Upgrade
 
-With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line, note the example is based on Ubuntu Linux, execute this within the ownCloud root folder.
+With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line. Note that the example is based on Ubuntu Linux. Execute this within the ownCloud root folder.
 
 [source,bash,subs="attributes+"]
 ----


### PR DESCRIPTION
* The manual upgrade missed that we need to set occ to executeable.
* Speeded up the commands by using xargs
* Added *config.php and *.json to be copied to the new config directory

References: https://github.com/owncloud/docs-server/pull/472#commitcomment-76974777

Backport to 10.10 and 10.9

@d7oc fyi