### PR TITLE
Config-to-docs run from latest core changes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1753,7 +1753,9 @@ quick action will not be displayed!
 'sharing.showPublicLinkQuickAction' => false,
 ....
 
-=== Save and display version of uploaded and edited files.
+=== Save and display the author of each version of uploaded and edited files.
+
+WARNING: This does not work for S3 storage backends.
 
 ==== Code Sample
 


### PR DESCRIPTION
Config to docs run from latest core changes

Replaces: #586 (Update config_sample_php_parameters.adoc)

Backport to 10.10 and 10.9