### PR TITLE
Update jQuery warnings page

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
@@ -1,21 +1,33 @@
 = jQuery Warnings
+:toc:right
 
-While ownCloud is using an older version of jQuery we have fixed the known vulnerabilities in the patches listed below.
-We closely follow any security related news regarding the library for any new issues.
-The version shipped inside ownCloud is secure.
+:description: While ownCloud is using an older version of jQuery, we have fixed the known vulnerabilities in the patches listed below. We closely follow any security related news regarding the library for any new issues.
 
-Fixed issues:
+== Introduction
 
-* CVE-2020-11022 / CVE-2020-11023
+{description}
+
+NOTE: *The jQuery version shipped inside ownCloud is secure.*
+
+Note that automatic scanners may still report false positive, even the CVE's have been addressed as the scanners just look on the jQuery version shipped.
+ 
+== Fixed Issues
+
+* jQuery
+** CVE-2020-11022 and CVE-2020-11023 +
 https://github.com/owncloud/core/pull/37596[patched in 10.5.0]
 
-* CVE-2015-9251
+** CVE-2015-9251 +
 https://github.com/owncloud/core/pull/31972[patched in 10.0.9 RC3]
 
-* CVE-2019-11358
+** CVE-2019-11358 +
 https://github.com/owncloud/core/pull/38841[patched in 10.8.0]
 
-* CVE-2016-7103
+** CVE-2016-7103 +
 https://github.com/owncloud/core/pull/39545[patched in 10.9.0]
+
+* jQuery-ui
+** CVE-2021-41182, CVE-2021-41183 and CVE-2021-41184 +
+https://github.com/owncloud/core/pull/39451[patched in 10.9.0]
 
 If you know about any issues which were not patched yet or which are not included in this list please notify us at mailto:security@owncloud.com[security@owncloud.com].

--- a/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
@@ -9,7 +9,7 @@
 
 NOTE: *The jQuery version shipped inside ownCloud is secure.*
 
-Note that automatic scanners may still report false positive, even the CVE's have been addressed as the scanners just look on the jQuery version shipped.
+Note that automatic scanners may still report false positives even if the CVE's have been addressed as the scanners just look on the jQuery version shipped.
  
 == Fixed Issues
 

--- a/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/jquery_warnings.adoc
@@ -9,7 +9,7 @@
 
 NOTE: *The jQuery version shipped inside ownCloud is secure.*
 
-Note that automatic scanners may still report false positives even if the CVE's have been addressed as the scanners just look on the jQuery version shipped.
+Note that automatic scanners may still report false positives even if the CVE's have been addressed as the scanners just look at the jQuery version shipped.
  
 == Fixed Issues
 


### PR DESCRIPTION
Update of the jQuery warning page, references: https://github.com/owncloud/core/issues/37463 (JQuery 1.2 < 3.5.0 XSS) 

Backport to 10.10 and 10.9