### PR TITLE
Fix file_versions table

### DIFF
--- a/modules/admin_manual/pages/configuration/files/file_versioning.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_versioning.adoc
@@ -101,7 +101,7 @@ You may alter the xref:configuration/server/config_sample_php_parameters.adoc#de
 
 |`disabled`
 |Disable version retention; no files will be deleted.
-|==
+|===
 
 ==== Example 1:
 


### PR DESCRIPTION
References: #899

The table definition was accidentially broken - fixed.

Backport to 10.12 