### PR TITLE
Review of user_management page

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -33,13 +33,13 @@ _Login Name (Username)_::
 _Full Name_::
   The user’s display name that appears on file shares, the ownCloud Web interface and emails. Admins and users may change the full name anytime. If the full name is not set, it defaults to the login name.
 _Password_::
-  The admin sets the new user’s first password. Both, the user and the admin can change the user’s password at anytime.
+  The admin sets the new user’s first password. Both the user and the admin can change the user’s password at anytime.
 _E-Mail_::
-  The admin sets the new user’s e-mail. The user then gets an e-mail to set the password. Both, the user and the admin can change the user’s e-mail at anytime.
+  The admin sets the new user’s e-mail. The user then gets an e-mail to set the password. Both the user and the admin can change the user’s e-mail at anytime.
 _Groups_::
   You may create system (non-LDAP) groups and assign system group memberships to users. By default, new users are not assigned to any groups.
 _Group Admin_::
-  Group admins are granted administrative privileges on system groups and can add new users and remove existing users from those groups.
+  Group admins are granted administrative privileges on system groups and can add new users, edit user properties, and remove existing users from those groups.
 _Quota_::
   The maximum disk space assigned to each user. Any user that exceeds the quota cannot upload or sync data. You have the option to include external storage in user quotas.
 
@@ -53,7 +53,7 @@ To create a user account:
 
 image:configuration/user/users-page-new-user.png[image]
 
-Login names may contain letters (a-z, A-Z), numbers (0-9), dashes (-), underscores (_), periods (.) and at signs (@). After creating the user, you may fill in their *Full Name* if it is different than the login name, or leave it for the user to complete.
+Login names may contain letters (a-z, A-Z), numbers (0-9), dashes (-), underscores (_), periods (.) and at signs (@). After creating the user, you may fill in their *Full Name* if it is different from the login name, or leave it for the user to complete.
 
 == Password Reset
 
@@ -86,9 +86,11 @@ image::configuration/user/delete-user-confirmation.png[The ownCloud delete user 
 
 To delete a user, hover your cursor over their name on the *Users* page and click the trashcan icon that appears at the far right. You’ll then see a confirmation dialog appear, asking if you’re sure that you want to delete the user. 
 
-If you click btn:[Yes], the user is permanently deleted, including all of the files owned by the user, including all files they have shared. If you need to preserve the user’s files and shares, you must first download them from your ownCloud Files page, (which compresses them into a zip file). 
+If you click btn:[Yes], the user is permanently deleted, including all the files owned by the user, including all files they have shared. If you need to preserve the user’s files and shares, you must first download them from their ownCloud Files page, (which compresses them into a zip file).
 
-Alternatively, you can use a sync client to copy them to your local computer. If you click btn:[No], the confirmation dialog will disappear and the user is not deleted.
+Alternatively, you can use a sync client to copy them to your local computer.
+
+If you click btn:[No], the confirmation dialog will disappear and the user is not deleted.
 
 TIP: See xref:configuration/files/file_sharing_configuration.adoc[File Sharing Configuration] to learn how to create persistent file shares that survive user deletions.
 


### PR DESCRIPTION
Some minor things after recent edits. The main things were:

1) group admins can edit the properties of users in the group(s) that they manage (change display names, change passwords, change email addresses...)

2) to "save a copy" of a user's files before deleting them, you would have to login to that user's files page to download a zip file of all their data.