### PR TITLE
escape variable

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -138,7 +138,7 @@ FILE="/etc/apache2/sites-available/owncloud.conf"
 cat <<EOM >$FILE
 <VirtualHost *:80>
 # uncommment the line below if variable was set
-#ServerName $my_domain 
+#ServerName \$my_domain 
 DirectoryIndex index.php index.html
 DocumentRoot /var/www/owncloud
 <Directory /var/www/owncloud>


### PR DESCRIPTION
because if not, bash leaves it empty

Backport to 10.10, 10.11 and 10.12