### PR TITLE
Update metrics.adoc for PR #166

### DIFF
--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -46,7 +46,7 @@ The following data is available for analysis:
 .**System data**
 * Date/Time stamp - Server time of the request
 * Storage
-  ** Used storage (this also includes storage for avatars and thumbnails)
+  ** Used storage (this includes both, data that count against user Quotas `usedQuota`, and `usedOther` like avatars, thumbnails and file versions)
   ** Free storage
   ** Total storage (used + free)
   ** Number of files


### PR DESCRIPTION
Fixes: https://github.com/owncloud/metrics/issues/170 ([QA] Data format of metrics/api/v1/metrics changed)

We now mention new the fields usedQuota and usedOther --  maybe that is a bit to much, as all other fields are not explicitly mentioned with their exact names...

If you ask me, it does not harm :-)