### PR TITLE
Added some hints how to survive the trusted_domains issue with docker

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -92,9 +92,9 @@ long as you have access to the physical server you can always log in. In
 the event that a load-balancer is in place, there will be no issues as
 long as it sends the correct `X-Forwarded-Host` header.
 
-In case of a docker based setup, the trusted_domains setting is controlled by the environment variables `OWNCLOUD_TRUSTED_DOMAINS` or `OWNCLOUD_DOMAIN`. The latter takes only effect, if `OWNCLOUD_TRUSTED_DOMAINS` is undefined and can provide one IP-addres or hostname. `OWNCLOUD_TRUSTED_DOMAINS` can specify multiple values as a comma-separated list. 
+In case of a docker based setup, the trusted_domains setting is controlled by the environment variables `OWNCLOUD_TRUSTED_DOMAINS` or `OWNCLOUD_DOMAIN`. The latter only takes effect, if `OWNCLOUD_TRUSTED_DOMAINS` is undefined and can provide one IP-address or hostname. `OWNCLOUD_TRUSTED_DOMAINS` can specify multiple values as a comma-separated list. 
 
-Here is an example, how this can be used from within a docker-compose.yml file to allow access to ownCloud under two differnet names, and one IP-address, in addition to localhost and 127.0.0.1:
+Here is an example of how this can be used from within a docker-compose.yml file to allow access to ownCloud under two different names, and one IP-address, in addition to localhost and 127.0.0.1:
 
 [source,yaml,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -92,6 +92,19 @@ long as you have access to the physical server you can always log in. In
 the event that a load-balancer is in place, there will be no issues as
 long as it sends the correct `X-Forwarded-Host` header.
 
+In case of a docker based setup, the trusted_domains setting is controlled by the environment variables OWNCLOUD_TRUSTED_DOMAINS or OWNCLOUD_DOMAIN. The latter takes only effect, if OWNCLOUD_TRUSTED_DOMAINS is undefined and can provide one IP-addres or hostname. 
+OWNCLOUD_TRUSTED_DOMAINS can specify multiple values as a comma-separated list. 
+
+Here is an example, how this can be used from within a docker-compose.yml fie to allow access to ownCloud under two differnet names, and one IP-address (in addition to localhost and 127.0.0.1):
+```
+services:
+  owncloud:
+    image: "owncloud/server:10.12.2"
+    environment:
+      OWNCLOUD_DOMAIN: "myowncloud.mydomain.com, myowncloud, 12.23.34.45"
+...
+```
+
 == Example Migration
 
 The following is an example migration with assumptions to make

--- a/modules/admin_manual/pages/maintenance/migrating.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating.adoc
@@ -92,25 +92,26 @@ long as you have access to the physical server you can always log in. In
 the event that a load-balancer is in place, there will be no issues as
 long as it sends the correct `X-Forwarded-Host` header.
 
-In case of a docker based setup, the trusted_domains setting is controlled by the environment variables OWNCLOUD_TRUSTED_DOMAINS or OWNCLOUD_DOMAIN. The latter takes only effect, if OWNCLOUD_TRUSTED_DOMAINS is undefined and can provide one IP-addres or hostname. 
-OWNCLOUD_TRUSTED_DOMAINS can specify multiple values as a comma-separated list. 
+In case of a docker based setup, the trusted_domains setting is controlled by the environment variables `OWNCLOUD_TRUSTED_DOMAINS` or `OWNCLOUD_DOMAIN`. The latter takes only effect, if `OWNCLOUD_TRUSTED_DOMAINS` is undefined and can provide one IP-addres or hostname. `OWNCLOUD_TRUSTED_DOMAINS` can specify multiple values as a comma-separated list. 
 
-Here is an example, how this can be used from within a docker-compose.yml fie to allow access to ownCloud under two differnet names, and one IP-address (in addition to localhost and 127.0.0.1):
-```
+Here is an example, how this can be used from within a docker-compose.yml file to allow access to ownCloud under two differnet names, and one IP-address, in addition to localhost and 127.0.0.1:
+
+[source,yaml,subs="attributes+"]
+----
 services:
   owncloud:
-    image: "owncloud/server:10.12.2"
+    image: "owncloud/server:{latest-server-version}"
     environment:
-      OWNCLOUD_DOMAIN: "myowncloud.mydomain.com, myowncloud, 12.23.34.45"
+      OWNCLOUD_TRUSTED_DOMAINS: "myowncloud.mydomain.com, myowncloud, 12.23.34.45"
 ...
-```
+----
 
 == Example Migration
 
 The following is an example migration with assumptions to make
 this migration work:
 
-* Ubuntu 16.04+
+* Ubuntu 20.04+
 * SSH with `PermitRootLogin` set to `yes`
 * Database used is MySQL / MariaDB
 


### PR DESCRIPTION
We have this link embedded in the trusted domains error message: https://doc.owncloud.com/server/10.12/go.php?to=admin-untrusted-domain it seems to end up in the migration.html page. Maybe there is other/better places, that already describe trusted domains issues in more detail? 
I just want to dump these hints somewhere, as this is probably, how we can get the appliance to behave.

My markdown syntax is probably completely wrong, and this should of course not only go to 10.12, but also to master. Sorry.
