### PR TITLE
Fix Impersonate not working with Shibboleth

### DIFF
--- a/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :page-aliases: issues/impersonate_users.adoc
 
-:description: To help users debug an issue or to get a better understanding of what they see when they use their ownCloud account, you can impersonate their ownCloud account.
+:description: To help users debug an issue or to get a better understanding of what they see when they use their ownCloud account, you can impersonate their ownCloud user.
 
 == Introduction
 
@@ -15,9 +15,9 @@
 
 == Impersonating a User
 
-When installed, you can then impersonate users; in effect, you will be logged in as said user. To do so, go to the Users list, where you will now see a new column available called "**Impersonate**", as in the screenshot below.
+When installed, you can then impersonate users; in effect, you will be logged in as a specific user. To do so, go to the Users list, where you will now see a new column available called "**Impersonate**", as in the screenshot below.
 
-image::apps/impersonate/picking-a-user-to-impersonate.png[Picking a user to Impersonate, width=450]
+image::apps/impersonate/picking-a-user-to-impersonate.png[Picking a User to Impersonate, width=450]
 
 Click the gray head icon next to the user that you want to impersonate. Doing so will log you in as that user, temporarily pausing your current session. You will see a notification at the top of the page that confirms you're now logged in as (or impersonating) that user.
 
@@ -29,7 +29,7 @@ Anything that you see until you log out will be what that user would see.
 
 When you're ready to stop impersonating the user, log out and you will return to your normal user session.
 
-== Allow Some or All Group Administrators To Impersonate Users
+== Allow Some or All Group Administrators to Impersonate Users
 
 As a security measure, the application lets ownCloud administrators restrict the ability to impersonate users to:
 
@@ -45,11 +45,11 @@ When enabled and configured, only a group's administrator can impersonate member
 
 To configure it, in the administrator settings panel, which you can find under menu:administrator[Settings > Admin > User Authentication], you'll see a section titled: "**Impersonate Settings**" (which you can see below).
 
-image::apps/impersonate/impersonate-settings.png[Impersonate App settings]
+image::apps/impersonate/impersonate-settings.png[Impersonate App Settings]
 
-If you want to allow group admins to impersonate users within groups which they administer, click btn:[Allow all group admins to impersonate users within the groups they are admins of].
+If you want to allow group admins to impersonate users within groups which they administer, click btn:[Allow all group admins to impersonate users within the groups they administrate].
 
-If you want to limit impersonation to specific group admins, first click btn:[Allow group admins of specific groups to impersonate the users within those groups]. With the option checked, click into the textbox underneath it. You will see a list of the matching groups on your ownCloud installation appear, which will change, based on what you type in the textbox.
+If you want to limit impersonation to specific group admins, first click btn:[Allow group admins of specific groups to impersonate the users within those groups]. With the option checked, click into the textbox underneath it. You will see a list of all groups on your ownCloud installation, which will change, based on what you type in the textbox to search for specific groups.
 
 image::apps/impersonate/limit-impersonation-to-specific-groups.png[Restricting the ability to impersonate users to specific groups]
 

--- a/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
+++ b/modules/admin_manual/pages/configuration/general_topics/impersonate_users.adoc
@@ -2,39 +2,32 @@
 :toc: right
 :page-aliases: issues/impersonate_users.adoc
 
+:description: To help users debug an issue or to get a better understanding of what they see when they use their ownCloud account, you can impersonate their ownCloud account.
+
 == Introduction
 
-Sometimes you may need to use your ownCloud installation as another
-user, whether to help users debug an issue or to get a better
-understanding of what they see when they use their ownCloud account. The
-ability to do so is a feature delivered via an ownCloud app called
-{oc-marketplace-url}/apps/impersonate[Impersonate].
+{description} The ability to do so is a feature delivered via an ownCloud app called {oc-marketplace-url}/apps/impersonate[Impersonate].
 
-NOTE: This functionality is available only to administrators.
+== Limitations
+
+* This functionality is available to administrators only.
+* Impersonating is not possible when using Shibboleth or OpenID.
 
 == Impersonating a User
 
-When installed, you can then impersonate users; in effect, you will be
-logged in as said user. To do so, go to the Users list, where you will
-now see a new column available called "**Impersonate**", as in the
-screenshot below.
+When installed, you can then impersonate users; in effect, you will be logged in as said user. To do so, go to the Users list, where you will now see a new column available called "**Impersonate**", as in the screenshot below.
 
-image:apps/impersonate/picking-a-user-to-impersonate.png[Picking a user to Impersonate.]
+image::apps/impersonate/picking-a-user-to-impersonate.png[Picking a user to Impersonate, width=450]
 
-Click the gray head icon next to the user that you want to impersonate.
-Doing so will log you in as that user, temporarily pausing your current
-session. You will see a notification at the top of the page that
-confirms you're now logged in as (or impersonating) that user.
+Click the gray head icon next to the user that you want to impersonate. Doing so will log you in as that user, temporarily pausing your current session. You will see a notification at the top of the page that confirms you're now logged in as (or impersonating) that user.
 
-image:apps/impersonate/impersonating-a-user.png[Impersonating a user.]
+image::apps/impersonate/impersonating-a-user.png[Impersonating a user, width=350]
 
-Anything that you see until you log out will be what that user would
-see.
+Anything that you see until you log out will be what that user would see.
 
 == Ending an Impersonation
 
-When you're ready to stop impersonating the user, log out and you will
-return to your normal user session.
+When you're ready to stop impersonating the user, log out and you will return to your normal user session.
 
 == Allow Some or All Group Administrators To Impersonate Users
 
@@ -45,24 +38,19 @@ As a security measure, the application lets ownCloud administrators restrict the
 
 [NOTE] 
 ====
-By default, when the Impersonate app is installed, only the ownCloud administrator will be allowed to impersonate users.
-When the app is installed and configured, ownCloud administrators retain the ability to impersonate all users of an ownCloud instance.
+By default, when the Impersonate app is installed, only the ownCloud administrator will be allowed to impersonate users. When the app is installed and configured, ownCloud administrators retain the ability to impersonate all users of an ownCloud instance.
 ====
 
-When enabled and configured, only a group's administrator can impersonate members of their group.
-For example, if an ownCloud administrator restricts user impersonation only to the group: `group1`, then only `group1`'s administrators can impersonate users belonging to `group1`. 
-No other users can impersonate other users.
+When enabled and configured, only a group's administrator can impersonate members of their group. For example, if an ownCloud administrator restricts user impersonation only to the group: `group1`, then only `group1`'s administrators can impersonate users belonging to `group1`. No other users can impersonate other users.
 
 To configure it, in the administrator settings panel, which you can find under menu:administrator[Settings > Admin > User Authentication], you'll see a section titled: "**Impersonate Settings**" (which you can see below).
 
-image:apps/impersonate/impersonate-settings.png[Impersonate App settings]
+image::apps/impersonate/impersonate-settings.png[Impersonate App settings]
 
 If you want to allow group admins to impersonate users within groups which they administer, click btn:[Allow all group admins to impersonate users within the groups they are admins of].
 
-If you want to limit impersonation to specific group admins, first click btn:[Allow group admins of specific groups to impersonate the users within those groups]. 
-With the option checked, click into the textbox underneath it.
-You will see a list of the matching groups on your ownCloud installation appear, which will change, based on what you type in the textbox.
+If you want to limit impersonation to specific group admins, first click btn:[Allow group admins of specific groups to impersonate the users within those groups]. With the option checked, click into the textbox underneath it. You will see a list of the matching groups on your ownCloud installation appear, which will change, based on what you type in the textbox.
 
-image:apps/impersonate/limit-impersonation-to-specific-groups.png[Restricting the ability to impersonate users to specific groups]
+image::apps/impersonate/limit-impersonation-to-specific-groups.png[Restricting the ability to impersonate users to specific groups]
 
 Choose one or more groups from the list, and they will be added to the textbox, restricting this functionality to only those groups.


### PR DESCRIPTION
Fixes: [Shibboleth users cannot impersonate](https://github.com/owncloud/docs-server/issues/111#top)

Beside that, removing not necessary line breakes and image fixes.

Backport to 10.10 and 10.9