### PR TITLE
Update user_roles.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_roles.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_roles.adoc
@@ -10,10 +10,6 @@
 
 {description}
 
-== User Request for Changing a Role
-
-Users can request a change of their current role under menu:User Name[Settings > Personal > General > Account]. When clicking the button btn:[Request new role], the new role can be entered and an email will be sent to the admin group for further processing.
-
 == Anonymous
 
 * Is not a regular user.


### PR DESCRIPTION
I am puzzled by https://doc.owncloud.com/server/next/admin_manual/configuration/user/user_roles.html#user-request-for-changing-a-role - users can request a role change and then some e-mail is sent?

An 'Account' section cannot be found in

Settings -> Personal -> General

I assume this feature does not exist / no longer exists. 
@pako81 @hodyroff should it just be dropped from documentation?

Similarly dubious section in https://github.com/owncloud/docs-webui/blob/master/modules/classic_ui/pages/personal_settings/general.adoc#account-related-settings

Github search https://github.com/search?q=org%3Aowncloud+%22Request+new+role%22&type=code
returns only these two hits in the documentation, but no code to implement that button.