### PR TITLE
Fixup quota explanation

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -141,7 +141,7 @@ You now have a configurable option in `config.php` that controls whether externa
 
 === Storage Space Considerations
 
-Metadata (such as thumbnails, temporary files, and encryption keys) takes up about 10% of disk space but is not counted against user quotas. Users can check their used and available space on their Personal pages. Only files that originate from a user, or are in a share owned by the user, count against that user's quota, not file shares received from other users. For example, if you upload files to a different user’s share, those files count against that user's quota. If you share a folder with other user's and they add files to the folder then those files count against your quota. If you re-share a file that another user shared with you, that file does not count against your quota, but the originating user’s.
+Metadata (such as thumbnails, temporary files, and encryption keys) takes up about 10% of disk space but is not counted against user quotas. Users can check their used and available space on their Personal pages. Only files that originate from a user, or are in a share owned by the user, count against that user's quota, not file shares received from other users. For example, if you upload files to a different user’s share, those files count against that user's quota. If you share a folder with other user's and they add files to that folder, then those files count against your quota. If you re-share a file that another user shared with you, that file does not count against your quota, but the originating user’s.
 
 Encrypted files are a little larger than unencrypted files; the unencrypted size is calculated against the user’s quota.
 

--- a/modules/admin_manual/pages/configuration/user/user_management.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_management.adoc
@@ -141,7 +141,7 @@ You now have a configurable option in `config.php` that controls whether externa
 
 === Storage Space Considerations
 
-Metadata (such as thumbnails, temporary files, and encryption keys) takes up about 10% of disk space but is not counted against user quotas. Users can check their used and available space on their Personal pages. Only files that originate from a user count against that user's quota, not files shared by other users. For example, if you upload files to a different user’s share, those files count against your quota. If you re-share a file that another user shared with you, that file does not count against your quota, but the originating user’s.
+Metadata (such as thumbnails, temporary files, and encryption keys) takes up about 10% of disk space but is not counted against user quotas. Users can check their used and available space on their Personal pages. Only files that originate from a user, or are in a share owned by the user, count against that user's quota, not file shares received from other users. For example, if you upload files to a different user’s share, those files count against that user's quota. If you share a folder with other user's and they add files to the folder then those files count against your quota. If you re-share a file that another user shared with you, that file does not count against your quota, but the originating user’s.
 
 Encrypted files are a little larger than unencrypted files; the unencrypted size is calculated against the user’s quota.
 


### PR DESCRIPTION
The existing explanation was not correct. Files in a file share always count against the quota of the user who is the "owner" of the share.

I edited and added words - please review.

And I suspect that we address this quota stuff elsewhere in the docs? Can someone have a look, because if we already explain it somewhere else, then we can just link to that.

Backport to 10.11 and 10.10