### PR TITLE
Update ui-testing.adoc

### DIFF
--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -62,7 +62,7 @@ taken to do the test.
 
 [source,console]
 ----
-docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug
+docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:3.141.59-oxygen
 ----
 
 Ports on the Selenium Docker IP address are mapped to `localhost` so they can be accessed by the tests and the `vnc` viewer.


### PR DESCRIPTION
First we explain that chrome 74 is needed, and not 75 from latest, then we download exactly the right docker image, and finally we still run latest, despite all the nice preparations?? Naah!

 Wasted some hours there, today.