### PR TITLE
added instructions how to enable legacy support

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -7,7 +7,6 @@
 :pecl-package-url: https://pecl.php.net/package
 :sabre-url: http://sabre.io/
 :gnu-make-url: https://www.gnu.org/software/make/
-:wiki-openssl-3-url: https://wiki.openssl.org/index.php/OpenSSL_3.0#Providers
 
 == Introduction
 
@@ -36,39 +35,55 @@ If you plan to:
 * install or upgrade your server where the server upgrade delivers the new openSSL v3 version **and**
 * you have enabled and use encryption
 
-your encryption environment will break due to openSSL v3 retired (legacy) ciphers. As a result, encrypted files cant be accessed. As a _temporary solution_, you have to manually reenable in the openSSL v3 config the legacy ciphers. To do so, see the example in the {wiki-openssl-3-url}[OpenSSL 3.0 Wiki] at section **6.2 Providers**.
+your encryption environment will break due to openSSL v3 retired (legacy) ciphers. As a result, encrypted files cant be accessed. As a _temporary solution_, you have to manually reenable in the openSSL v3 config the legacy ciphers. To do so, see the example in the https://wiki.openssl.org/index.php/OpenSSL_3.0#Providers[OpenSSL 3.0 Wiki,window=_blank] at section **6.2 Providers**.
 ====
 
 How to implement the fix for the above mentioned issue:
 
 1. Find the openssl config directory with 
++
+--
+[source,bash]
+----
+openssl version -d
+----
 
-"openssl version -d"
+Output example:
 
-Output:
+`OPENSSLDIR: "/usr/lib/ssl"`
+--
 
-OPENSSLDIR: "/usr/lib/ssl"
-
-2. Go in to that directory and open the config file "openssl.cnf"
-
+2. Go in to that directory and open the config file `openssl.cnf`
++
+--
 Look for:
 
+[source,plaintext]
+----
 [openssl_init]
 providers = provider_sect
+----
 
 and add this line below
 
-legacy = legacy_sect
+`legacy = legacy_sect`
 
 then look for 
 
+[source,plaintext]
+----
 [default_sect]
 # activate = 1
+----
 
 remove the "#" before "activate" and add the following lines below:
 
+[source,plaintext]
+----
 [legacy_sect]
 activate = 1
+----
+--
 
 3. Save the file. Now you have enabled the legacy support.
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -7,7 +7,7 @@
 :pecl-package-url: https://pecl.php.net/package
 :sabre-url: http://sabre.io/
 :gnu-make-url: https://www.gnu.org/software/make/
-:wiki-openssl-3-url: https://wiki.openssl.org/index.php/OpenSSL_3.0
+:wiki-openssl-3-url: https://wiki.openssl.org/index.php/OpenSSL_3.0#Providers
 
 == Introduction
 
@@ -38,6 +38,39 @@ If you plan to:
 
 your encryption environment will break due to openSSL v3 retired (legacy) ciphers. As a result, encrypted files cant be accessed. As a _temporary solution_, you have to manually reenable in the openSSL v3 config the legacy ciphers. To do so, see the example in the {wiki-openssl-3-url}[OpenSSL 3.0 Wiki] at section **6.2 Providers**.
 ====
+
+How to implement the fix for the above mentioned issue:
+
+1. Find the openssl config directory with 
+
+"openssl version -d"
+
+Output:
+
+OPENSSLDIR: "/usr/lib/ssl"
+
+2. Go in to that directory and open the config file "openssl.cnf"
+
+Look for:
+
+[openssl_init]
+providers = provider_sect
+
+and add this line below
+
+legacy = legacy_sect
+
+then look for 
+
+[default_sect]
+# activate = 1
+
+remove the "#" before "activate" and add the following lines below:
+
+[legacy_sect]
+activate = 1
+
+3. Save the file. Now you have enabled the legacy support.
 
 === PHP Version
 


### PR DESCRIPTION
Added an example to to implement the fix required for current LTS version of Ubuntu (22.04) and ownCloud encryption.

relevant docs page: 
https://doc.owncloud.com/server/next/admin_manual/installation/manual_installation/manual_installation_prerequisites.html#openssl-version

it's in the "important" block.

please add the docs magic to it so it looks nice. The commands should be in code blocks, but I did not know how to do them right.

I am aware that this example might become outdated in the future, but without it many users and or admins might get lost on what to implement where and how. This should act as a example. 


I also added an anchor for the relevant section of the ssl docs.