### PR TITLE
Update federated_cloud_sharing_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -32,16 +32,23 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 +
 [source,bash]
 ----
-mysql -u root -e "update oc_jobs set last_run=0 where class='OCA\\Federation\\SyncJob';" owncloud;
-mysql -u root -e "update oc_jobs set last_checked=0 where class='OCA\\Federation\\SyncJob';" owncloud;
+{occ-command-example-prefix} occ system:cron
+{occ-command-example-prefix} occ background:queue:execute --force --accept-warning 10
+{occ-command-example-prefix} occ system:cron
+{occ-command-example-prefix} occ system:cron
 ----
 . Navigate to **admin settings -> sharing -> Federation**
 . Add **server 1** to the trusted servers on **server 2**.
 . Add **server 2** to the trusted servers on **server 1**.
-. Now run the cron job in your ownCloud directory (for example `/var/www/owncloud/`).
+. Now add both serves as trusted domains of each other into config.php and then run cron jobs again on both machines.
 +
 [source,bash,subs="attributes+"]
 ----
+{occ-command-example-prefix} occ config:system:get trusted_domains | wc -l # use this number in the next command
+{occ-command-example-prefix} occ config:system:set trusted_domains 3 --value "**server other**"
+{occ-command-example-prefix} occ system:cron
+{occ-command-example-prefix} occ background:queue:execute --force --accept-warning 10
+{occ-command-example-prefix} system:cron
 {occ-command-example-prefix} system:cron
 ----
 . Now the check should be green

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -47,7 +47,7 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 {occ-command-example-prefix} occ config:system:set trusted_domains 3 --value "**server other**"
 {occ-command-example-prefix} occ system:cron
 {occ-command-example-prefix} occ background:queue:execute --force --accept-warning 10
-{occ-command-example-prefix} system:cron
+{occ-command-example-prefix} occ system:cron
 ----
 . Now the check should be green
 . Sync now your users with

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -35,7 +35,6 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 {occ-command-example-prefix} occ system:cron
 {occ-command-example-prefix} occ background:queue:execute --force --accept-warning 10
 {occ-command-example-prefix} occ system:cron
-{occ-command-example-prefix} occ system:cron
 ----
 . Navigate to **admin settings -> sharing -> Federation**
 . Add **server 1** to the trusted servers on **server 2**.
@@ -48,7 +47,6 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 {occ-command-example-prefix} occ config:system:set trusted_domains 3 --value "**server other**"
 {occ-command-example-prefix} occ system:cron
 {occ-command-example-prefix} occ background:queue:execute --force --accept-warning 10
-{occ-command-example-prefix} system:cron
 {occ-command-example-prefix} system:cron
 ----
 . Now the check should be green

--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -40,7 +40,7 @@ image:configuration/files/browser-address-bars.png[Lock icon in Firefox, Google 
 . Navigate to **admin settings -> sharing -> Federation**
 . Add **server 1** to the trusted servers on **server 2**.
 . Add **server 2** to the trusted servers on **server 1**.
-. Now add both serves as trusted domains of each other into config.php and then run cron jobs again on both machines.
+. Now add both servers as trusted domains of each other into config.php and then run cron jobs again on both machines.
 +
 [source,bash,subs="attributes+"]
 ----


### PR DESCRIPTION
trusted server setup gets more complex.

Hope I correclty misunderstood what Piotr found in https://github.com/owncloud/enterprise/issues/5676#issuecomment-1512708126

It must be very frustrating for a suer to distringuish between a trusted server entry and a remote trusted domains entry and then force run selected cron jobs manually...

(At least, I believe, I could obsolete direct database hacking here.)

Backport to 10.12 and master