### PR TITLE
Update PHP minimum version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,9 +7,9 @@ nav:
 
 asciidoc:
   attributes:
-    minimum-php-version: '7.3'
-    minimum-php-printed: '7.3.0'
-    minimum-php-version-short-code: '73'
+    minimum-php-version: '7.4'
+    minimum-php-printed: '7.4.0'
+    minimum-php-version-short-code: '74'
     recommended-php-version: '7.4'
     recommended-php-version-short-code: '74'
-    supported-php-versions: '7.3 and 7.4'
+    supported-php-versions: '7.4'


### PR DESCRIPTION
Fixes: #661 (PHP 7.3 support will get dropped - needs documentation)

Update the minimum required PHP version to 7.4.

Locally tested, looks fine.

No backport !