### PR TITLE
Update config_apps_sample_php_parameters.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -444,11 +444,9 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 		  // auto-update user account info with current information provided by the
 		  // OpenID Connect provider account attributes, that will be updated,
 		  // can be specified in `attributes` config option
-		'auto-provision' => [
-			'update' => [
-				  // enable the user info auto-update mode
-				'enabled' => true,
-			],
+		'update' => [
+			  // enable the user info auto-update mode
+			'enabled' => true,
 		],
 	],
 	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud


### PR DESCRIPTION
removed cascading auto-provioning ...

According to dev docs https://github.com/owncloud/openidconnect#setup-auto-provisioning-mode

Backport to 10.11 and 10.10