### PR TITLE
occ: Allow to Temporarily Ignore Invalid Federated Shares

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -2,7 +2,7 @@
 
 == Cleanup Remote Storages
 
-This is an occ command to cleanup orphaned remote storages. 
+This is an occ command to clean up orphaned remote storages. 
 To explain why this is necessary, a little background is required. 
 While shares are able to be deleted as a normal matter of course, remote storages with `shared::` are not included in this process.
 
@@ -26,14 +26,14 @@ NOTE: These commands are not available in xref:maintenance-commands[single-user 
 
 == Allow to Temporarily Ignore Invalid Federated Shares
 
-Currently, if a federated share is invalid or the api endpoint returns not found, the availability check would validate whether this is a problem with a server. If checks complete, that given share is removed. However, in some cases these checks might not be enough like in complex migrations of tightly federated setups. In that case, invalidation behaviour can be disabled using the below app setting. When set, instead of removing the share, a warning in the browser is displayed.
+Currently, if a federated share is invalid or the API endpoint returns a "not found", the availability check tests whether this is a problem with a server. If checks complete, that given share is removed. However, in some cases these checks might not be enough like in complex migrations of tightly federated setups. In that case, invalidation behavior can be disabled using the below app setting. When set, instead of removing the share, a warning is displayed in the browser.
 
 [source,bash,subs="attributes+"]
 ----
 {occ-command-example-prefix} config:app:set files_sharing enable_cleanup_invalid_external_shares --value no
 ----
 
-To revert that setting to its default behaviour, run:
+To revert that setting to its default behavior, run:
 
 [source,bash,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_sharing_commands.adoc
@@ -1,5 +1,7 @@
 = Sharing
 
+== Cleanup Remote Storages
+
 This is an occ command to cleanup orphaned remote storages. 
 To explain why this is necessary, a little background is required. 
 While shares are able to be deleted as a normal matter of course, remote storages with `shared::` are not included in this process.
@@ -21,3 +23,19 @@ So, to cleanup all orphaned remote storages, run it as follows:
 You can also set it up to run as xref:background-jobs-selector[a background job].
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].
+
+== Allow to Temporarily Ignore Invalid Federated Shares
+
+Currently, if a federated share is invalid or the api endpoint returns not found, the availability check would validate whether this is a problem with a server. If checks complete, that given share is removed. However, in some cases these checks might not be enough like in complex migrations of tightly federated setups. In that case, invalidation behaviour can be disabled using the below app setting. When set, instead of removing the share, a warning in the browser is displayed.
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:set files_sharing enable_cleanup_invalid_external_shares --value no
+----
+
+To revert that setting to its default behaviour, run:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} config:app:delete files_sharing enable_cleanup_invalid_external_shares
+----


### PR DESCRIPTION
Fixes: #837 (New occ config app key for files_sharing)

A new app config key has been added to allow to temporarily ignore invalid federated shares.

No backport, part of the next release.