### PR TITLE
add testing of apache config

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -157,6 +157,31 @@ DocumentRoot /var/www/owncloud
 EOM
 ----
 
+
+==== Test the configuration
+
+[source,bash]
+----
+apachectl -t
+----
+
+At this point you would expect the following output
+
+[source,bash]
+----
+apachectl -t
+AH00112: Warning: DocumentRoot [/var/www/owncloud] does not exist
+AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message
+Syntax OK
+----
+
+First warning will be resolved after we install ownCloud. Second message we can resolve with:
+
+[source,bash]
+----
+echo "ServerName $my_domain" >> /etc/apache2/apache2.conf
+----
+
 ==== Enable the Virtual Host Configuration
 
 [source,bash]

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -158,14 +158,14 @@ EOM
 ----
 
 
-==== Test the configuration
+==== Test the Configuration
 
 [source,bash]
 ----
 apachectl -t
 ----
 
-At this point you would expect the following output
+At this point, the following output is expected:
 
 [source,bash]
 ----
@@ -175,7 +175,7 @@ AH00558: apache2: Could not reliably determine the server's fully qualified doma
 Syntax OK
 ----
 
-First warning will be resolved after we install ownCloud. Second message we can resolve with:
+The first warning will be resolved after ownCloud is installed. The second message can be resolved with following command. Check that the entry is only present once in the `apache2.conf` file:
 
 [source,bash]
 ----


### PR DESCRIPTION
testing at this point prevents further debugging at a later point in the setup.

please rewrite the text and formatting as you see fit.

maybe this is also not the most elegant solution for fixing the warning message when you reboot apache, but this solution works.

I know that if you use this script more than once the end of your apache2 conf gets messy at the bottom.

Backport to 10.10, 10.11 and 10.12