### PR TITLE
Update activity app

### DIFF
--- a/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
@@ -7,7 +7,7 @@
 
 {description}
 
-These events can be like:
+These events include:
 
 * A file or folder has been shared
 * A file or folder has been changed
@@ -31,5 +31,5 @@ Email notifications for shared files can be enabled/disabled by administrators w
 
 == Time Base
 
-* Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing ownCloud Server.
-* When a client recieves an expiry notifications for a share, the notification is by the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.
+* Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing the ownCloud Server.
+* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing the ownCloud Server.

--- a/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
@@ -1,31 +1,35 @@
 = Configuring the Activity App
 :page-aliases: configuration_server/activity_configuration.adoc
 :toc: right
+:description: You can configure your ownCloud server to automatically send out Email notifications to your users for various events.
 
 == Introduction
 
-You can configure your ownCloud server to automatically send out e-mail notifications to your users for various events like:
+{description}
+
+These events can be like:
 
 * A file or folder has been shared
-* A new file or folder has been created
 * A file or folder has been changed
 * A file or folder has been deleted
+* A new file or folder has been created
 
-Users can see actions (_delete_, _add_, _modify_) that happen to files they have access to. 
-Sharing actions are only visible to the sharer and recipient.
+Users can see actions (_delete_, _add_, _modify_) that happen to files they have access to. Sharing actions are only visible to the sharer and recipient.
 
 == Enabling the Activity App
 
-The Activity App is shipped and enabled by default. 
-If it is not enabled, go to your ownCloud Apps page to enable it.
+The Activity App is shipped and enabled by default. If it is not enabled, go to menu:Settings[Admin > Apps] to enable it.
 
 == Configuring your ownCloud for the Activity App
 
 [TIP] 
 ====
-A working e-mail configuration is required to configure your ownCloud to send out e-mail notifications.
-Furthermore, it is recommended to configure the xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[background job] `Webcron` or `Cron`.
+A working Email configuration is required to configure your ownCloud to send out Email notifications. Furthermore, it is recommended to configure the xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[background job] `Webcron` or `Cron`.
 ====
 
-Email notifications for shared files can be enabled/disabled by administrators with the "_Allow users to send mail notifications for shared files to other users_", available in menu:Settings[Admin > Sharing].
-There is also a xref:configuration/server/config_apps_sample_php_parameters.adoc#app-activity[configuration option] `activity_expire_days` available in your `config.php` which allows you to clean-up older activities from the database.
+Email notifications for shared files can be enabled/disabled by administrators with the "_Allow users to send mail notifications for shared files to other users_", available in menu:Settings[Admin > Sharing]. There is also a xref:configuration/server/config_apps_sample_php_parameters.adoc#app-activity[configuration option] `activity_expire_days` available in your `config.php` which allows you to clean-up older activities from the database.
+
+== Time Base
+
+* Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing ownCloud Server.
+* When a client recieves an expiry notifications for a share, the notification is by the end of the day based on the time of the ownCloud server and not the time of the client accessing ownCloud Server.

--- a/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/activity_configuration.adoc
@@ -1,7 +1,7 @@
 = Configuring the Activity App
 :page-aliases: configuration_server/activity_configuration.adoc
 :toc: right
-:description: You can configure your ownCloud server to automatically send out Email notifications to your users for various events.
+:description: You can configure your ownCloud server to automatically send out email notifications to your users for various events.
 
 == Introduction
 
@@ -24,12 +24,12 @@ The Activity App is shipped and enabled by default. If it is not enabled, go to 
 
 [TIP] 
 ====
-A working Email configuration is required to configure your ownCloud to send out Email notifications. Furthermore, it is recommended to configure the xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[background job] `Webcron` or `Cron`.
+A working email configuration is required to configure your ownCloud to send out email notifications. Furthermore, it is recommended to configure the xref:configuration/server/background_jobs_configuration.adoc#cron-jobs[background job] `Webcron` or `Cron`.
 ====
 
-Email notifications for shared files can be enabled/disabled by administrators with the "_Allow users to send mail notifications for shared files to other users_", available in menu:Settings[Admin > Sharing]. There is also a xref:configuration/server/config_apps_sample_php_parameters.adoc#app-activity[configuration option] `activity_expire_days` available in your `config.php` which allows you to clean-up older activities from the database.
+Email notifications for shared files can be enabled/disabled by administrators with the "_Allow users to send mail notifications for shared files to other users_" option, available in menu:Settings[Admin > Sharing]. There is also a xref:configuration/server/config_apps_sample_php_parameters.adoc#app-activity[configuration option] `activity_expire_days` available in your `config.php` which allows you to clean up older activities from the database.
 
 == Time Base
 
-* Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing the ownCloud Server.
-* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing the ownCloud Server.
+* Whenever a default date is enabled and set for expiring shares (e.g. after 7 days), the time base for default dates is the time of the ownCloud server, not the time of the client accessing the ownCloud server.
+* When a client receives an expiry notification for a share, the expiry is effective at the end of the day based on the time of the ownCloud server and not the time of the client accessing the ownCloud server.


### PR DESCRIPTION
Fixes: #592 ([QA] describe expectatins about expiry notifications)

Add some info about the time base when it comes to email notifications for expired shares and default expiration dates.

There will be an additional PR in webui to tell the same from the user pov.

Backport to 10.10 and 10.9

Note that the activity app is part of the shipment but also can be downloaded from marketplace. Backport is needed therefore.