### PR TITLE
Update ubuntu_22_04.adoc

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -86,7 +86,7 @@ apt install -y \
   php7.4-gd php7.4-imap php7.4-intl php7.4-json \
   php7.4-mbstring php7.4-gmp php7.4-bcmath php7.4-mysql \
   php7.4-ssh2 php7.4-xml php7.4-zip php7.4-apcu \
-  php7.4-redis php7.4-ldap php7.4-phpseclib\
+  php7.4-redis php7.4-ldap php-phpseclib\
 ----
 
 === Install smbclient php Module


### PR DESCRIPTION
php7.4-phpseclib seems not existing yet. using it here will break this easy-to-use package installation, leading to not installing any of these packages.

i proposed "php-phpseclib" since it was mentioned in the code block here:
https://github.com/owncloud/docs-server/issues/252#issuecomment-1116232718