### PR TITLE
Fix VirtualHost parameter

### DIFF
--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -65,7 +65,7 @@ After that, add an Alias directive for the `/.well-known/acme-challenge` locatio
 
 [source,apache]
 ----
-<VirtualHost *.80>
+<VirtualHost *:80>
   ServerName mydom.tld
 
   Alias /.well-known/acme-challenge/ /var/www/letsencrypt/.well-known/acme-challenge/


### PR DESCRIPTION
Fixes: #720 (Let's Encrypt with Apache2 currently has a slight error)

The VirtualHost definition contained an error: `VirtualHost *.80` --> `VirtualHost *:80`

Backport to 10.11 and 10.10
