### PR TITLE
Config-to-docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -682,6 +682,18 @@ Depends on `mail_smtpauth`. Specify the password for authenticating to the SMTP 
 'mail_smtppassword' => '',
 ....
 
+=== Remove the sender display name in sharing emails
+Mail notifications about shares include the display name of the sharer in the email
+"from" address. This can cause some email filters to to block these as impersonation
+attempts. Set remove_sender_display_name to true to not include this information.
+
+==== Code Sample
+
+[source,php]
+....
+'remove_sender_display_name' => false,
+....
+
 == Proxy Configurations
 
 === Override automatic proxy detection

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -684,7 +684,7 @@ Depends on `mail_smtpauth`. Specify the password for authenticating to the SMTP 
 
 === Remove the sender display name in sharing emails
 Mail notifications about shares include the display name of the sharer in the email
-"from" address. This can cause some email filters to to block these as impersonation
+"from" address. This can cause some email filters to block these as impersonation
 attempts. Set remove_sender_display_name to true to not include this information.
 
 ==== Code Sample


### PR DESCRIPTION
References: #887 and https://github.com/owncloud/core/pull/40671

A config-to-docs run is necessary because of recent changes in core.

Backport to 10.12 only