### PR TITLE
Change old references from PHP 7.3 to 7.4

### DIFF
--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -93,7 +93,7 @@ ownCloud can run with following PHP versions: {supported-php-versions}
 
 [IMPORTANT]
 ====
-ownCloud recommends PHP 7.4 for new installations. Sites using a version earlier than PHP 7.3 are *strongly encouraged* to migrate at least to PHP 7.3.
+PHP 7.4 *must* be used for all installations. Sites currently using a different PHP version *must* migrate to PHP 7.4.
 ====
 
 [IMPORTANT]

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_20.04.adoc
@@ -445,7 +445,7 @@ xref:installation/manual_installation/manual_installation_db.adoc[Manual Install
 
 NOTE: Follow the procedure described in xref:useful-tips[Useful Tips], if you want to `Disable Transparent Huge Pages (THP),Transparent Huge Pages`
 
-You may want to use the latest version of phpmyadmin as the OS default versions lags behind the {phpmyadmin_latest_url}[latest available stable] version a lot and may report PHP errors with PHP 7.3 onwards. Follow this
+You may want to use the latest version of phpmyadmin as the OS default versions lags behind the {phpmyadmin_latest_url}[latest available stable] version a lot and may report PHP errors with PHP 7.4. Follow this
 xref:installation/manual_installation/upgrade_install_phpmyadmin.adoc[quick upgrade guide] to install it.
 
 == Useful Tips

--- a/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_22.04.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/server_prep_ubuntu_22.04.adoc
@@ -377,7 +377,7 @@ xref:installation/manual_installation/manual_installation_db.adoc[Manual Install
 
 NOTE: Follow the procedure described in xref:useful-tips[Useful Tips] if you want to `Disable Transparent Huge Pages (THP),Transparent Huge Pages`.
 
-You may want to use the latest version of phpmyadmin as the OS default versions lags behind the {phpmyadmin_latest_url}[latest available stable] version a lot and may report PHP errors with PHP 7.3 onwards. Follow this
+You may want to use the latest version of phpmyadmin as the OS default versions lags behind the {phpmyadmin_latest_url}[latest available stable] version a lot and may report PHP errors with PHP 7.4. Follow this
 xref:installation/manual_installation/upgrade_install_phpmyadmin.adoc[quick upgrade guide] to install it.
 
 == Useful Tips

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade_php.adoc
@@ -11,8 +11,8 @@ And if you're on a version of PHP older than {minimum-php-printed} you *must* up
 This guide takes you through upgrading your installation of PHP to one of the supported PHP versions ({supported-php-versions}) on Red Hat or CentOS 7.
 
 :from-version: 5.6
-:to-version: 7.3
-:to-pkg-version: 73
+:to-version: 7.4
+:to-pkg-version: 74
 
 include::partial$/maintenance/upgrading/upgrade_steps.adoc[leveloffset=+1]
 


### PR DESCRIPTION
While reading some docs, I noticed that there are still some mentions of PHP 7.3. But ownCloud 10.12 drops support for PHP 7.3
https://github.com/owncloud/core/pull/40394

Backport to 10.12 branch only.