### PR TITLE
occ previews:cleanup

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -316,6 +316,8 @@ include::./occ_commands/core_commands/_mimetype_update_commands.adoc[leveloffset
 
 include::./occ_commands/core_commands/_notifications_commands.adoc[leveloffset=+2]
 
+include::./occ_commands/core_commands/_previews_commands.adoc[leveloffset=+2]
+
 include::./occ_commands/core_commands/_incoming_shares_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/core_commands/_security_commands.adoc[leveloffset=+2]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_managing_background_jobs.adoc
@@ -95,19 +95,26 @@ This example lists the queue status:
 ----
 {occ-command-example-prefix} background:queue:status
 
-+----+---------------------------------------------------+---------------------------+---------------+
-| Id | Job                                               | Last run                  | Job Arguments |
-+----+---------------------------------------------------+---------------------------+---------------+
-| 1  | OCA\Files\BackgroundJob\ScanFiles                 | 2018-06-13T15:15:04+00:00 |               |
-| 2  | OCA\Files\BackgroundJob\DeleteOrphanedItems       | 2018-06-13T15:15:04+00:00 |               |
-| 3  | OCA\Files\BackgroundJob\CleanupFileLocks          | 2018-06-13T15:15:04+00:00 |               |
-| 4  | OCA\DAV\CardDAV\SyncJob                           | 2018-06-12T19:15:02+00:00 |               |
-| 5  | OCA\Federation\SyncJob                            | 2018-06-12T19:15:02+00:00 |               |
-| 6  | OCA\Files_Sharing\DeleteOrphanedSharesJob         | 2018-06-13T15:15:04+00:00 |               |
-| 7  | OCA\Files_Sharing\ExpireSharesJob                 | 2018-06-12T19:15:02+00:00 |               |
-| 8  | OCA\Files_Trashbin\BackgroundJob\ExpireTrash      | 2018-06-13T15:15:04+00:00 |               |
-| 9  | OCA\Files_Versions\BackgroundJob\ExpireVersions   | 2018-06-13T15:15:04+00:00 |               |
-| 10 | OCA\UpdateNotification\Notification\BackgroundJob | 2018-06-12T19:15:03+00:00 |               |
-| 11 | OC\Authentication\Token\DefaultTokenCleanupJob    | 2018-06-13T15:15:04+00:00 |               |
-+----+---------------------------------------------------+---------------------------+---------------+
++--------+----------------------------------------------------+---------------+----------+---------------------------+-------------+------------------------+
+| Job ID | Job                                                | Job Arguments | Last Run | Last Checked              | Reserved At | Execution Duration (s) |
++--------+----------------------------------------------------+---------------+----------+---------------------------+-------------+------------------------+
+| 1      | OCA\Files\BackgroundJob\ScanFiles                  |               | N/A      | 2022-09-08T16:42:47+00:00 | N/A         | N/A                    |
+| 2      | OCA\Files\BackgroundJob\DeleteOrphanedItems        |               | N/A      | 2022-09-08T16:42:47+00:00 | N/A         | N/A                    |
+| 3      | OCA\Files\BackgroundJob\CleanupFileLocks           |               | N/A      | 2022-09-08T16:42:47+00:00 | N/A         | N/A                    |
+| 4      | OCA\Files\BackgroundJob\CleanupPersistentFileLocks |               | N/A      | 2022-09-08T16:42:47+00:00 | N/A         | N/A                    |
+| 5      | OCA\Files\BackgroundJob\PreviewCleanupJob          |               | N/A      | 2022-09-08T16:42:47+00:00 | N/A         | N/A                    |
+| 6      | OCA\DAV\CardDAV\SyncJob                            |               | N/A      | 2022-09-08T16:42:49+00:00 | N/A         | N/A                    |
+| 7      | OCA\DAV\BackgroundJob\CleanProperties              |               | N/A      | 2022-09-08T16:42:49+00:00 | N/A         | N/A                    |
+| 8      | OCA\Activity\BackgroundJob\EmailNotification       |               | N/A      | 2022-09-08T16:42:49+00:00 | N/A         | N/A                    |
+| 9      | OCA\Activity\BackgroundJob\ExpireActivities        |               | N/A      | 2022-09-08T16:42:49+00:00 | N/A         | N/A                    |
+| 10     | OCA\Federation\SyncJob                             |               | N/A      | 2022-09-08T16:42:50+00:00 | N/A         | N/A                    |
+| 11     | OCA\Files_Sharing\DeleteOrphanedSharesJob          |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 12     | OCA\Files_Sharing\ExpireSharesJob                  |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 13     | OCA\Files_Sharing\External\ScanExternalSharesJob   |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 14     | OCA\Files_Trashbin\BackgroundJob\ExpireTrash       |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 15     | OCA\Files_Versions\BackgroundJob\ExpireVersions    |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 16     | OCA\Market\CheckUpdateBackgroundJob                |               | N/A      | 2022-09-08T16:42:51+00:00 | N/A         | N/A                    |
+| 17     | OCA\UpdateNotification\Notification\BackgroundJob  |               | N/A      | 2022-09-08T16:42:52+00:00 | N/A         | N/A                    |
+| 18     | OC\Authentication\Token\DefaultTokenCleanupJob     |               | N/A      | 2022-09-08T16:42:52+00:00 | N/A         | N/A                    |
++--------+----------------------------------------------------+---------------+----------+---------------------------+-------------+------------------------+
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
@@ -35,7 +35,7 @@ Removing not referenced previews can be necessary, e.g., when the image has been
 
 Description:
 
-* `chunk size` defines the number of files being processed in one loop and also how often a database commit will be made. The lower the number, the more commits are generated.
+* The value of `chunk size` defines the number of files being processed in one loop and also how often a database commit will be made. The lower the number, the more commits are generated.
 * if `--all` is set, the loop will loop until all are processed
 * if `--all` is not set, the loop will run once
 
@@ -50,8 +50,8 @@ In the example below, you run one loop with max (default) 1000 files processed.
 
 Other combinations could be:
 
-* `chunk_size=50`: run once and process 50 files
-* `--all chunk_size=50`: process all files in blocks of 50 files
+* `previews:cleanup -- 50`: run once and process 50 files
+* `previews:cleanup --all 50`: process all files in blocks of 50 files
 
 === Background Job
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
@@ -1,0 +1,58 @@
+= Previews Commands
+
+A set of commands to remove unreferenced preview images:
+
+[source,plaintext]
+----
+previews
+ previews:cleanup            Remove unreferenced previews
+----
+
+== Cleanup
+
+Removing unreferenced previews can be necessary, like when the image has been deleted or the ID of the moint point changes which happens when renaming it. Previews will be regenerated when reaccessing the image, but unreferenced previews are orphanes. To circumvent orphans, a occ command has been added to manually remove those unreferenced previews as they are eating up storage unneccessarily. In addition, a backgroundjob has been created which automatically removes them on a regulary basis. For more info see the xref:background-job[Background Job] section and the example listing xref:configuration/server/occ_command.adoc#list-queued-backgroundjobs[OCA\Files\BackgroundJob\PreviewCleanupJob].
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} previews:cleanup [options] [--] [<chunk_size>]
+----
+
+=== Arguments
+
+[width="100%",cols="25%,70%",]
+|====
+| `chunk_size`
+| Define the number of files being processed in one loop [default: 1000]
+|====
+
+=== Options
+
+[width="100%",cols="25%,70%",]
+|====
+| `-all`
+| Run as many loops until no chunks remain
+|====
+
+Description:
+
+* `chunk size` defines the number of files being processed in one loop and also how often a database commit will be made. As lower the number, as more commits are generated.
+* if `--all` is set, the loop will loop until all are processed
+* if `--all` is not set, the loop will run once
+
+=== Example
+
+In the example below, run one loop with max (default) 1000 files processed.
+ 
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} previews:cleanup
+----
+
+Other combinations could be like:
+
+* `chunk_size=50`: run once and process 50 files
+* `--all chunk_size=50`: process all files in blocks of 50 files
+
+=== Background Job
+
+The background job to cleanup previews is added by default and suits perfect for smaller installations like when you use the community edition. The occ command is to be used in regular system cron on bigger installations like when using the enterprise edition. In this case, the background job can stay enabled in such a setup - there is no harm, but with the combination admins have better control. Note that you also can remove a background job if it does not fit to your environment.

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
@@ -10,7 +10,7 @@ previews
 
 == Cleanup
 
-Removing unreferenced previews can be necessary, like when the image has been deleted or the ID of the moint point changes which happens when renaming it. Previews will be regenerated when reaccessing the image, but unreferenced previews are orphanes. To circumvent orphans, a occ command has been added to manually remove those unreferenced previews as they are eating up storage unneccessarily. In addition, a backgroundjob has been created which automatically removes them on a regulary basis. For more info see the xref:background-job[Background Job] section and the example listing xref:configuration/server/occ_command.adoc#list-queued-backgroundjobs[OCA\Files\BackgroundJob\PreviewCleanupJob].
+Removing not referenced previews can be necessary, e.g., when the image has been deleted or the ID of the mountpoint changes which happens when renaming it. Previews will be generated anew when accessing the image again, but not referenced previews are orphans. To avoid orphans, an occ command has been added to manually remove those not referenced previews as they are eating up storage space unnecessarily. In addition, a background job has been created which automatically removes them on a regular basis. For more info see the xref:background-job[Background Job] section and the example listing xref:configuration/server/occ_command.adoc#list-queued-backgroundjobs[OCA\Files\BackgroundJob\PreviewCleanupJob].
 
 [source,bash,subs="attributes+"]
 ----
@@ -35,24 +35,24 @@ Removing unreferenced previews can be necessary, like when the image has been de
 
 Description:
 
-* `chunk size` defines the number of files being processed in one loop and also how often a database commit will be made. As lower the number, as more commits are generated.
+* `chunk size` defines the number of files being processed in one loop and also how often a database commit will be made. The lower the number, the more commits are generated.
 * if `--all` is set, the loop will loop until all are processed
 * if `--all` is not set, the loop will run once
 
 === Example
 
-In the example below, run one loop with max (default) 1000 files processed.
+In the example below, you run one loop with max (default) 1000 files processed.
  
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} previews:cleanup
 ----
 
-Other combinations could be like:
+Other combinations could be:
 
 * `chunk_size=50`: run once and process 50 files
 * `--all chunk_size=50`: process all files in blocks of 50 files
 
 === Background Job
 
-The background job to cleanup previews is added by default and suits perfect for smaller installations like when you use the community edition. The occ command is to be used in regular system cron on bigger installations like when using the enterprise edition. In this case, the background job can stay enabled in such a setup - there is no harm, but with the combination admins have better control. Note that you also can remove a background job if it does not fit to your environment.
+The background job to cleanup previews is added by default and suits smaller installations of the community edition. The occ command should be used in regular system cron jobs on bigger installations using the enterprise edition. In this case, the background job can stay enabled, but in combination with a cron job admins have better control. Note that you also can remove a background job if it does not fit your environment.


### PR DESCRIPTION
Fixes: #498 (Command to delete orphaned previews/thumbnails)

Adding a new occ command to cleanup previews

Backport to 10.11 only 

Technically ready, but draft atm because a QA clarification is necessary

@jnweiger 