### PR TITLE
Update manual_upgrade.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -234,9 +234,18 @@ If you have configured a script for xref:installation/manual_installation/script
 
 == Finalize the Upgrade
 
+=== Disable Maintenance Mode
+
+Assuming your upgrade succeeded, disable maintenance mode using the occ command.
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} maintenance:mode --off
+----
+
 === Start the Upgrade
 
-With the apps disabled and ownCloud in maintenance mode, start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line. Note that the example is based on Ubuntu Linux. Execute this within the ownCloud root folder.
+To start the xref:configuration/server/occ_command.adoc#command-line-upgrade[upgrade process] from the command line. Note that the example is based on Ubuntu Linux. Execute this within the ownCloud root folder.
 
 [source,bash,subs="attributes+"]
 ----
@@ -262,15 +271,6 @@ post_max_size=513M                |     post_max_size=1G
 * Check that `chmod` with `0640` for `.htaccess` and `.user.ini` files has been applied.
 
 If you have configured a script for xref:installation/manual_installation/script_guided_install.adoc[guided installations], you can use it for this step as well as it automates it.
-
-=== Disable Maintenance Mode
-
-Assuming your upgrade succeeded, disable maintenance mode using the occ command.
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} maintenance:mode --off
-----
 
 === Enable Browser Access
 


### PR DESCRIPTION
maintenance mode needs to be disabled to perform `occ upgrade`, if i didn't miss something:

```
:~# sudo -uwww-data ./occ ma:mo --on
Maintenance mode enabled
Please also consider to stop the web server on all ownCloud instances
:~# sudo -uwww-data ./occ upgrade
ownCloud is in maintenance mode - no app have been loaded

<warning>ownCloud is in maintenance mode</warning>
Maybe an upgrade is already in process. Please check the logfile (data/owncloud.log). If you want to re-run the upgrade procedure, remove the "maintenance mode" from config.php and call this script again.
:~# 
```

"Disable Maintenance Mode" can also be put before "Finalize the Upgrade"