### PR TITLE
Config-to-docs Update

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -376,6 +376,19 @@ Client ID to be used with the token introspection endpoint.
 token-introspection-endpoint-client-secret::
 Client secret to be used with the token introspection endpoint.
 
+use-access-token-payload-for-user-info::
+If set to `true` any user information will be read from the access token.
+If set to `false` the userinfo endpoint is used (starting app version 1.1.0).
+
+use-token-introspection-endpoint::
+If set to `true`, the token introspection endpoint is used to verify a given access
+token - only needed if the access token is not a JWT. If set to `false`, the userinfo
+endpoint is used (requires version >= 1.1.0)
+Tokens which are not JSON WebToken (JWT) may not have information like the
+expiry. In these cases, the OpenID Connect Provider needs to call on the token
+introspection endpoint to get this information. The default value is `false`. See
+https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
+
 === Easy setup
 
 ==== Code Sample
@@ -463,7 +476,8 @@ Client secret to be used with the token introspection endpoint.
 		'token_endpoint_auth_methods_supported' => '...',
 		'userinfo_endpoint' => '...'
 	],
-	'provider-url' => '...'
+	'provider-url' => '...',
+	'use-token-introspection-endpoint' => true
 ],
 ....
 
@@ -482,6 +496,7 @@ Client secret to be used with the token introspection endpoint.
 	'loginButtonName' => 'node-oidc-provider',
 	'mode' => 'userid',
 	'search-attribute' => 'sub',
+	'use-token-introspection-endpoint' => true,
 	  // do not verify tls host or peer
 	'insecure' => true
 ],


### PR DESCRIPTION
References: https://github.com/owncloud/core/pull/40374 ([docs-only] Revert "config.apps.sample changes")

Config-to-docs Update because of a regression that needed a revert.

Backport to 10.11 only

@DeepDiver1975 fyi