### PR TITLE
Expand MariaDB support up to 10.11

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -60,7 +60,7 @@ including all 100% compatible derivatives
 * openSUSE Leap 15.2
 
 | Database
-| * xref:#database-requirements[MySQL] 8+ or xref:#database-requirements[MariaDB] 10.2 through 10.8 ^1^ (*Recommended*)
+| * xref:#database-requirements[MySQL] 8+ or xref:#database-requirements[MariaDB] 10.2 through 10.11 ^1^ (*Recommended*)
 * Oracle 11 and 12 (*Enterprise only*)
 * PostgreSQL 9, 10, 11, 12, 13 or 14
 * SQLite (*Not for production*)


### PR DESCRIPTION
Fixes #962 

oC10 works with recent MariaDB releases 10.9 10.10 and 10.11 - see core issue https://github.com/owncloud/core/issues/40762 -  Update the docs to say this.

I could only find this one place to change. All other mentions of MariaDB in the docs do not need to change.

After running the core tests linked from core issue https://github.com/owncloud/core/issues/40762 I am confident that there is no problem using these newer MariaDB releases, so we may as well document that.

It will work fine with any oC10 core release from 10.9 onward. (oC10.9 provided support for a change that happened in MariaDB 10.6). So backport this docs change to oC core 10.12 and 10.11 docs branches.
