### PR TITLE
warn about external storages in guests_app.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/user/guests_app.adoc
+++ b/modules/admin_manual/pages/configuration/user/guests_app.adoc
@@ -19,6 +19,8 @@ Install and enable the {oc-marketplace-url}/apps/guests[Guests] app if not alrea
 
 Check your Guests app's configuration in menu:Settings[Admin > Sharing]. There you can change the Guest's **group name** and add to or exclude apps from the app **whitelist** of the Guests app. Guests cannot access apps that are not on that list.
 
+Note: Per default guests see external storages that are available to all users (i.e. empty user/group list)
+
 With a blocklist, an admin can block domains for guest invitations:
 
 * Up to Guests 0.12.1, the blocklist entries were a suffix match. An entry like `example.com` would also block `user@otherexample.com` -- this was considered an error and admins relying on this feature must review their blocklists when upgrading to Guests 0.12.2.


### PR DESCRIPTION
Guests have access to external storages, even when the files_external app is not in the whitelist.
I could not find anything to limit external storages to non-guest users. IMHO, that would be a sane default.

@pako81 Maybe this is a bug and should be fixed, rather than documented?

Not sure, if this warning should be here, or in the section about external storages instead.