### PR TITLE
[10.11] [PR 762] Improve visibility that files:scan is not possible for S3

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
@@ -115,28 +115,32 @@ connections to other services on your network!
 
 == Detecting Files Added to External Storages
 
-We recommend xref:configuration/server/background_jobs_configuration.adoc[configuring the background job Webcron or Cron] to enable ownCloud to automatically detect files added to your external storages.
+* Rescanning S3 for manually added files is not possible
++
+NOTE: The command `occ files:scan` is only possible with POSIX but not with S3 and compatible filesystems. See the xref:configuration/server/occ_command.adoc#the-filesscan-command[occ’s file operations] for more information.
 
+* We recommend xref:configuration/server/background_jobs_configuration.adoc[configuring the background job Webcron or Cron] to enable ownCloud to automatically detect files added to your external storages.
++
 TIP: You cannot scan/detect changed files on external storage mounts when you select the
 *Log-in credentials, save in session* authentication mechanism. However, there is a workaround,
 and that is to use Ajax cron mode.
 See xref:configuration/files/external_storage/auth_mechanisms.adoc#password-based-mechanisms[Password-based Mechanisms] for more information.
 
-ownCloud may not always be able to find out what has been changed remotely
+* ownCloud may not always be able to find out what has been changed remotely
 (files changed without going through ownCloud), especially when it’s very deep
 in the folder hierarchy of the external storage.
-
++
 You might need to setup a cron job that runs
-
++
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} files:scan --all`
 ----
 
-Alternatively, replace `--all` with the user name to trigger a rescan of the user’s files periodically,
+* Alternatively, replace `--all` with the user name to trigger a rescan of the user’s files periodically,
 for example every 15 minutes, which includes the mounted external storage.
-
-TIP: See xref:configuration/server/occ_command.adoc#the-filesscan-command[the occ’s file operations] for more information.
++
+TIP: See the xref:configuration/server/occ_command.adoc#the-filesscan-command[occ’s file operations] for more information.
 
 == Known limitations
 

--- a/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/configuration.adoc
@@ -140,7 +140,7 @@ You might need to setup a cron job that runs
 * Alternatively, replace `--all` with the user name to trigger a rescan of the user’s files periodically,
 for example every 15 minutes, which includes the mounted external storage.
 +
-TIP: See the xref:configuration/server/occ_command.adoc#the-filesscan-command[occ’s file operations] for more information.
+TIP: See xref:configuration/server/occ_command.adoc#the-filesscan-command[occ’s file operations] for more information.
 
 == Known limitations
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_file_commands.adoc
@@ -131,7 +131,7 @@ The `files:scan` command
 
 File scans can be performed per-user, for a space-delimited list of users, for groups of users, and for all users.
 
-NOTE: Scanning is only possible when using POSIX filesystems but not for object storages like S3. This is because the object storage implementation uses the database as primary data source and the S3 storage for only holding the data blobs but no metadata. A sync from S3 storage to database is therefore not reasonable.
+IMPORTANT: Scanning is only possible when using POSIX filesystems but not for object storages like S3. This is because the object storage implementation uses the database as primary data source and the S3 storage for only holding the data blobs but no metadata. A sync from S3 storage to database is therefore not reasonable.
 
 [source,bash,subs="attributes+"]
 ----


### PR DESCRIPTION
Backport of PR #762 