### PR TITLE
Update s3_compatible_object_storage_as_primary.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
+++ b/modules/admin_manual/pages/configuration/files/external_storage/s3_compatible_object_storage_as_primary.adoc
@@ -92,7 +92,7 @@ $CONFIG = [
             'bucket' => 'owncloud',
               //
               // uncomment to indicate available storage size in the objectstore in bytes (in this example 1TB),
-              // without this setting, the app relying on available storage might be limited in funcionality e.g. metrics app
+              // without this setting, apps relying on available storage might be limited in funcionality e.g. metrics app
               //'availableStorage' => 1099511627776,
               //
               // uncomment to enable server side encryption
@@ -136,7 +136,7 @@ $CONFIG = [
             'bucket' => 'owncloud',
               //
               // uncomment to indicate available storage size in the objectstore, in bytes (in this example 1TB),
-              // without this setting app relying on available storage might be limited in funcionality e.g. metrics app
+              // without this setting, apps relying on available storage might be limited in funcionality e.g. metrics app
               //'availableStorage' => 1099511627776,
               //
               // uncomment to enable server side encryption
@@ -184,7 +184,7 @@ $CONFIG = [
             'bucket' => 'owncloud',
               //
               // uncomment to indicate available storage size in the objectstore, in bytes (in this example 1TB),
-              // without this setting app relying on available storage might be limited in funcionality e.g. metrics app
+              // without this setting, apps relying on available storage might be limited in funcionality e.g. metrics app
               //'availableStorage' => 1099511627776,
               //
               // uncomment to enable server side encryption


### PR DESCRIPTION
Readable grammer: it's not about a 'setting app' ...

Question: why is availableStorage commented out? Do we know anything against using the new feature? (yeah, it is a cheat, we should query the storage directly - but in any case, I'd say it is better than nothing...)

Backport to 10.12 and 10.11