### PR TITLE
Rename Classic Server (no reference changes)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: server
-title: ownCloud Classic Server
+title: ownCloud Server
 version: next
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
References: https://github.com/owncloud/docs/pull/4792 (Rename Classic Server (no reference changes))

Renaming the headlines `Classic Server` to `ownCloud Server` on request of @dragotin.

Note no changes to references are made, optical change only.

Only merge when the referenced PR has been merged.

Backport to 10.11 and 10.10