### PR TITLE
Increased mariadb version in docker compose file

### DIFF
--- a/modules/admin_manual/examples/installation/docker/docker-compose.yml
+++ b/modules/admin_manual/examples/installation/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - files:/mnt/data
 
   mariadb:
-    image: mariadb:10.5
+    image: mariadb:10.6 # minimum required ownCloud version is 10.9
     container_name: owncloud_mariadb
     restart: always
     environment:


### PR DESCRIPTION
Increase the mariadb version to 10.6 in the dockerfile + comment that it needs oC 10.9

Backport to 10.10 and 10.9