### PR TITLE
Update generated volume name in index.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -192,10 +192,7 @@ To inspect the volumes run:
 docker volume ls
 ----
 
-The volume name depends on the project name which builds the first part of the volume and the name of the volume in the docker file. 
-It can be configured using the variable `COMPOSE_PROJECT_NAME` which can also be defined in a `.env` file. 
-If not specified, the directory in which docker-compose is executed will be used as a name.
-The naming pattern of the volume is `<COMPOSE_PROJECT_NAME>_<VOLUME_NAME>`.
+The volume name depends on the project name which builds the first part of the volume and the name of the volume in the docker file. The naming pattern of the volume is `<COMPOSE_PROJECT_NAME>_<VOLUME_NAME>`. An environment variable for `COMPOSE_PROJECT_NAME` can be set and also be defined in a `.env` file. If not specified, the directory in which docker-compose is executed will be used as a name.
 
 To export the files of the project "owncloud-docker-server" as a tar archive run:
 [source,docker]

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -189,7 +189,7 @@ It is the admin's responsibility to make the files persistent.
 To inspect the volumes run:
 [source,docker]
 ----
-docker volume ls
+docker volume ls | grep files
 ----
 
 The volume name depends on the project name which builds the first part of the volume and the name of the volume in the docker file. The naming pattern of the volume is `<COMPOSE_PROJECT_NAME>_<VOLUME_NAME>`. An environment variable for `COMPOSE_PROJECT_NAME` can be set and also be defined in a `.env` file. If not specified, the directory in which docker-compose is executed will be used as a name.
@@ -197,7 +197,7 @@ The volume name depends on the project name which builds the first part of the v
 To export the files of the project "owncloud-docker-server" as a tar archive run:
 [source,docker]
 ----
-docker run -v owncloud-docker-server_files:/mnt \
+docker run -v <YOUR_DOCKER_VOLUME>:/mnt \
        ubuntu tar cf - -C /mnt . > files.tar
 ----
 ====

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -189,13 +189,18 @@ It is the admin's responsibility to make the files persistent.
 To inspect the volumes run:
 [source,docker]
 ----
-docker volume ls | grep owncloud-setup
+docker volume ls
 ----
 
-To export the files as a tar archive run:
+The volume name depends on the project name which builds the first part of the volume and the name of the volume in the docker file. 
+It can be configured using the variable `COMPOSE_PROJECT_NAME` which can also be defined in a `.env` file. 
+If not specified, the directory in which docker-compose is executed will be used as a name.
+The naming pattern of the volume is `<COMPOSE_PROJECT_NAME>_<VOLUME_NAME>`.
+
+To export the files of the project "owncloud-docker-server" as a tar archive run:
 [source,docker]
 ----
-docker run -v owncloud-setup_files:/mnt \
+docker run -v owncloud-docker-server_files:/mnt \
        ubuntu tar cf - -C /mnt . > files.tar
 ----
 ====

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -189,13 +189,13 @@ It is the admin's responsibility to make the files persistent.
 To inspect the volumes run:
 [source,docker]
 ----
-docker volume ls | grep ownclouddockerserver
+docker volume ls | grep owncloud-setup
 ----
 
 To export the files as a tar archive run:
 [source,docker]
 ----
-docker run -v ownclouddockerserver_files:/mnt \
+docker run -v owncloud-setup_files:/mnt \
        ubuntu tar cf - -C /mnt . > files.tar
 ----
 ====


### PR DESCRIPTION
Having followed the instructions and using the provided `docker-compose.yml` file, the generated volume name is different from what is mentioned in the docs.

[modules/admin_manual/examples/installation/docker/docker-compose.yml](https://github.com/owncloud/docs-server/blob/master/modules/admin_manual/examples/installation/docker/docker-compose.yml)

My docker version is "Docker version 20.10.12, build 20.10.12-0ubuntu4" if that matters.

```bash
$ docker volume ls
DRIVER    VOLUME NAME
local     owncloud-setup_files
local     owncloud-setup_mysql
local     owncloud-setup_redis
```