### PR TITLE
Remove all senseless index.adoc pages from the enterprise section

### DIFF
--- a/modules/admin_manual/pages/enterprise/authentication/enterprise_only_auth.adoc
+++ b/modules/admin_manual/pages/enterprise/authentication/enterprise_only_auth.adoc
@@ -1,5 +1,6 @@
 = Enterprise-Only Authentication Options
 :toc: right
+:page-aliases: enterprise/external_storage/enterprise_only_auth.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/creating_branded_apps.adoc
@@ -1,5 +1,6 @@
 = Creating Branded Client Apps
 :toc: right
+:page-aliases: enterprise/clients/index.adoc
 
 == Overview
 

--- a/modules/admin_manual/pages/enterprise/clients/index.adoc
+++ b/modules/admin_manual/pages/enterprise/clients/index.adoc
@@ -1,5 +1,0 @@
-:section-title: Enterprise Clients
-:section-preamble-ender: to configure ownCloud enterprise clients 
-
-include::partial$section_page.adoc[]
-

--- a/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/collabora_secure_view.adoc
@@ -1,7 +1,7 @@
 = Collabora Online / Secure View
 :toc: right
 :secure-view-label: Secure View (with watermarks)
-:page-aliases: collabora_online_integration.adoc
+:page-aliases: collabora_online_integration.adoc, enterprise/collaboration/index.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/collaboration/index.adoc
+++ b/modules/admin_manual/pages/enterprise/collaboration/index.adoc
@@ -1,5 +1,0 @@
-:section-title: Enterprise Collaboration
-:section-preamble-ender: to configure enterprise collaboration in ownCloud
-
-include::partial$section_page.adoc[]
-

--- a/modules/admin_manual/pages/enterprise/document_classification/classification_and_policy_enforcement.adoc
+++ b/modules/admin_manual/pages/enterprise/document_classification/classification_and_policy_enforcement.adoc
@@ -1,6 +1,8 @@
 = Document Classification and Policy Enforcement
 :toc: right
-:page-aliases: document_classification/index.adoc, enterprise/classification_and_policy_enforcement.adoc
+:page-aliases: document_classification/index.adoc, \
+enterprise/classification_and_policy_enforcement.adoc, \
+enterprise/document_classification/index.adoc
 
 :iso_27001_url: https://www.iso.org/isoiec-27001-information-security.html
 :vda_url: https://www.vda.de/de/themen/digitalisierung/daten/informationssicherheit

--- a/modules/admin_manual/pages/enterprise/document_classification/index.adoc
+++ b/modules/admin_manual/pages/enterprise/document_classification/index.adoc
@@ -1,4 +1,0 @@
-:section-title: Document Classification
-:section-preamble-ender: to configure document classification in ownCloud
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/external_storage/index.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/index.adoc
@@ -1,5 +1,0 @@
-:section-title: External Storage
-:section-preamble-ender: to configure enterprise external storage in ownCloud
-:page-aliases: enterprise/external_storage/onedrive.adoc
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
+++ b/modules/admin_manual/pages/enterprise/external_storage/windows-network-drive_configuration.adoc
@@ -1,6 +1,7 @@
 = Windows Network Drive (WND)
 :toc: right
 :toclevels: 3
+:page-aliases: enterprise/external_storage/index.adoc
 :description: The Windows Network Drives app seamlessly integrates Windows and Samba/CIFS shared network drives as external storages. WND has great advantages compared to standard SMB access.
 
 :anacron-examples: http://www.thegeekstuff.com/2011/05/anacron-examples

--- a/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/files_tagging.adoc
@@ -1,5 +1,6 @@
 = Advanced File Tagging With the Workflow App
 :toc: right
+:page-aliases: enterprise/file_management/index.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/file_management/index.adoc
+++ b/modules/admin_manual/pages/enterprise/file_management/index.adoc
@@ -1,5 +1,0 @@
-:section-title: Enterprise File Management
-:section-preamble-ender: to configure enterprise file management in ownCloud. 
-
-include::partial$section_page.adoc[]
-

--- a/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/file_firewall.adoc
@@ -1,6 +1,8 @@
 = File Firewall
 :toc: right
+:page-aliases: enterprise/firewall/index.adoc
 :description: The File Firewall app lets you control access and sharing in fine detail by creating rules for allowing or denying access to files.
+
 :regex-info-url: http://www.regular-expressions.info/
 :supported-mimetype-list-url: https://github.com/owncloud/core/blob/master/resources/config/mimetypemapping.dist.json
 

--- a/modules/admin_manual/pages/enterprise/firewall/index.adoc
+++ b/modules/admin_manual/pages/enterprise/firewall/index.adoc
@@ -1,5 +1,0 @@
-:section-title: Enterprise Firewall Configuration
-:section-preamble-ender: to configure enterprise firewall configuration in ownCloud appliance. 
-
-include::partial$section_page.adoc[]
-

--- a/modules/admin_manual/pages/enterprise/index.adoc
+++ b/modules/admin_manual/pages/enterprise/index.adoc
@@ -1,3 +1,0 @@
-= Enterprise Edition
-
-In this section, you will find all the information you need for managing ownCloud Enterprise Edition.

--- a/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/admin_audit.adoc
@@ -1,8 +1,9 @@
 = Auditing
 :toc: right
 :toclevels: 3
+:page-aliases: enterprise/logging/enterprise_logging_apps.adoc, enterprise/logging/index.adoc
+
 :splunk-url: https://splunkbase.splunk.com/app/5503/
-:page-aliases: enterprise/logging/enterprise_logging_apps.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/logging/index.adoc
+++ b/modules/admin_manual/pages/enterprise/logging/index.adoc
@@ -1,4 +1,0 @@
-:section-title: Enterprise Logging Configuration
-:section-preamble-ender: to configure enterprise logging configuration in ownCloud 
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/reporting/index.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/index.adoc
@@ -1,4 +1,0 @@
-:section-title: Enterprise Reporting
-:section-preamble-ender: to setup reporting for the ownCloud Enterprise installation 
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
+++ b/modules/admin_manual/pages/enterprise/reporting/metrics.adoc
@@ -1,6 +1,7 @@
 = Metrics
 :toc: right
 :toclevel: 2
+:page-aliases: enterprise/reporting/index.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/security/index.adoc
+++ b/modules/admin_manual/pages/enterprise/security/index.adoc
@@ -1,4 +1,0 @@
-:section-title: Enterprise Security
-:section-preamble-ender: to configure enterprise security in ownCloud 
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/security/ransomware-protection.adoc
+++ b/modules/admin_manual/pages/enterprise/security/ransomware-protection.adoc
@@ -1,7 +1,9 @@
 = Ransomware Protection
 :toc: right
 :page-aliases: enterprise/ransomware-protection/index.adoc, \
-configuration/server/security/ransomware-protection.adoc
+configuration/server/security/ransomware-protection.adoc, \
+enterprise/security/ransomware-protection/index.adoc, \
+enterprise/security/index.adoc
 
 == Introduction
 

--- a/modules/admin_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
+++ b/modules/admin_manual/pages/enterprise/server_branding/enterprise_server_branding.adoc
@@ -1,4 +1,6 @@
 = Enterprise Server Branding
+:toc: right
+:page-aliases: enterprise/server_branding/index.adoc
 
 ownBrander is an ownCloud build service that is exclusive to Enterprise
 edition customers for creating branded ownCloud clients and servers. You

--- a/modules/admin_manual/pages/enterprise/server_branding/index.adoc
+++ b/modules/admin_manual/pages/enterprise/server_branding/index.adoc
@@ -1,4 +1,0 @@
-:section-title: Enterprise Server Branding
-:section-preamble-ender: to configure enterprise server branding in ownCloud 
-
-include::partial$section_page.adoc[]

--- a/modules/admin_manual/pages/enterprise/user_management/index.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/index.adoc
@@ -1,8 +1,0 @@
-:section-title: Enterprise User Management
-:section-preamble-ender: to configure enterprise user management in ownCloud 
-
-include::partial$section_page.adoc[]
-
-* xref:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
-
-* xref:enterprise/user_management/saml_2.0_sso.adoc[SAML 2.0 Based SSO]

--- a/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
+++ b/modules/admin_manual/pages/enterprise/user_management/saml_2.0_sso.adoc
@@ -1,6 +1,8 @@
 = SAML 2.0 Based SSO with Active Directory Federation Services (ADFS) and mod-shib
 :toc: right
 :toclevels: 1
+:page-aliases: enterprise/user_management/index.adoc
+
 :adfs-url: https://docs.microsoft.com/en-us/previous-versions/windows/server-2008/bb897402(v=msdn.10)
 :adfs-step-by-step-url: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/gg317734(v=ws.10)
 :adfs-step-by-step-II-url: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/gg317734(v=ws.10)

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -34,7 +34,7 @@
 ** xref:admin_manual:configuration/index.adoc[Configuration]
 *** xref:admin_manual:configuration/database/index.adoc[Database]
 **** xref:admin_manual:configuration/database/db_conversion.adoc[Database Conversion]
-**** xref:admin_manual:configuration/database/linux_database_configuration.adoc[Database Configuration on Linux]
+**** xref:admin_manual:configuration/database/linux_database_configuration.adoc[Database Configuration]
 
 *** xref:admin_manual:configuration/files/encryption/index.adoc[Encryption]
 **** xref:admin_manual:configuration/files/encryption/encryption_configuration.adoc[Encryption Configuration]
@@ -163,38 +163,40 @@
 
 ** xref:admin_manual:qnap/index.adoc[ownCloud on QNAP]
 
-** xref:admin_manual:enterprise/index.adoc[Enterprise]
-*** xref:admin_manual:enterprise/clients/index.adoc[Clients]
+** Enterprise
+*** Authentication
+**** xref:admin_manual:enterprise/external_storage/enterprise_only_auth.adoc[Enterprise Only Authentication]
+*** Clients
 **** xref:admin_manual:enterprise/clients/creating_branded_apps.adoc[Creating Branded Apps]
 **** xref:admin_manual:enterprise/clients/custom_client_repos.adoc[Custom Client Repos]
-*** xref:admin_manual:enterprise/collaboration/index.adoc[Collaboration]
+*** Collaboration
 **** xref:admin_manual:enterprise/collaboration/collabora_secure_view.adoc[Collabora Online / Secure View]
 **** xref:admin_manual:enterprise/collaboration/msoffice-wopi-integration.adoc[Microsoft Office Online / WOPI Integration]
-*** xref:admin_manual:enterprise/document_classification/index.adoc[Document Classification]
+*** Document Classification
 **** xref:admin_manual:enterprise/document_classification/classification_and_policy_enforcement.adoc[Classify Documents and Enforce Policies]
-*** xref:admin_manual:enterprise/external_storage/index.adoc[External Storage]
-**** xref:admin_manual:enterprise/external_storage/enterprise_only_auth.adoc[Enterprise Only Authentication]
+*** External Storage
 **** xref:admin_manual:enterprise/external_storage/ldap_home_connector_configuration.adoc[LDAP Home Connector Configuration]
 **** xref:admin_manual:enterprise/external_storage/sharepoint-integration_configuration.adoc[Sharepoint integration Configuration]
 **** xref:admin_manual:enterprise/external_storage/windows-network-drive_configuration.adoc[Windows Network Drive Configuration]
 **** xref:admin_manual:enterprise/external_storage/wnd_quick_guide.adoc[WND Configuration Quick Guide]
-*** xref:admin_manual:enterprise/file_management/index.adoc[File Management]
+*** File Management
 **** xref:admin_manual:enterprise/file_management/files_tagging.adoc[File Tagging]
 **** xref:admin_manual:enterprise/file_management/files_lifecycle.adoc[File Lifecycle Management]
-*** xref:admin_manual:enterprise/firewall/index.adoc[Firewall]
+*** Firewall
 **** xref:admin_manual:enterprise/firewall/file_firewall.adoc[File Firewall]
-*** xref:admin_manual:enterprise/installation/install.adoc[Installation]
+*** Installation
+**** xref:admin_manual:enterprise/installation/install.adoc[Installing & Upgrading ownCloud Enterprise Edition]
 **** xref:admin_manual:enterprise/installation/oracle_db_configuration.adoc[Oracle DB Setup & Configuration]
-*** xref:admin_manual:enterprise/logging/index.adoc[Logging]
+*** Logging
 **** xref:admin_manual:enterprise/logging/admin_audit.adoc[Auditing]
-*** xref:admin_manual:enterprise/reporting/index.adoc[Reporting]
+*** Reporting
 **** xref:admin_manual:enterprise/reporting/metrics.adoc[Metrics]
 **** xref:admin_manual:enterprise/reporting/config_report.adoc[Generate a Config Report]
-*** xref:admin_manual:enterprise/security/index.adoc[Security]
+*** Security
 **** xref:admin_manual:enterprise/security/ransomware-protection/index.adoc[Ransomware Protection]
-*** xref:admin_manual:enterprise/server_branding/index.adoc[Server Branding]
+*** Server Branding
 **** xref:admin_manual:enterprise/server_branding/enterprise_server_branding.adoc[Enterprise Server Branding]
-*** xref:admin_manual:enterprise/user_management/index.adoc[User Management]
+*** User Management
 **** xref:admin_manual:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
 **** xref:admin_manual:enterprise/user_management/saml_2.0_sso.adoc[SAML 2.0 Based SSO]
 


### PR DESCRIPTION
This PR removes all index.adoc pages from the enterprise section which were just telling "you are here".
A redirect as been added to a page part of each sub section to avoid a 404.

Necessary as preperation for the enterprise/kerberos documentation, see issue #1098.

Backport to 10.13 and 10.12