### PR TITLE
Fix encryption configuration page aliases

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -2,9 +2,6 @@
 :toc: right
 :toclevels: 2
 :description: The primary purpose of the ownCloud server-side encryption is to protect users’ files when they’re located on remote storage sites, such as Dropbox and Google Drive, smoothly and seamlessly from within ownCloud.
-
-:hackerone-url: https://hackerone.com/reports/108082
-:oc-uses-enc-url: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/
 :page-aliases: go/admin-encryption.adoc, \
 configuration/files/encryption/disabling-encryption.adoc, \
 configuration/files/encryption/enabling-user-key-encryption.adoc, \
@@ -15,6 +12,9 @@ configuration/files/encryption/migration-guide.adoc, \
 configuration/files/encryption/moving-key-locations.adoc, \
 configuration/files/encryption/sharing-encrypted-files.adoc, \
 configuration/files/encryption_configuration.adoc
+
+:hackerone-url: https://hackerone.com/reports/108082
+:oc-uses-enc-url: https://owncloud.com/news/how-owncloud-uses-encryption-to-protect-your-data/
 
 == Introduction
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs/issues/4883
Page aliases did not work. Newline between page attributes was removed. While asciidoc does not care about newlines between custom attributes like `hackerone-url` for Antora page attributes, this did not work. 

Backport to 10.13 and 10.12