### PR TITLE
Create a Useful Pages page

### DIFF
--- a/modules/admin_manual/pages/useful_pages.adoc
+++ b/modules/admin_manual/pages/useful_pages.adoc
@@ -1,0 +1,18 @@
+= Useful Pages
+:toc: right
+
+:description: When new to ownCloud Server, the following list of useful pages help getting up and running quickly.
+
+== Introduction
+
+{description}
+
+== Page List
+
+Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available.
+
+* xref:{latest-server-version}@server:admin_manual:installation/index.adoc[Manual Installation]
+* xref:{latest-server-version}@server:admin_manual:installation/docker/index.adoc[Installation with Docker]
+* xref:{latest-server-version}@server:admin_manual:configuration/server/occ_command.adoc[OCC Commands]
+* xref:{latest-server-version}@server:admin_manual:configuration/server/caching_configuration.adoc#small-organization-single-server-setup[File Locking and Caching Configuration]
+* xref:{latest-server-version}@server:admin_manual:maintenance/manual_upgrade.adoc[Manual Upgrade]

--- a/modules/admin_manual/pages/useful_pages.adoc
+++ b/modules/admin_manual/pages/useful_pages.adoc
@@ -1,7 +1,7 @@
 = Useful Pages
 :toc: right
 
-:description: When new to ownCloud Server, the following list of useful pages help getting up and running quickly.
+:description: When new to ownCloud Server, the following list of useful pages may help getting up and running quickly.
 
 == Introduction
 
@@ -9,7 +9,7 @@
 
 == Page List
 
-Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available.
+Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available ones.
 
 * xref:{latest-server-version}@server:admin_manual:installation/index.adoc[Manual Installation]
 * xref:{latest-server-version}@server:admin_manual:installation/docker/index.adoc[Installation with Docker]

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -1,6 +1,7 @@
 // note that the module reference post xref is now a mandatory element
 * Admin Manual
 ** xref:admin_manual:index.adoc[Introduction]
+** xref:admin_manual:useful_pages.adoc[Useful Pages]
 ** xref:admin_manual:faq/index.adoc[FAQ]
 ** xref:admin_manual:gdpr.adoc[GDPR]
 ** xref:admin_manual:installation/index.adoc[Installation]


### PR DESCRIPTION
When cleaning up the main [docs page](https://github.com/owncloud/docs/pull/4800), the following content was not appropriate located anymore and is now moved to the server. It got an own page. Beside the headlines it is contenwise 1:1

Backport to 10.11 and 10.10