### PR TITLE
remove extra backslash

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -86,7 +86,7 @@ apt install -y \
   php7.4-gd php7.4-imap php7.4-intl php7.4-json \
   php7.4-mbstring php7.4-gmp php7.4-bcmath php7.4-mysql \
   php7.4-ssh2 php7.4-xml php7.4-zip php7.4-apcu \
-  php7.4-redis php7.4-ldap php-phpseclib\
+  php7.4-redis php7.4-ldap php-phpseclib
 ----
 
 === Install smbclient php Module


### PR DESCRIPTION
if you test it and copy paste the block - you get this: 

```
....
php7.4-redis php7.4-ldap php-phpseclib\
>
```
without the extra back slash the command gets executed as expected.