### PR TITLE
Update theming.adoc

### DIFF
--- a/modules/developer_manual/pages/core/theming.adoc
+++ b/modules/developer_manual/pages/core/theming.adoc
@@ -75,7 +75,7 @@ sudo chown -R www-data: mynewtheme
 +
 [source,console,subs="attributes+"]
 ----
-{occ-command-example-prefix} app:enable mynewtheme
+occ app:enable mynewtheme
 ----
 
 . Exclude your new theme from integrity checking. Add the following setting to `config/config.php`:


### PR DESCRIPTION
removed occ prefix. Quick guide expects one to be in the apps-external directory, the occ command + prefix does not work. Additionally the occ wrapper is expected at this point.