### PR TITLE
user:sync short form of backend classes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -824,14 +824,26 @@ Synchronize users from a given backend to the accounts table.
 
 === Arguments:
 
-[width="90%",cols="50%,80%",]
+[width="100%",cols="40%,90%,30%",options="header"]
 |===
-| `backend-class`
-| The quoted PHP class name for the backend, e.g., +
-- LDAP:        `"OCA\User_LDAP\User_Proxy"` +
-- Samba:       `"OCA\User\SMB"` +
-- Shibboleth:  `"OCA\User_Shibboleth\UserBackend"` +
+| backend-class Type
+| The quoted PHP class name for the backend
+| Short Form
+
+| LDAP:
+| `"OCA\User_LDAP\User_Proxy"`
+| `ldap`
+
+| Samba:
+| `"OCA\User\SMB"`
+| `samba`
+
+| Shibboleth:
+| `"OCA\User_Shibboleth\UserBackend"`
+| `shibboleth`
 |===
+
+The argument for the backend-class can be the quoted PHP class name but also the short form can be used.
 
 === Options
 

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_user_commands.adoc
@@ -843,7 +843,7 @@ Synchronize users from a given backend to the accounts table.
 | `shibboleth`
 |===
 
-The argument for the backend-class can be the quoted PHP class name but also the short form can be used.
+The argument for the backend class can be the quoted PHP class name but also the short form can be used.
 
 === Options
 


### PR DESCRIPTION
Fixes: #853 (Backend class alias on user:sync)

Backend classes can now have a short form.

No backport