### PR TITLE
Fix configreport and logging

### DIFF
--- a/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
@@ -61,7 +61,7 @@ The log type can be set to xref:configuration/server/config_sample_php_parameter
 "loglevel" => "3",
 ----
 
-The syslog format can be changed to remove or add information. In addition to the `%replacements%` below `%level%` can be used, but it is used as a dedicated parameter to the syslog logging facility anyway.
+The syslog format can be changed to remove or add information. In addition to the `%replacements%` below, `%level%` can be used, but it is used as a dedicated parameter to the syslog logging facility anyway.
 
 [source,php]
 ----
@@ -76,7 +76,7 @@ For the old syslog message format use:
 
 === Conditional Logging Level Increase
 
-xref:configuration/server/config_sample_php_parameters.adoc#define-log-conditions[Log conditions] for log level increase based on conditions can be set. This will incfrease the logging level to automatically to `debug` when the first condition inside a condition block is met. All conditions are optional !
+xref:configuration/server/config_sample_php_parameters.adoc#define-log-conditions[Log conditions] for log level increase based on conditions can be set. This will increase the logging level automatically to `debug` when the first condition inside a condition block is met. All conditions are optional !
 
 * `shared_secret`: A unique token. If a http(s) request parameter named `log_secret` is added to the request and set to this token, the condition is met.
 * `users`: If the current request is done by one of the specified users, this condition is met.
@@ -106,7 +106,7 @@ The first one that matches triggers the condition block writing the log entry to
 ],
 ----
 
-Based on the conditional log settings above, following logs are written to the same logfile defined:
+Based on the conditional log settings above, the following logs are written to the same logfile:
 
 * Requests matching `log_secret` are debug logged.
 

--- a/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/logging/logging_configuration.adoc
@@ -2,11 +2,11 @@
 :toc: right
 :page-aliases: configuration/server/logging_configuration.adoc
 
+:description: Use your ownCloud log to review system status, or to help debug problems. You may adjust logging levels and choose between using the ownCloud log or using the default syslog daemon.
+
 == Introduction
 
-Use your ownCloud log to review system status, or to help debug
-problems. You may adjust logging levels, and choose between using the
-ownCloud log or your syslog.
+{description}
 
 == Parameters
 
@@ -18,24 +18,29 @@ Logging levels range from *DEBUG*, which logs all activity, to *FATAL*, which lo
 * *3*: ERROR: Error messages and fatal issues.
 * *4*: FATAL: Fatal issues only.
 
-By default the log level is set to *2* (WARN). Use *DEBUG* when you have
-a problem to diagnose, and then reset your log level to a less-verbose
-level, as *DEBUG* outputs a lot of information, and can affect your
-server performance.
+By default the log level is set to *2* (WARN). Use *DEBUG* when you have a problem to diagnose, and then reset your log level to a less-verbose level, as *DEBUG* outputs a lot of information, and can affect your server performance.
 
-Logging level parameters are set in the config/config.php file, or on
-the Admin page of your ownCloud Web GUI.
+Logging level parameters are set in the config/config.php file, or on the Admin page of your ownCloud Web GUI.
 
 === ownCloud
 
-All log information will be written to a separate log file which can be
-viewed using the log viewer on your Admin page. By default, a log file
-named *owncloud.log* will be created in the directory which has been
-configured by the *datadirectory* parameter in config/config.php.
+All log information will be written to a separate log file which can be viewed using the log viewer on your Admin page. By default, a log file named *owncloud.log* will be created in the directory which has been configured by the *datadirectory* parameter in config/config.php. As an example see:
 
-The desired date format can optionally be defined using the *logdateformat* parameter in config/config.php. 
-By default the {php-net-url}/manual/en/function.date.php[PHP date function] parameter `__c__` is used, and therefore the date/time is written in the format `__2013-01-10T15:20:25+02:00__`. 
-By using the date format in the example below, the date/time format will be written in the format `__January 10, 2013 15:20:25__`.
+[source,php]
+----
+'datadirectory' => '/var/www/owncloud/data',
+----
+
+When not using the default location for the logfile, it can be xref:configuration/server/config_sample_php_parameters.adoc#define-the-log-path[specified] via:
+
+[source,php]
+----
+'logfile' => '<your-path>/owncloud.log',
+----
+
+Note that the web server user must have write rights to that directory.
+
+The desired date format can optionally be defined using the xref:configuration/server/config_sample_php_parameters.adoc#define-the-log-date-format[logdateformat] parameter in config/config.php. By default the {php-net-url}/manual/en/function.date.php[PHP date function] parameter `__c__` is used, and therefore the date/time is written in the format `__2013-01-10T15:20:25+02:00__`. By using the date format in the example below, the date/time format will be written in the format `__January 10, 2013 15:20:25__`.
 
 [source,php]
 ----
@@ -47,7 +52,7 @@ By using the date format in the example below, the date/time format will be writ
 
 === syslog
 
-All log information will be sent to your default syslog daemon.
+The log type can be set to xref:configuration/server/config_sample_php_parameters.adoc#define-the-log-type[syslog] and all log information will be sent to your default syslog daemon.
 
 [source,php]
 ----
@@ -56,9 +61,7 @@ All log information will be sent to your default syslog daemon.
 "loglevel" => "3",
 ----
 
-The syslog format can be changed to remove or add information. In
-addition to the `%replacements%` below `%level%` can be used, but it is
-used as a dedicated parameter to the syslog logging facility anyway.
+The syslog format can be changed to remove or add information. In addition to the `%replacements%` below `%level%` can be used, but it is used as a dedicated parameter to the syslog logging facility anyway.
 
 [source,php]
 ----
@@ -73,9 +76,7 @@ For the old syslog message format use:
 
 === Conditional Logging Level Increase
 
-You can configure the logging level to automatically increase to `debug`
-when the first condition inside a condition block is met. All conditions
-are optional !
+xref:configuration/server/config_sample_php_parameters.adoc#define-log-conditions[Log conditions] for log level increase based on conditions can be set. This will incfrease the logging level to automatically to `debug` when the first condition inside a condition block is met. All conditions are optional !
 
 * `shared_secret`: A unique token. If a http(s) request parameter named `log_secret` is added to the request and set to this token, the condition is met.
 * `users`: If the current request is done by one of the specified users, this condition is met.
@@ -105,8 +106,7 @@ The first one that matches triggers the condition block writing the log entry to
 ],
 ----
 
-Based on the conditional log settings above, following logs are written
-to the same logfile defined:
+Based on the conditional log settings above, following logs are written to the same logfile defined:
 
 * Requests matching `log_secret` are debug logged.
 

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :page-aliases: configuration/server/logging/providing_logs_and_config_files.adoc
 
-:description: Generating configreports and prepare log files are essential to support identifying the cause of a problem. Here are instructions for how to collect them.
+:description: Generating configreports and preparing log files are essential to support identifying the cause of a problem. Here are instructions for how to collect them.
 
 == Introduction
 
@@ -12,7 +12,7 @@ When you report a problem to {oc-support-url}[ownCloud Support] or our {oc-centr
 
 == Generate a Config Report
 
-You can use the webUI or the command line to generate a config report. The webUI includes the web server environment, while the command line generated one doesn't as it can't access it. Therefore, if possible, always generate it through the webUI. The configreport app is always part of bundled apps, but it may needs to be enabled before it can be used.
+You can use the webUI or the command line to generate a config report. The webUI includes the web server environment, while the command line generated one doesn't as it can't access it. Therefore, if possible, always generate it through the webUI. The configreport app is always part of bundled apps, but it may need to be enabled before it can be used.
 
 Check if it is disabled:
 [source,bash,subs="attributes+"]
@@ -65,7 +65,7 @@ When not using the default location for the logfile, it can be specified via:
 
 == LDAP Config
 
-Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server. To get the output file, execute this command:
+If LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server. To get the output file, execute this command:
 
 [source,bash,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
+++ b/modules/admin_manual/pages/troubleshooting/providing_logs_and_config_files.adoc
@@ -2,32 +2,28 @@
 :toc: right
 :page-aliases: configuration/server/logging/providing_logs_and_config_files.adoc
 
+:description: Generating configreports and prepare log files are essential to support identifying the cause of a problem. Here are instructions for how to collect them.
+
 == Introduction
 
-When you report a problem to {oc-support-url}[ownCloud Support] or our {oc-central-url}/latest[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers (or other users). 
-These are essential in better understanding your issue, your specific configuration, and the cause of the problem.
+{description}
 
-Here are instructions for how to collect them.
+When you report a problem to {oc-support-url}[ownCloud Support] or our {oc-central-url}/latest[Forum (ownCloud Central)] you will be asked to provide certain log files or configurations for our engineers or other supporting staff. This information is necessary in better understanding your issue, your specific configuration, and for further support.
 
 == Generate a Config Report
 
-You can use the webUI or the command line to generate a config report. 
-The webUI includes the web server environment, while the command line generated one doesn't as it can't access it.
-Therefore, if possible, always generate it through the webUI.
-Please note that you have to have the configreport app enabled. 
-Check if it's already enabled by going to the apps section of the admin settings.
-You can enable this app using the following commands:
+You can use the webUI or the command line to generate a config report. The webUI includes the web server environment, while the command line generated one doesn't as it can't access it. Therefore, if possible, always generate it through the webUI. The configreport app is always part of bundled apps, but it may needs to be enabled before it can be used.
 
-Install it, if it’s not already installed:
+Check if it is disabled:
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} market:install configreport
+{occ-command-example-prefix} app:list --disabled configreport
 ----
 
-Or enable it, if it’s already installed:
+Enable it if it was formerly disabled:
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix}:app enable configreport
+{occ-command-example-prefix} app:enable configreport
 ----
 
 === Generate via webUI
@@ -53,27 +49,23 @@ menu:Settings[Admin > General > Log > "Download logfile"].
 
 === Generate via Command Line
 
-If the log file is too big, you will need to transfer it from the command line. 
-The location of the log file can be found in your config.php. It's in your data directory. 
+If the log file is too big, you will need to transfer it from the command line. The location of the log file can be found in your config.php. By default it is in your data directory. Note that you may need to compress the logfile before uploading:
 
 [source,php]
 ----
- 'datadirectory' => '/var/www/owncloud/data',
+'datadirectory' => '/var/www/owncloud/data',
 ----
 
-You also can specify a different location of the log file.
+When not using the default location for the logfile, it can be specified via:
 
 [source,php]
 ----
-'logfile' => '/home/www-data/owncloud.log',
+'logfile' => '<your-path>/owncloud.log',
 ----
-
-Note that the web server user has to have rights to write in that directory.
 
 == LDAP Config
 
-Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server.
-To get the output file, execute this command:
+Assuming that LDAP is used, viewing the LDAP configuration is important when checking for errors between your ownCloud instance and your LDAP server. To get the output file, execute this command:
 
 [source,bash,subs="attributes+"]
 ----

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -89,7 +89,8 @@
 **** xref:admin_manual:configuration/server/occ_command.adoc[OCC Command]
 **** xref:admin_manual:configuration/server/language_configuration.adoc[Language Configuration]
 **** xref:admin_manual:configuration/server/legal_settings_configuration.adoc[Legal Settings Configuration]
-**** xref:admin_manual:configuration/server/logging/logging_configuration.adoc[Logging Configuration]
+**** Logging
+***** xref:admin_manual:configuration/server/logging/logging_configuration.adoc[Logging Configuration]
 ***** xref:admin_manual:configuration/server/logging/request_tracing.adoc[Request Tracing]
 **** xref:admin_manual:configuration/server/reverse_proxy_configuration.adoc[Reverse Proxy Configuration]
 **** xref:admin_manual:configuration/server/security/index.adoc[Security]

--- a/site.yml
+++ b/site.yml
@@ -59,7 +59,7 @@ asciidoc:
     oc-examples-username: 'username'
     oc-examples-password: 'password'
     oc-complete-name: 'owncloud-complete-latest'
-    occ-command-example-prefix: 'sudo -u www-data occ'
+    occ-command-example-prefix: 'sudo -u www-data ./occ'
     occ-command-example-prefix-no-sudo: 'occ'
     php-net-url: 'https://www.php.net'
     php-supported-versions-url: 'https://www.php.net/supported-versions.php'


### PR DESCRIPTION
Fixes: [configreport application unknown to marketplace -> misleading](https://github.com/owncloud/docs-server/issues/579#top)

* fixes configreport - marketplace
* fixes logging navigation (note no link changes)
* text fixes
* repo only - fixes occ command attribute - an own PR in docs will be made to publish it 

Note that there are only a few text changes made but due to removing linebreakes, it offers to have a text review too - language review welcomed

Backport to 10.10 and 10.9