### PR TITLE
Document "remove_sender_display_name" config.php option

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -682,6 +682,16 @@ Depends on `mail_smtpauth`. Specify the password for authenticating to the SMTP 
 'mail_smtppassword' => '',
 ....
 
+=== Remove the sender display name from the "From" address
+Setting this parameter to `true` will remove the sender display name from the "From" address. This may be needed in such cases where mail notifications related to sharing activities are blocked by mail filters as being flagged as email impersonation.
+
+==== Code Sample
+
+[source,php]
+....
+'remove_sender_display_name' => true,
+....
+
 == Proxy Configurations
 
 === Override automatic proxy detection


### PR DESCRIPTION
## WHAT Needs to be Documented?
References: https://github.com/owncloud/core/pull/40671 (Make sender display name in mail notifications configurable)

`remove_sender_display_name => true`

## WHERE Does This Need To Be Documented (Link)?
config sample

## WHY Should This Change Be Made?
Completeness of docs

## (Optional) What Type Of Content Change Is This? 
- [x] New Content Addition
- [ ] Old Content Deprecation
- [ ] Existing Content Simplification
- [ ] Bug Fix to Existing Content

## (Optional) Which Manual Does This Relate To?
- [x] Admin Manual
- [ ] Developer Manual
- [ ] User Manual
- [ ] Android
- [ ] iOS
- [ ] Branded Clients
- [ ] Desktop Client
- [ ] Other