### PR TITLE
added enabling of ssl module to apache ssl configuration

### DIFF
--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -132,11 +132,11 @@ IMPORTANT: For the moment, comment out the `Include` directive, as the certifica
 
 == Test and Enable the Apache Configuration
 
-Apache2 ssl module needs to be enabled for ssl configuration. Use the following command to enable it:
+If not already done, enable the Apache2 ssl module necessary for the ssl configuration. Use the following command to enable it:
 
 [source,bash]
 ----
-a2enmod ssl
+sudo a2enmod ssl
 ----
 
 With the configuration created, test it by running one of the following two commands:

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -132,6 +132,13 @@ IMPORTANT: For the moment, comment out the `Include` directive, as the certifica
 
 == Test and Enable the Apache Configuration
 
+Apache2 ssl module needs to be enabled for ssl configuration. Use the following command to enable it:
+
+[source,bash]
+----
+a2enmod ssl
+----
+
 With the configuration created, test it by running one of the following two commands:
 
 [source,bash]


### PR DESCRIPTION
https://doc.owncloud.com/server/next/admin_manual/installation/letsencrypt/apache.html

This docs was missing the ssl mode enabling part, so I added it. Without it the ssl configuration fails.

Backport to 10.11 and 10.12