### PR TITLE
Added note about overwritten .htaccess file

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -1,6 +1,6 @@
 = Manual ownCloud Upgrade
 :toc: right
-:toclevels: 1
+:toclevels: 2
 :description: This document describes how to manually upgrade your ownCloud installation. Because installations can vary, this guide can only give an overview of methods and examples.
 :page-aliases: maintenance/manual_upgrade.adoc
 
@@ -75,7 +75,7 @@ Go to menu:Settings[Admin > Apps] and disable all third-party apps.
 
 === Backup Manual Changes in `.htaccess`
 
-If you have made changes in `.htaccess` located at the webroot of ownCloud, you must backup these changes. Only backup the changes made but not the complete file as this file will be recreated on upgrades and may contain different settings provided by ownCloud. Manual changes in `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams].
+If you have made changes in `.htaccess` located at the webroot of ownCloud, you must backup these changes. Only backup the changes made but not the complete file as this file will be recreated on upgrades and may contain different settings provided by ownCloud. Manual changes in `.htaccess` can be necessary when you e.g. xref:configuration/integration/ms-teams.adoc[Integrate ownCloud into Microsoft Teams] or fixing WebDav connection errors as xref:troubleshooting/general_troubleshooting.adoc#error-0x80070043-the-network-name-cannot-be-found-while-adding-a-network-drive[The network name cannot be found] on Windows.
 
 === Backup Manual Changes in `.user.ini`
 

--- a/modules/admin_manual/pages/troubleshooting/general_troubleshooting.adoc
+++ b/modules/admin_manual/pages/troubleshooting/general_troubleshooting.adoc
@@ -282,6 +282,8 @@ You need to add the following rule set to your main web server or
 virtual host configuration, or the `.htaccess` file in your document
 root.
 
+NOTE: Please keep in mind that the `.htaccess` file in the ownCloud directory will be overwritten on update. Post upgrading ownCloud, you need to manually restore these changes. See the section xref:maintenance/upgrading/manual_upgrade.adoc#backup-manual-changes-in-htaccess[Backup Manual Changes in .htaccess] for details.
+
 [source,apache]
 ----
 # Fixes Windows WebDav client error 0x80070043 "The network name cannot be found."


### PR DESCRIPTION
ownCloud's `.htaccess` file will be overwritten on update. So readers should be aware of this when changing something in there.

Backport to 10.10 and 10.9