### PR TITLE
added redirect permanent configuration

### DIFF
--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -186,3 +186,24 @@ It is now ready to serve HTTPS request for the given domain using the issued cer
 ----
 sudo service apache2 reload
 ----
+
+== Add a redirect directive
+
+Now that we have SSL configured and enabled, we need to configure that all traffic to our server is redirected to use the encrypted ssl site.
+
+[source,apache]
+----
+<VirtualHost *:80>
+  ServerName mydom.tld
+  Redirect permanent / https://<Your-Server-FQDN>/
+  Alias /.well-known/acme-challenge/ /var/www/letsencrypt/.well-known/acme-challenge/
+  <Directory "/var/www/letsencrypt/.well-known/acme-challenge/">
+      Options None
+      AllowOverride None
+      ForceType text/plain
+      RedirectMatch 404 "^(?!/\.well-known/acme-challenge/[\w-]{43}$)"
+  </Directory>
+
+  # ... remaining configuration
+</VirtualHost>
+----

--- a/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
+++ b/modules/admin_manual/pages/installation/letsencrypt/apache.adoc
@@ -187,9 +187,9 @@ It is now ready to serve HTTPS request for the given domain using the issued cer
 sudo service apache2 reload
 ----
 
-== Add a redirect directive
+== Add a Redirect Directive
 
-Now that we have SSL configured and enabled, we need to configure that all traffic to our server is redirected to use the encrypted ssl site.
+Now that SSL has been configured and enabled, a redirection of all traffic to the encrypted ssl site needs to be added. Reload the Apache configuration to activate it.
 
 [source,apache]
 ----


### PR DESCRIPTION
If we provide a apache documentation here: https://doc.owncloud.com/server/next/admin_manual/installation/letsencrypt/apache.html then it's missing the important last step to redirect all http traffic to https.

This PR adds the instructions at the end of the page.

Backport to 10.11 and 10.12