### PR TITLE
Update system_requirements, use MariaDB 10.11 as default

### DIFF
--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -29,7 +29,7 @@ For _best performance_, _stability_, _support_ and _full functionality_, we offi
 | Ubuntu 20.04 LTS
 
 | Database
-| xref:#database-requirements[MariaDB] 10.5 ^1^
+| xref:#database-requirements[MariaDB] 10.11 ^1^
 
 | Redis
 | >= 6


### PR DESCRIPTION
Fixes: #1016 (System Requirements page update)

Update MariaDB to 10.11

Backport to 10.11 and 10.12