### PR TITLE
Remove trailing comma in JSON

### DIFF
--- a/modules/admin_manual/pages/configuration/files/mimetypes.adoc
+++ b/modules/admin_manual/pages/configuration/files/mimetypes.adoc
@@ -29,7 +29,7 @@ Below you can see a snippet of the file where the mimetype’s on the left and t
  "application/font-woff": "image",
  "application/illustrator": "image",
  "application/epub+zip": "text",
- "application/javascript": "text/code",
+ "application/javascript": "text/code"
 }
 ----
 
@@ -192,7 +192,7 @@ and also returns a basic JSON array.
  "arw": ["image/x-dcraw"],
  "avi": ["video/x-msvideo"],
  "bash": ["text/x-shellscript"],
- "json": ["application/json", "text/plain"],
+ "json": ["application/json", "text/plain"]
 }
 ----
 


### PR DESCRIPTION
my IDE tells me that a trailing comma is not valid in JSON.

So I think that these example responses need the trailing comma removed.

Backport to 10.12 and 10.11