### PR TITLE
Fixing the sort order of suggested commands in owncloud_prep.sh

### DIFF
--- a/modules/admin_manual/examples/installation/manual_installation/owncloud_prep.sh
+++ b/modules/admin_manual/examples/installation/manual_installation/owncloud_prep.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script Version 2022.06.23
+# Script Version 2023.01.25
 
 # To set up this script for your environment, hand over the following variables according your needs:
 #
@@ -289,9 +289,9 @@ if [ "$do_upgrade" = "y" ]; then
     echo
   fi
   echo "Please change to your upgraded ownCloud directory: cd $ocroot/$ocname"
+  echo "Please manually run: sudo -u $htuser ./occ maintenance:mode --off"
   echo "Please manually run: sudo -u $htuser ./occ upgrade"
   echo "Copy any changes manually added in .user.ini and .htaccess from the backup directory"
-  echo "Please manually run: sudo -u $htuser ./occ maintenance:mode --off"
   echo "Please manually remove the directory of the old instance: $oldocpath"
   echo "When successfully done, re-run this script to secure your .htaccess files"
   echo


### PR DESCRIPTION
Fixes: #809 ([QA] instance.sh suggests to run occ upgrade while still in maintenance mode)

The suggested order of commands that have to be typed manually post the script run needed to be resorted.

Backport to 10.11 and 10.10

@jnweiger fyi