### PR TITLE
Update collabora_secure_view.adoc [10.12.0]

### DIFF
--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -65,10 +65,6 @@ When enabled, this mode allows documents to be printed or exported to PDF format
 
 NOTE: Admins can specify that all shares are "_secure view_" by default and that the user has to intentionally change this setting.
 
-== View Only for Public Links
-
-When secure view is enabled and configured, users can share office documents with  view-only permissions, named _Preview_. Using this functionality, the document opens in Collabora Online but only viewing is possible. For details see the xref:next@webui:classic_ui:files/public_link_shares.adoc[Public Link Shares] documentation of the user guide. Unlike in secure view preview mode, no watermarking is used.
-
 == Secure View Restrictions
 
 When "_{secure-view-label}_" is enabled, any attempts to download the file will be blocked as shown in the screenshot below. In addition, copy & paste is disabled.


### PR DESCRIPTION
Preview role for public links does not exist yet. Will likely be implemented in 10.13.0. References to it should be removed from the 10.12 documentation. "Next" can stay.