### PR TITLE
[OIDC] Branded desktop and mobile clients for Azure AD

### DIFF
--- a/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
@@ -147,4 +147,4 @@ If you want to let ownCloud create users which are not present during a OIDC aut
 
 To allow the ownCloud clients (Web/desktop/Android/iOS) to interact with the identity provider, you have to register them as clients.
 
-Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be build with customized `scope` and `prompt` parameters. ownCloud full branding subscription is needed. Please get in touch with ownCloud Consulting for more help.
+Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be built with customized `scope` and `prompt` parameters. ownCloud full branding subscription is needed. Please get in touch with ownCloud Consulting for more help.

--- a/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
@@ -147,4 +147,4 @@ If you want to let ownCloud create users which are not present during a OIDC aut
 
 To allow the ownCloud clients (Web/desktop/Android/iOS) to interact with the identity provider, you have to register them as clients.
 
-Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be built with customized `scope` and `prompt` parameters. As prerequisite, an ownCloud Enterprise subscription including full branding is needed. For more details get in touch with {oc-support-url}[ownCloud Support].
+Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be built with customized `scope` and `prompt` parameters. As prerequisite, an ownCloud full branding subscription is needed. For more details get in touch with {oc-support-url}[ownCloud Support].

--- a/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
@@ -147,4 +147,4 @@ If you want to let ownCloud create users which are not present during a OIDC aut
 
 To allow the ownCloud clients (Web/desktop/Android/iOS) to interact with the identity provider, you have to register them as clients.
 
-Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be built with customized `scope` and `prompt` parameters. ownCloud full branding subscription is needed. Please get in touch with ownCloud Consulting for more help.
+Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be built with customized `scope` and `prompt` parameters. As prerequisite, an ownCloud Enterprise subscription including full branding is needed. For more details get in touch with {oc-support-url}[ownCloud Support].

--- a/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/ms-azure-setup.adoc
@@ -143,8 +143,8 @@ If you want to let ownCloud create users which are not present during a OIDC aut
     ],
 ----
 
-////
-=== Register ownCloud Clients
+=== Register ownCloud Desktop and Mobile Clients
 
 To allow the ownCloud clients (Web/desktop/Android/iOS) to interact with the identity provider, you have to register them as clients.
-////
+
+Only branded ownCloud desktop and mobile clients can be registered with Azure AD, because they need to be build with customized `scope` and `prompt` parameters. ownCloud full branding subscription is needed. Please get in touch with ownCloud Consulting for more help.

--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -175,7 +175,7 @@ NOTE: The desktop and mobile apps (clients) have a default client ID and secret 
 
 === Client IDs, Secrets and Redirect URIs
 
-All IdPs can use ownCloud's default implemented _Client IDs, Secrets and Redirect URIs_ with the exception of Microsoft Azure AD, which uses a different approach. Here is the data necessary for the configuration.
+All IdPs can use ownCloud's default _client IDs, secrets and redirect URIs_ with the exception of Microsoft Azure AD, which uses a different approach. Here is the data necessary for the configuration.
 
 ==== Client ID
 

--- a/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
+++ b/modules/admin_manual/pages/configuration/user/oidc/oidc.adoc
@@ -131,17 +131,17 @@ IMPORTANT: If you use the `.htaccess` file in the ownCloud web root, you have to
 
 == General Example Setup
 
-All IdPs have their own setup, but often share common ways of configuring things. Although not identical, the xref:example-setup-using-kopano-konnect[Kopano Konnect] example may be a good starting point for the specific configuration of your setup. As Microsoft with Azure is different, it has its own example section.
+All IdPs have their own setup, but often share common ways of configuring things. Although not identical, the xref:example-setup-using-kopano-konnect[Kopano Konnect] example may be a good starting point for the specific configuration of your setup. As Microsoft with Azure AD is different, it has its own example section.
 
 == Example Setup Using Kopano Konnect
 
 Follow this link to see 
 xref:configuration/user/oidc/kopano-setup.adoc[Example Setup Using Kopano Konnect].
 
-== Example Setup Using Microsoft Azure
+== Example Setup Using Microsoft Azure AD
 
 Follow this link to see 
-xref:configuration/user/oidc/ms-azure-setup.adoc[Example Setup Using Microsoft Azure].
+xref:configuration/user/oidc/ms-azure-setup.adoc[Example Setup Using Microsoft Azure AD].
 
 == Example Setup Using OneLogin
 
@@ -175,7 +175,7 @@ NOTE: The desktop and mobile apps (clients) have a default client ID and secret 
 
 === Client IDs, Secrets and Redirect URIs
 
-All IdPs can use ownCloud's default implemented _Client IDs, Secrets and Redirect URIs_ with the exception of Microsoft, which uses a different approach. Here is the data necessary for the configuration.
+All IdPs can use ownCloud's default implemented _Client IDs, Secrets and Redirect URIs_ with the exception of Microsoft Azure AD, which uses a different approach. Here is the data necessary for the configuration.
 
 ==== Client ID
 
@@ -237,7 +237,7 @@ All IdPs can use ownCloud's default implemented _Client IDs, Secrets and Redirec
 | `oc://ios.owncloud.com`
 |===
 
-(1) See the xref:configuration/user/oidc/ms-azure-setup.adoc#microsoft-azure-ad-and-redirecturi[following note] when using Microsoft Azure and 127.0.0.1 as redirect URI.
+(1) See the xref:configuration/user/oidc/ms-azure-setup.adoc#microsoft-azure-ad-and-redirecturi[following note] when using Microsoft Azure AD and 127.0.0.1 as redirect URI.
 
 === Migrate Clients from Basic Authentication to OIDC
 


### PR DESCRIPTION
You can build branded desktop and mobile clients for Azure AD. I'd like to add this to the docs.

Ho to test:

```
git clone https://github.com/owncloud/docs-server.git
cd docs-server
git checkout azure-branded-clients
yarn install
yarn antora
yarn serve
```

Preview:
- http://127.0.0.1:8080/server/next/admin_manual/configuration/user/oidc/oidc.html#example-setup-using-microsoft-azure-ad
- http://127.0.0.1:8080/server/next/admin_manual/configuration/user/oidc/ms-azure-setup.html#register-owncloud-desktop-and-mobile-clients

Backport to 10.11 and 10.10