### PR TITLE
Move occ system commands to the correct location

### DIFF
--- a/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/background_jobs_configuration.adoc
@@ -45,7 +45,7 @@ NOTE: It's for this reason that we encourage you to use Cron — if at all possi
 
 Using the operating system Cron feature is the preferred method for executing regular tasks. This method enables the execution of scheduled jobs without the inherent limitations which the web server might have.
 
-For example, to run a Cron job on a *nix system every 15 minutes (recommended), under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ `background:cron` command:
+For example, to run a Cron job on a *nix system every 15 minutes (recommended), under the default web server user (often, `www-data` or `wwwrun`) you must set up the following Cron job to call the occ `system:cron` command:
 
 [source,bash]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -324,6 +324,8 @@ include::./occ_commands/core_commands/_security_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/core_commands/_sharing_commands.adoc[leveloffset=+2]
 
+include::./occ_commands/core_commands/_system_command.adoc[leveloffset=+2]
+
 include::./occ_commands/core_commands/_trashbin_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/core_commands/_2fa_core_commands.adoc[leveloffset=+2]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -21,5 +21,3 @@ So, to cleanup all orphaned remote storages, run it as follows:
 You can also set it up to run as xref:background-jobs-selector[a background job].
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
-
-include::partial$configuration/server/occ_command/system_command.adoc[leveloffset=+1]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_system_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_system_command.adoc
@@ -1,4 +1,4 @@
-= System
+= System Commands
 
 [source,console]
 ----


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-server/issues/273 (background_jobs_configuration.adoc correction)

Two fixes:

* Correct the location of the occ system commands page
This was falsly located in partials as part of the sharing page. No page additionally references this partial - moving
* Correcting the command in the bg jobs config page

Backport to 10.11, 10.10 and 10.9