### PR TITLE
Fix occ preview command

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_previews_commands.adoc
@@ -29,7 +29,7 @@ Removing not referenced previews can be necessary, e.g., when the image has been
 
 [width="100%",cols="25%,70%",]
 |====
-| `-all`
+| `--all`
 | Run as many loops until no chunks remain
 |====
 


### PR DESCRIPTION
References: #617 (occ previews:cleanup)

Added a missing dash in the option, fixed already in the backport of #617

No backport