### PR TITLE
Config to docs run based on recent changes from core

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -388,15 +388,6 @@ use-access-token-payload-for-user-info::
 If set to `true` any user information will be read from the access token.
 If set to `false` the userinfo endpoint is used (starting app version 1.1.0).
 
-use-token-introspection-endpoint::
-If set to `true`, the token introspection endpoint is used to verify a given access
-token - only needed if the access token is not a JWT. If set to `false`, the userinfo
-endpoint is used (requires version >= 1.1.0)
-Tokens which are not JSON WebToken (JWT) may not have information like the
-expiry. In these cases, the OpenID Connect Provider needs to call on the token
-introspection endpoint to get this information. The default value is `false`. See
-https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
-
 === Easy setup
 
 ==== Code Sample
@@ -481,7 +472,6 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 		'userinfo_endpoint' => '...'
 	],
 	'provider-url' => '...',
-	'use-token-introspection-endpoint' => true
 ],
 ....
 
@@ -500,7 +490,6 @@ https://datatracker.ietf.org/doc/html/rfc7662 for more information on token intr
 	'loginButtonName' => 'node-oidc-provider',
 	'mode' => 'userid',
 	'search-attribute' => 'sub',
-	'use-token-introspection-endpoint' => true,
 	  // do not verify tls host or peer
 	'insecure' => true
 ],


### PR DESCRIPTION
References: https://github.com/owncloud/core/pull/40688 (chore: remove unused openidconnect config option `use-token-introspection-endpoint`)

The config setting has been removed from the docs,
it was never functional in the openidconnect app.

Backport to 10.12 and 10.11