### PR TITLE
Document ldapNetworkTimeout

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_ldap_integration_commands.adoc
@@ -362,6 +362,7 @@ Available keys, along with default values for configValue, are listed in the tab
 | ldapLoginFilterMode           | 0
 | ldapLoginFilterUsername       | 1
 | ldapNestedGroups              | 0
+| ldapNetworkTimeout            | 15
 | ldapOverrideMainServer        |
 | ldapPagingSize                | 500
 | ldapPort                      | 389


### PR DESCRIPTION
## WHAT Needs to be Documented?

`ldapNetworkTimeout` key when using the `ldap:set-config` occ command

## WHERE Does This Need To Be Documented (Link)?
https://doc.owncloud.com/server/next/admin_manual/configuration/server/occ_command.html#manipulate-ldap-configurations

## WHY Should This Change Be Made?
Currently this key is not documented.

## (Optional) What Type Of Content Change Is This? 
- [x] New Content Addition
- [ ] Old Content Deprecation
- [ ] Existing Content Simplification
- [ ] Bug Fix to Existing Content

## (Optional) Which Manual Does This Relate To?
- [x] Admin Manual
- [ ] Developer Manual
- [ ] User Manual
- [ ] Android
- [ ] iOS
- [ ] Branded Clients
- [ ] Desktop Client
- [ ] Other

@mmattel as discussed. Documented default value to 15secs as next user_ldap version (0.17.0) will set default to this value. See https://github.com/owncloud/user_ldap/pull/734.

Backport to 10.10, 10.11 and 10.12