### PR TITLE
Apache rewriteRule requires mod_rewrite and no leading / in .htaccess

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -119,7 +119,7 @@ To make the endpoint available under the static service discovery path, it is re
 [source,apache]
 ----
 RewriteEngine on
-RewriteRule "^/\.well-known/openid-configuration" "/index.php/apps/openidconnect/config" [P]
+RewriteRule "^\.well-known/openid-configuration" "/index.php/apps/openidconnect/config" [P]
 SSLProxyEngine On #This can be omitted if no SSL is used
 ----
 +

--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -114,7 +114,7 @@ https://cloud.example.com/index.php/apps/openidconnect/config
 
 . Webserver Rewrite Rule
 +
-To make the endpoint available under the static service discovery path, it is recommended to put a `RewriteRule` in place using in the `VirtualHost` section. The Apache modules `proxy`, `proxy_http` and `proxy_connect` have to be enabled if SSL is used:
+To make the endpoint available under the static service discovery path, it is recommended to put a `RewriteRule` in place using in the `VirtualHost` section. The Apache module `rewrite` must be enabled, and if SSL is used, also the modules `proxy`, `proxy_http` and `proxy_connect`:
 +
 [source,apache]
 ----


### PR DESCRIPTION
Often mod_rewrite is auto-enabled in stock apache installations, so this ommission is quite harmless.

As the text mentions .htaccess as a possible file for the RewriteRule, the syntax should be without leading /. With a / it will never match from within the .htaccess file.

The syntax for a separate /etc/apache2/conf-available/oidc.conf file is very different:
```
<Location /.well-known/openid-configuration >
    RewriteEngine on
    RewriteRule .* /index.php/apps/openidconnect/config [P]
</Location>
SSLProxyEngine On     #This can be omitted if no SSL is used
```

Backport to 10.11 and 10.10