### PR TITLE
Update of the guest app description

### DIFF
--- a/modules/admin_manual/pages/configuration/user/guests_app.adoc
+++ b/modules/admin_manual/pages/configuration/user/guests_app.adoc
@@ -19,6 +19,12 @@ Install and enable the {oc-marketplace-url}/apps/guests[Guests] app if not alrea
 
 Check your Guests app's configuration in menu:Settings[Admin > Sharing]. There you can change the Guest's **group name** and add to or exclude apps from the app **whitelist** of the Guests app. Guests cannot access apps that are not on that list.
 
+With a blocklist, an admin can block domains for guest invitations:
+
+* Up to Guests 0.12.1, the blocklist entries were a suffix match. An entry like `example.com` would also block `user@otherexample.com` -- this was considered an error and admins relying on this feature must review their blocklists when upgrading to Guests 0.12.2.
+
+* Starting with Guests 0.12.2, the entries in the blocklist are exact matches. That means, that an entry `example.com` blocks `user@example.com`, but `user@mail.example.com` is *not* blocked. Admins are advised to list all possible subdomains explicitly.
+
 image::configuration/user/guest_app/guest_app_settings.png[width=470]
 
 == Troubleshooting


### PR DESCRIPTION
Fixes: #771 ([QA] guests app blocklist description missing)

Adding proper descriptions when using blocklists

Backport to 10.11 and 10.10