### PR TITLE
Add missing attributes in site.yml (local build relevant only)

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -74,8 +74,9 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0'
-    ocis-compiled: '2022-11-30 00:00:00 +0000 UTC'
+    ocis-actual-version: '3.0.0'
+    ocis-former-version: '2.0.0'
+    ocis-compiled: '2023-06-07 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   desktop
     latest-desktop-version: 'next'


### PR DESCRIPTION
We have updated `site.yml` in the docs repo but missed to do this here too.
It had no negative effect as the main build runs via the docs repo but local building throws a warning about missing attributes.

Note that there will be a CI error that has nothing to do with the PR, I am currently investigating.

Backport to 10.11 and 10.12