### PR TITLE
Config-to-docs run for openidconnect

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -510,7 +510,7 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 ....
 
 === Authenticate guests only with basic auth
-Allows guests only to be able to log in using basic auth. Other users will need to use
+Only guests are able to log in using basic auth. Other users will need to use
 another auth mechanisms (such as OIDC).
 
 ==== Code Sample

--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -301,10 +301,12 @@ name can be freely set based on your requirements.
 
 Possible keys: `openid-connect` ARRAY
 
+Possible keys: `openid-connect.basic_auth_guest_only` BOOL
+
 
 **Configure OpenID Connect - all possible sub-keys**
 
-_You have to use the main key together with sub keys listed below, see code samples._
+_You have to use the main key `openid-connect` together with sub keys listed below, see code samples._
 
 allowed-user-backends::
 Limit the users which are allowed to login to a specific user backend - e.g. LDAP
@@ -333,6 +335,11 @@ information provided by the OpenID Connect provider upon each user log in.
 insecure::
 Boolean value (`true`/`false`), no SSL verification will take place when talking to the
 IdP - **DO NOT use in production!**
+
+jwt-self-signed-jwk-header-supported::
+If set to true, JWK (JSON Web Token) will be taken from the JWT header instead of the IdP's jwks_uri.
+Should only be enabled in exceptional cases as this could lead to vulnerabilities
+https://portswigger.net/kb/issues/00200902_jwt-self-signed-jwk-header-supported
 
 loginButtonName::
 The name as displayed on the login screen which is used to redirect to the IdP.
@@ -500,6 +507,17 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 	  // do not verify tls host or peer
 	'insecure' => true
 ],
+....
+
+=== Authenticate guests only with basic auth
+Allows guests only to be able to log in using basic auth. Other users will need to use
+another auth mechanisms (such as OIDC).
+
+==== Code Sample
+
+[source,php]
+....
+'openid-connect.basic_auth_guest_only' => false,
 ....
 
 == App: Richdocuments


### PR DESCRIPTION
Fixes: #665 ([QA] openid-connect.basic_auth_guest_only)

**ONLY MERGE** when https://github.com/owncloud/core/pull/40481 (Config Sample update for openidconnect) has been merged.

Backport to 10.11 and 10.10