### PR TITLE
Fix a remnant of the term classic

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
-= Introduction to ownCloud Classic Server
+= Introduction to ownCloud Server
 
-Welcome to the ownCloud Classic Server documentation. These documents provide an xref:admin_manual:index.adoc[admin guide] with information for installation, configuration and administrative tasks as well as documentation for xref:developer_manual:index.adoc[developers].
+Welcome to the ownCloud Server documentation. These documents provide an xref:admin_manual:index.adoc[admin guide] with information for installation, configuration and administrative tasks as well as documentation for xref:developer_manual:index.adoc[developers].


### PR DESCRIPTION
Missed: `ownCloud Classic Server`--> `ownCloud Server`

Backport to 10.11 and 10.10