### PR TITLE
Fix typo in federated_cloud_sharing_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/federated_cloud_sharing_configuration.adoc
@@ -182,7 +182,7 @@ Possible values are:
 * EMAIL
 * CLOUD
 
-The value `CLOUD` enables searching by federation ID. Note that when `EMAIL` or `CLOUD` are enabled, hostnames are included in the search. Results are then returned for sbustrings of the hostname part, even when no user related field matches.
+The value `CLOUD` enables searching by federation ID. Note that when `EMAIL` or `CLOUD` are enabled, hostnames are included in the search. Results are then returned for substrings of the hostname part, even when no user related field matches.
 
 === Listing Federated Shares
 


### PR DESCRIPTION
This typo was accidentally introduced in PR #1106 