### PR TITLE
Public link share of a single file can now have edit access

### DIFF
--- a/modules/developer_manual/examples/core/scripts/curl/create-share.sh
+++ b/modules/developer_manual/examples/core/scripts/curl/create-share.sh
@@ -6,9 +6,13 @@
 base_uri={oc-examples-server-url}
 API_PATH=ocs/v1.php/apps/files_sharing/api/v1/shares
 
-# Create a public link share with read permissions, named "paris photo"
+# Create a public link share of a single file with read permissions, named "paris photo"
 curl --user {oc-examples-username}:{oc-examples-password} "$base_uri/$API_PATH" \
      --data 'path=/Photos/Paris.jpg&shareType=3&permissions=3&name=paris%20photo'
+
+# Create a public link share of a single file with read and write permissions, named "Notes"
+curl --user {oc-examples-username}:{oc-examples-password} "$base_uri/$API_PATH" \
+     --data 'path=/Documents/notes.txt&shareType=3&permissions=15&name=Notes'
 
 # Create a user share with read permissions, named "welcome.txt" that has read
 # and share permissions set.

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -696,10 +696,12 @@ The list of available permissions can be obtained from a request to xref:core/ap
 ====
 Things to remember about public link shares
 
-* Files will only ever have the *read* permission set
-* Folders will have *read*, *update*, *create*, and *delete* set
+* Files can only ever have the *read* and *update* permission set
+* Folders can have *read*, *update*, *create*, and *delete* set
 * Public link shares *cannot* be shared with users and groups
 * Public link shares are not available if public link sharing is disabled by the administrator
+* When creating a public link share of a folder, specify permissions 15 to give download/view/edit access
+* When creating a public link share of a single file, also specify permissions 15 in the API request to give download/view/edit access. The public link share will actually be given permissions 3 (read and update) because create and delete permissions are not relevant for single file shares
 
 *Mandatory Fields*
 


### PR DESCRIPTION
Fixes #572 

Note: the ownCloud core behavior when creating public link shares is that if I ask for permissions 3 (read and update) on a public link share API share creation request, then I actually get just permission 1 (read). That has been that way for "a long time" (tm), and maybe there are existing clients that "accidentally" send permissions 3 when actually they only expect to get a public link share with read permission. (Probably requests asking for permission 3 on a public link should have returned some 4xxx code to indicate that the request is not valid, but it's too late for that now)

So that behavior needs to be preserved.

To create a public link share of a single file, the client has to request permissions 15 (read, update, create, delete) to actually get permissions 3 (read, update). I have noted that in the documentation - it is a bit of a weird thing that you ask for permissions 15 and get 3, but if you ask for permissions 3, you get 1.
