### PR TITLE
Document that ownCloud 10.9 and above also works with Mariadb 10.7 and 10.8

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -38,7 +38,7 @@ For _best performance_, _stability_, _support_ and _full functionality_, we offi
 | {recommended-php-version}
 |===
 
-(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
+(1) MariaDB 10.6 and later is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
 
 == Officially Supported Environments
 
@@ -60,7 +60,7 @@ including all 100% compatible derivatives
 * openSUSE Leap 15.2
 
 | Database
-| * xref:#database-requirements[MySQL] 8+ or xref:#database-requirements[MariaDB] 10.2, 10.3, 10.4 or 10.5 ^1^ (*Recommended*)
+| * xref:#database-requirements[MySQL] 8+ or xref:#database-requirements[MariaDB] 10.2 through 10.8 ^1^ (*Recommended*)
 * Oracle 11 and 12 (*Enterprise only*)
 * PostgreSQL 9, 10, 11, 12, 13 or 14
 * SQLite (*Not for production*)
@@ -72,7 +72,7 @@ including all 100% compatible derivatives
 |* {supported-php-versions}
 |===
 
-(1) MariaDB 10.6 is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
+(1) MariaDB 10.6 and later is *only supported* with ownCloud release 10.9 and upwards. See the xref:installation/manual_installation/manual_installation.adoc#install-a-database[Install a Database] guide and xref:maintenance/upgrading/database_upgrade.adoc[Database Upgrade] guide.
 
 [NOTE]
 ====

--- a/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
@@ -47,13 +47,13 @@ Threads: 16  Questions: 891020  Slow queries: 0  Opens: 119  Flush tables: 1  Op
 
 For information on how to install a higher stable release of MariaDB than the one provided by Ubuntu, refer to the {install-mariadb-latest-url}[MariaDB installation documentation].
 
-WARNING: The installation and use of MariaDB 10.6 is *only* supported and functional with ownCloud release 10.9 or above if it is a *new* ownCloud installation. Using an existing older version of ownCloud is not supported with MariaDB 10.6. The necessary manual migration steps are only available with ownCloud release 10.9 or above.
+WARNING: The installation and use of MariaDB 10.6 and later is *only* supported and functional with ownCloud release 10.9 or above if it is a *new* ownCloud installation. Using an existing older version of ownCloud is not supported with MariaDB 10.6 and later. The necessary manual migration steps are only available with ownCloud release 10.9 or above.
 
 == Upgrading an Existing Release
 
 When upgrading from one minor version of MariaDB to another, e.g. from 10.4 to 10.5, follow the respective {upgrade-mariadb-url}[Upgrading MariaDB] guide.
 
-WARNING: Do not upgrade a running ownCloud installation to MariaDB 10.6 until ownCloud release 10.9 or above is installed. ownCloud release 10.9 or above runs well with MariaDB lower than 10.6 and has special instructions for upgrading to MariaDB 10.6. 
+WARNING: Do not upgrade a running ownCloud installation to MariaDB 10.6 and later until ownCloud release 10.9 or above is installed. ownCloud release 10.9 or above runs well with MariaDB lower than 10.6 and has special instructions for upgrading to MariaDB 10.6 and later.
 
 WARNING: You must not skip minor releases of MariaDB when upgrading like from 10.4 -> 10.6, you have to upgrade to each minor version in between step by step.
 


### PR DESCRIPTION
See core PRs https://github.com/owncloud/core/pull/40206 and https://github.com/owncloud/core/pull/40207 for a demonstration that Mariadb 10.7 and 10.8 work fine with ownCloud core. That should be true from ownCloud 10.9, when support for Mariadb 10.6 was explicitly added. There are no ownCloud core code changes needed for Mariadb 10.7 or 10.8.

IMO, we can mention that ownCloud core 10.9 and upwards supports using Mariadb all the way up to 10.8.