### PR TITLE
wrong command named

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_maintenance_commands.adoc
@@ -123,7 +123,7 @@ Usage:
 {occ-command-example-prefix} maintenance:mode [options]
 ----
 
-The `maintenance:repair` command supports the following options:
+The `maintenance:mode` command supports the following options:
 
 [cols="25%,75%",options="header"]
 |===


### PR DESCRIPTION
Changed `maintenance:repair` --> `maintenance:mode` since it wasn't listed correctly.

Backport to 10.10 and 10.11