### PR TITLE
Files are also scanned on download

### DIFF
--- a/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
+++ b/modules/admin_manual/pages/configuration/server/virus-scanner-support.adoc
@@ -204,7 +204,7 @@ ownCloud integrates with ClamAV natively in several ways, see xref:configuration
 
 === Scanning Notes for ClamAV
 
-. Files are checked when they are uploaded or updated but _not_ when they are downloaded.
+. Files are checked when they are uploaded or updated and before they are downloaded.
 . ownCloud does not maintain a cache of previously scanned files.
 . If the app is either not configured or is misconfigured, then it rejects file uploads.
 . If ClamAV is unavailable, then the app rejects file uploads.


### PR DESCRIPTION
Line 22 says:
```
When downloading, the files are scanned again to prevent infections to spread, which were not known by the scanner at the time of the upload and therefore missed.
```

But line 207 said:
```
Files are checked when they are uploaded or updated but _not_ when they are downloaded.
```

Those are contradictory. I have adjusted line 207 (assuming that line 22 is correct these days)

Backport to 10.11 and 10.10