### PR TITLE
Config-to-docs run to include new config elements coming from core

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -814,6 +814,18 @@ Example: `proxy.example.com:8081`.
 'proxy' => '',
 ....
 
+=== Define a list of hostnames that won't be proxied.
+
+This option only applies if the `proxy` option is used
+Example: `['specific.hostname.com', '.sub.domain.com']`.
+
+==== Code Sample
+
+[source,php]
+....
+'proxy_ignore' => [],
+....
+
 === Define proxy authentication
 The optional authentication for the proxy to use to connect to the internet.
 


### PR DESCRIPTION
Referencing: https://github.com/owncloud/core/pull/40148 (Add configuration option to bypass proxy settings for some domains)

NO backports, master only!