### PR TITLE
Update openssl

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -33,6 +33,7 @@ ownCloud’s server-side encryption encrypts files stored on the ownCloud server
 
 [NOTE]
 ====
+* See the important information on the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[OpenSSL Version] before you start configuraing the encryption app.
 * Encrypting files increases their size by an 8KB header plus 100 bytes per each 8KB block of the file. Remember to take this into account when you are both provisioning storage and setting storage quotas.
 * If you are _running_ the encryption app before version 1.5.0 or _started_ with an encryption app version before 1.5.0, BASE64 encoding was used and might still be used for old files if untouched since then. In these cases, old encrypted files increased their size by roughly 35%. We recommend to update the ownCloud system to be able to use the benefits of reduced file sizes for new and rewritten files. Note that the encryption app version lower than 1.5.0 was delivered as part of the ownCloud system lower than 10.7.
 * User quotas are based on the _unencrypted_ file size — *not* the encrypted size. This means that admins need to calculate with higher disk space requirements on the backend.

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,7 +1,7 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 2
-:description: The primary purpose of the ownCloud server-side encryption is to protect users’ files when they’re located on remote storage sites such as Dropbox and Google Drive, smoothly and seamlessly from within ownCloud.
+:description: The primary purpose of the ownCloud server-side encryption is to protect users’ files when they’re located on remote storage sites, such as Dropbox and Google Drive, smoothly and seamlessly from within ownCloud.
 
 :hackerone-url: https://hackerone.com/reports/108082
 :oc-uses-enc-url: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/
@@ -33,7 +33,7 @@ ownCloud’s server-side encryption encrypts files stored on the ownCloud server
 
 [NOTE]
 ====
-* See the important information on the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[OpenSSL Version] before you start configuraing the encryption app.
+* See the important information on the xref:installation/manual_installation/manual_installation_prerequisites.adoc#openssl-version[OpenSSL Version] before you start configuring the encryption app.
 * Encrypting files increases their size by an 8KB header plus 100 bytes per each 8KB block of the file. Remember to take this into account when you are both provisioning storage and setting storage quotas.
 * If you are _running_ the encryption app before version 1.5.0 or _started_ with an encryption app version before 1.5.0, BASE64 encoding was used and might still be used for old files if untouched since then. In these cases, old encrypted files increased their size by roughly 35%. We recommend to update the ownCloud system to be able to use the benefits of reduced file sizes for new and rewritten files. Note that the encryption app version lower than 1.5.0 was delivered as part of the ownCloud system lower than 10.7.
 * User quotas are based on the _unencrypted_ file size — *not* the encrypted size. This means that admins need to calculate with higher disk space requirements on the backend.

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -1,6 +1,8 @@
 = Encryption Configuration
 :toc: right
 :toclevels: 2
+:description: The primary purpose of the ownCloud server-side encryption is to protect users’ files when they’re located on remote storage sites such as Dropbox and Google Drive, smoothly and seamlessly from within ownCloud.
+
 :hackerone-url: https://hackerone.com/reports/108082
 :oc-uses-enc-url: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/
 :page-aliases: go/admin-encryption.adoc, \
@@ -13,8 +15,6 @@ configuration/files/encryption/migration-guide.adoc, \
 configuration/files/encryption/moving-key-locations.adoc, \
 configuration/files/encryption/sharing-encrypted-files.adoc, \
 configuration/files/encryption_configuration.adoc
-
-:description: The primary purpose of the ownCloud server-side encryption is to protect users’ files when they’re located on remote storage sites such as Dropbox and Google Drive, smoothly and seamlessly from within ownCloud.
 
 == Introduction
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -1,5 +1,7 @@
 = Prerequisites for Manual Installation on Linux
 :toc: right
+:description: This document guides you thru the prerequisites for a manual ownCloud Server installation on Linux.
+
 :avconv-url: https://libav.org/
 :ffmpeg-url: https://ffmpeg.org/
 :openoffice-url: https://www.openoffice.org/
@@ -9,6 +11,8 @@
 :gnu-make-url: https://www.gnu.org/software/make/
 
 == Introduction
+
+{description}
 
 The ownCloud tar archive contains all of the required third-party PHP libraries. As a result, no extra ones are, strictly, necessary. However, ownCloud does require that PHP has a set of extensions installed, enabled, and configured.
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -1,6 +1,6 @@
 = Prerequisites for Manual Installation on Linux
 :toc: right
-:description: This document guides you thru the prerequisites for a manual ownCloud Server installation on Linux.
+:description: This document guides you through the prerequisites for a manual ownCloud Server installation on Linux.
 
 :avconv-url: https://libav.org/
 :ffmpeg-url: https://ffmpeg.org/
@@ -14,7 +14,7 @@
 
 {description}
 
-The ownCloud tar archive contains all of the required third-party PHP libraries. As a result, no extra ones are, strictly, necessary. However, ownCloud does require that PHP has a set of extensions installed, enabled, and configured.
+The ownCloud tar archive contains all of the required third-party PHP libraries. As a result, no extra ones are strictly necessary. However, ownCloud does require that PHP has a set of extensions installed, enabled and configured.
 
 This section lists both the required and optional PHP extensions. If you need further information about a particular extension, please consult the relevant section of the {php-net-url}/manual/en/extensions.php[extensions section of the PHP manual].
 
@@ -104,7 +104,7 @@ activate = 1
 activate = 1
 ----
    
-. Save the file, you now have enabled OpenSSL legacy support.
+. Save the file and you have enabled OpenSSL legacy support.
 
 === PHP Version
 
@@ -296,7 +296,7 @@ See xref:configuration/server/caching_configuration.adoc[Caching Configuration] 
 | Enables command interruption by pressing `ctrl-c`
 |====
 
-NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, {sabre-url}[SabreDAV]. If `mod_webdav` is enabled you must disable it for ownCloud. See the xref:installation/manual_installation/manual_installation_apache.adoc[Apache preparation guide] for more details.
+NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, {sabre-url}[SabreDAV]. If `mod_webdav` is enabled, you must disable it for ownCloud. See the xref:installation/manual_installation/manual_installation_apache.adoc[Apache preparation guide] for more details.
 
 === For MySQL/MariaDB
 

--- a/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
+++ b/modules/admin_manual/pages/installation/manual_installation/manual_installation_prerequisites.adoc
@@ -10,22 +10,17 @@
 
 == Introduction
 
-The ownCloud tar archive contains all of the required third-party PHP libraries.
-As a result, no extra ones are, strictly, necessary.
-However, ownCloud does require that PHP has a set of extensions installed, enabled, and configured.
+The ownCloud tar archive contains all of the required third-party PHP libraries. As a result, no extra ones are, strictly, necessary. However, ownCloud does require that PHP has a set of extensions installed, enabled, and configured.
 
-This section lists both the required and optional PHP extensions.
-If you need further information about a particular extension, please consult the relevant section of the {php-net-url}/manual/en/extensions.php[extensions section of the PHP manual].
+This section lists both the required and optional PHP extensions. If you need further information about a particular extension, please consult the relevant section of the {php-net-url}/manual/en/extensions.php[extensions section of the PHP manual].
 
-If you are using a Linux distribution, it should have packages for all the required extensions.
-You can check the presence of a module by typing `php -m | grep -i <module_name>`.
-If you get a result, the module is present.
+If you are using a Linux distribution, it should have packages for all the required extensions. You can check the presence of a module by typing `php -m | grep -i <module_name>`. If you get a result, the module is present.
 
 == Required Prerequisites
 
 === openSSL Version
 
-ownCloud requires that you have openSSL version 1.1.x installed. With the release change of openSSL v1.x to openSSL version 3.x in December 2021, some ciphers which were valid in version 1.x, have been retired with immediate effect. This impacts the ownCloud encryption app.
+ownCloud requires that you have openSSL version 1.1.x installed. With the release change of openSSL v1.x to openSSL version 3.x in December 2021, some ciphers which were valid in version 1.x, have been retired with immediate effect. This impacts the ownCloud xref:configuration/files/encryption/encryption_configuration.adoc[encryption app].
 
 [IMPORTANT]
 ====
@@ -40,7 +35,7 @@ your encryption environment will break due to openSSL v3 retired (legacy) cipher
 
 How to implement the fix for the above mentioned issue:
 
-1. Find the openssl config directory with 
+. Find the openssl config directory with 
 +
 --
 [source,bash]
@@ -53,7 +48,7 @@ Output example:
 `OPENSSLDIR: "/usr/lib/ssl"`
 --
 
-2. Go in to that directory and open the config file `openssl.cnf`
+. Go in to that directory and open the config file `openssl.cnf`
 +
 --
 Look for:
@@ -85,7 +80,27 @@ activate = 1
 ----
 --
 
-3. Save the file. Now you have enabled the legacy support.
+. The file should now look like this:
++
+[source,plaintext]
+----
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+----
+   
+. Save the file, you now have enabled OpenSSL legacy support.
 
 === PHP Version
 
@@ -210,8 +225,7 @@ NOTE: The _Phar_, _OpenSSL_, and _cUrl_ extensions are mandatory if you want to 
 | For SMB/CIFS integration
 |====
 
-NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+.
-See xref:configuration/files/external_storage/smb.adoc[SMB/CIFS].
+NOTE: SMB/Windows Network Drive mounts require the PHP module smbclient version 0.8.0+. See xref:configuration/files/external_storage/smb.adoc[SMB/CIFS].
 
 === Optional
 
@@ -278,9 +292,7 @@ See xref:configuration/server/caching_configuration.adoc[Caching Configuration] 
 | Enables command interruption by pressing `ctrl-c`
 |====
 
-NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, {sabre-url}[SabreDAV].
-If `mod_webdav` is enabled you must disable it for ownCloud.
-See the xref:installation/manual_installation/manual_installation_apache.adoc[Apache preparation guide] for more details.
+NOTE: You don’t need the WebDAV module for your Web server (i.e., Apache’s `mod_webdav`), as ownCloud has a built-in WebDAV server of its own, {sabre-url}[SabreDAV]. If `mod_webdav` is enabled you must disable it for ownCloud. See the xref:installation/manual_installation/manual_installation_apache.adoc[Apache preparation guide] for more details.
 
 === For MySQL/MariaDB
 


### PR DESCRIPTION
Fixes: #1099 (Prerequisites for Manual Installation on Linux; openSSL version 3.x fix is not the same as in the openSSL wiki)

* Update the OpenSSL description
* Add/relocate the description attribute
* Add a reference to/from the encryption app
* removal of unnecessary linebreakes

Backport to 10.13 and 10.12