### PR TITLE
fix apache header merge command

### DIFF
--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -22,7 +22,7 @@ To get this working, you need to install and/or configure the following componen
 . Microsoft Azure Active Directory
 
 . ownCloud apps:
-.. {oc-marketplace-url}/apps/openidconnect[OpenID Connect] 
+.. {oc-marketplace-url}/apps/openidconnect[OpenID Connect]
 .. {oc-marketplace-url}/apps/msteamsbridge[MS-Teams Bridge App]
 
 . The custom app(s) you have generated with {msteams-generator-url}[ownCloud Generator for Admins]
@@ -32,7 +32,7 @@ To get this working, you need to install and/or configure the following componen
 === Option 2 "Standard": With Basic Authentication and ownCloud Standard Edition
 
 . ownCloud apps:
-.. {oc-marketplace-url}/apps/openidconnect[OpenID Connect] 
+.. {oc-marketplace-url}/apps/openidconnect[OpenID Connect]
 . The custom Microsoft Teams app(s) you have generated with the {msteams-generator-url}[ownCloud Generator for Admins]
 . Microsoft Teams
 
@@ -53,17 +53,18 @@ Assuming you have an ownCloud server version 10.7 or higher already running in y
 You need to configure the MS-Teams Bridge app in two steps:
 
 . Add a _header_ directive to the Apache `.htaccess` configuration located in your ownCloud web root in section `<IfModule mod_env.c>`
-+  
++
 [source,apache,options="nowrap"]
 ----
 Header merge Content-Security-Policy "frame-ancestors 'self' teams.microsoft.com *.teams.microsoft.com"
+Header edit* Content-Security-Policy , ;
 ----
 +
 Using `merge`, the response header is appended to any existing header of the same name, unless the value to be appended already appears in the header's comma-delimited list of values. When a new value is merged onto an existing header it is separated from the existing header with a comma. Merging avoids that headers of the same type and content being sent multiple times. This can happen if headers are also set on other locations.
 +
 IMPORTANT: For the time being, if you add the header to the ownCloud's `.htaccess` file in the ownCloud web root, you have to manually add that header again after an ownCloud upgrade.
 
-. Add a config key to your `config.php` file 
+. Add a config key to your `config.php` file
 +
 This key is necessary for security reasons. Users will be asked to click a login button each time when accessing the ownCloud app after a fresh start of their Microsoft Teams app or after idle time. This behavior is by design. The button name can be freely set based on your requirements.
 +
@@ -74,7 +75,7 @@ This key is necessary for security reasons. Users will be asked to click a login
 ],
 ----
 
-. Enable xref:configuration/server/index_php_less_urls.adoc[index.php less URL´s] on your web server. 
+. Enable xref:configuration/server/index_php_less_urls.adoc[index.php less URL´s] on your web server.
 
 == Microsoft
 
@@ -123,7 +124,7 @@ image:configuration/integration/ms-teams/download-zip-msteamsgen.png[,width=80%]
 
 . See the following documents on how to pin the app, set the order how apps appear or how to install apps on behalf of users.
 .. {manage-apps-url}[Manage your apps in the Microsoft Teams admin center]
-.. {teams-app-setup-policies-url}[Manage app setup policies in Microsoft Teams] 
+.. {teams-app-setup-policies-url}[Manage app setup policies in Microsoft Teams]
 
 See the xref:{latest-webui-version}@webui:classic_ui:integration/ms-teams.adoc[users documentation] about their necessary steps how to integrate ownCloud into Microsoft Teams.
 


### PR DESCRIPTION
While using the [Apache Header](https://httpd.apache.org/docs/current/mod/mod_headers.html) `merge` directive an existing header it is separated from the existing header with a comma. This is invalid for CSP and result in a broken syntax. To work around this issue, an `edit*` directive can be used for a search and replace. 