### PR TITLE
Update files:scan not to be used with S3

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -131,7 +131,7 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
-NOTE: Scanning is only possible when using POSIX filesystems but not for objectstores like S3. This is because the objectstore implementation uses the database as primary datasource and the S3 storage for only holding the data blobs but no metadata. A sync from S3 storage to database is therefore not reasonable.
+NOTE: Scanning is only possible when using POSIX filesystems but not for object storages like S3. This is because the object storage implementation uses the database as primary data source and the S3 storage for only holding the data blobs but no metadata. A sync from S3 storage to database is therefore not reasonable.
 
 [source,bash,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -131,6 +131,8 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
+NOTE: Scanning is only possible when using POSIX filesystems but not for objectstores like S3. This is because the objectstore implementation uses the database as primary datasource and the S3 storage for only holding the data blobs but no metadata. A sync from S3 storage to database is therefore not reasonable.
+
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --help


### PR DESCRIPTION
Fixes: #742 (occ files:scan doesn't work on S3)

Add a note to the occ files:scan command not to be used with S3.

Backport to 10.11 and 10.10