### PR TITLE
Changes necessary for 10.11

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "10.10"
+    latest_version = "10.11"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -48,10 +48,10 @@ asciidoc:
     latest-docs-version: 'next'
     previous-docs-version: 'next'
 #   server
-    latest-server-version: '10.10'
-    latest-server-download-version: '10.10.0'
-    previous-server-version: '10.9'
-    current-server-version: '10.10'
+    latest-server-version: '10.11'
+    latest-server-download-version: '10.11.0'
+    previous-server-version: '10.10'
+    current-server-version: '10.11'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://software.opensuse.org/download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
@@ -74,7 +74,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0-beta.3'
+    ocis-version: '2.0.0-beta.8'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
 #   desktop
     latest-desktop-version: 'next'


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 10.11 branch.

The 10.11 branch is already pushed and prepared and is included in the branch protection rules.

When 10.11 (core) is finally out, the 10.9 branch can be archived,
see step 3 in  https://github.com/owncloud/docs/blob/master/docs/new-version-branch.md

Note, that the 10.11 branch in this repo is already created, but the `latest` pointer on the web
will be set to it automatically when the tag in core is set. This means, that in the docs homepage,
`latest` will point to 10.9 until the tag in core is set accordingly. When merging this PR,
10.9 will be dropped from the web but is available via pdf as usual.

Note, this PR must be merged before the 10.11 tag in core is set to avoid a 404 for `latest`.

Before merging this PR, we should take care that 10.9 has all changes necessary merged as post
merging the 10.x9 pdf is fixed.

@pmaier1 @jnweiger fyi

@mmattel @EParzefall @phil-davis
post merging this, we need to backport all relevant changes to 10.11