### PR TITLE
Fix SQL commands when installing

### DIFF
--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_20_04.adoc
@@ -181,10 +181,11 @@ Ensure transaction-isolation level is set and performance_schema on.
 ----
 sed -i "/\[mysqld\]/atransaction-isolation = READ-COMMITTED\nperformance_schema = on" /etc/mysql/mariadb.conf.d/50-server.cnf
 systemctl start mariadb
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS owncloud; \
-GRANT ALL PRIVILEGES ON owncloud.* \
-  TO owncloud@localhost \
-  IDENTIFIED BY '${sec_db_pwd}'";
+mysql -u root -e \
+  "CREATE DATABASE IF NOT EXISTS owncloud; \
+  CREATE USER IF NOT EXISTS 'owncloud'@'localhost' IDENTIFIED BY '${sec_db_pwd}'; \
+  GRANT ALL PRIVILEGES ON *.* TO 'owncloud'@'localhost' WITH GRANT OPTION; \
+  FLUSH PRIVILEGES;"
 ----
 
 It is recommended to run mysqltuner script to analyse database configuration after running with load for several days.

--- a/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
+++ b/modules/admin_manual/pages/installation/quick_guides/ubuntu_22_04.adoc
@@ -157,7 +157,6 @@ DocumentRoot /var/www/owncloud
 EOM
 ----
 
-
 ==== Test the Configuration
 
 [source,bash]
@@ -200,10 +199,11 @@ Ensure transaction-isolation level is set and performance_schema on.
 ----
 sed -i "/\[mysqld\]/atransaction-isolation = READ-COMMITTED\nperformance_schema = on" /etc/mysql/mariadb.conf.d/50-server.cnf
 systemctl start mariadb
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS owncloud; \
-GRANT ALL PRIVILEGES ON owncloud.* \
-  TO owncloud@localhost \
-  IDENTIFIED BY '${sec_db_pwd}'";
+mysql -u root -e \
+  "CREATE DATABASE IF NOT EXISTS owncloud; \
+  CREATE USER IF NOT EXISTS 'owncloud'@'localhost' IDENTIFIED BY '${sec_db_pwd}'; \
+  GRANT ALL PRIVILEGES ON *.* TO 'owncloud'@'localhost' WITH GRANT OPTION; \
+  FLUSH PRIVILEGES;"
 ----
 
 It is recommended to run the mysqltuner script to analyze the database configuration after running with load for several days.

--- a/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
+++ b/modules/admin_manual/partials/installation/manual_installation/mariadb.adoc
@@ -11,7 +11,7 @@ Use these commands to install MariaDB provided by Ubuntu and secure its installa
 At the time of writing, the following MariaDB Server versions will be installed, which may change when the corresponding package gets updated:
 
 * With Ubuntu 20.04: `mariadb-server` version `10.4.21` 
-* With Ubuntu 22.04, `mariadb-server` version `10.6.7`
+* With Ubuntu 22.04, `mariadb-server` version `10.6.12`
 ====
 
 [source,bash]
@@ -80,9 +80,9 @@ To install an ownCloud database, you need an administrative user who can log in,
 ----
 sudo mysql --user=root -p
 
-CREATE USER 'dbadmin'@'localhost' IDENTIFIED BY 'password';
-GRANT ALL PRIVILEGES ON *.* TO 'dbadmin'@'localhost' WITH GRANT OPTION;
-FLUSH PRIVILEGES;
+ CREATE USER 'dbadmin'@'localhost' IDENTIFIED BY 'password';
+ GRANT ALL PRIVILEGES ON *.* TO 'dbadmin'@'localhost' WITH GRANT OPTION;
+ FLUSH PRIVILEGES;
 exit
 ----
 
@@ -98,11 +98,12 @@ _Don't forget to change the username and password according to your needs_.
 [source,bash]
 ----
 sudo mysql
-MariaDB [(none)]>
+
  CREATE USER IF NOT EXISTS 'dbadmin'@'localhost' IDENTIFIED BY 'password';
  GRANT ALL PRIVILEGES ON *.* TO 'dbadmin'@'localhost' WITH GRANT OPTION;
  FLUSH PRIVILEGES;
  SHOW GRANTS FOR 'dbadmin'@'localhost';
+exit
 ----
 ====
 

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -16,8 +16,8 @@
 ***** Detailed Installation Guide
 ****** xref:admin_manual:installation/manual_installation/manual_installation.adoc[Detailed Installation on Ubuntu (various versions)]
 ***** Quick Installation Guide
-****** xref:admin_manual:installation/quick_guides/ubuntu_20_04.adoc[Quick Install on Ubuntu 20.04]
-****** xref:admin_manual:installation/quick_guides/ubuntu_22_04.adoc[Quick Install on Ubuntu 22.04]
+****** xref:admin_manual:installation/quick_guides/ubuntu_20_04.adoc[On Ubuntu 20.04]
+****** xref:admin_manual:installation/quick_guides/ubuntu_22_04.adoc[On Ubuntu 22.04]
 ***** Linux Package Manager
 ****** xref:admin_manual:installation/linux_packetmanager_install.adoc[Linux Package Manager Installation]
 **** xref:admin_manual:installation/installation_wizard.adoc[The Installation Wizard]


### PR DESCRIPTION
Fixes: #1061 (Installation guide: Database: Grant privileges + create user no longer works on mysql)

* use the correct SQL command in the quick guides
* fix commands in the detailed guide 
* improve nav for better readbility (link stays the same)
* some other small fixes

Backport to 10.13 and 10.12