### PR TITLE
Fix antora.yml (the backport overwrote accidentially the version)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: server
 title: ownCloud Server
-version: next
+version: '10.11'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/partials/nav.adoc


### PR DESCRIPTION
Reverts the version changed in #754 ([10.10] [PR 752] Rename Classic Server (no reference changes))