### PR TITLE
Config-to-docs run based on recent changes from core

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1056,11 +1056,16 @@ process.
 ....
 
 === Define ownCloud operation modes
-This defines the mode of operations. The default value is 'single-instance'
-which means that ownCloud is running on a single node, which might be the
+This defines the mode of operations. The default value is `single-instance`
+which means, that ownCloud is running on a single node, which might be the
 most common operations mode. The only other possible value for now is
-'clustered-instance' which means that ownCloud is running on at least 2
-nodes. The mode of operations has various impact on the behavior of ownCloud.
+`clustered-instance` which means, that ownCloud is running on at least 2
+nodes. The mode of operations has various impacts on the behavior of ownCloud.
+
+The primary impact is, that clustered instances won't download apps from the
+marketplace and install in one server. Instead the admin has to ensure that
+this happens manually on all servers. The same applies to config.php configuration
+settings done via `occ`.
 
 ==== Code Sample
 


### PR DESCRIPTION
`config-to-docs` run based on recent changes in core,
see https://github.com/owncloud/core/pull/40182 (Enhanced clustered-instance mode documentation)

Backport to 10.10 and 10.9

@d7oc fyi