### PR TITLE
Catch all app directories for updating permissions

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -169,7 +169,7 @@ In addition, if there are installed apps (whether compatible or incompatible wit
 
 If you are using third party or enterprise applications, look in your new `/var/www/owncloud/apps/` or `/var/www/owncloud/apps-external/` directory to see if they are present. If not, copy them from your old instance to your new one.
 
-NOTE: Make sure that all app directories that are defined in the `apps_paths` section of your `config.php` file do exist in your new `/var/www/owncloud/` directory. Also, make sure, that all app directories listed in `apps_path` actually exist. If `occ` complains about missing `apps-external` then try
+NOTE: Make sure that all app directories that are defined in the `apps_paths` section of your `config.php` file do exist in your new `/var/www/owncloud/` directory. Also, make sure, that all app directories listed in `apps_path` actually exist. If `occ` complains about missing `apps-external` then try:
 
 [source,bash]
 ----
@@ -203,7 +203,7 @@ Set the ownership for all files and folders to `www-data:www-data` for the `conf
 ----
 sudo chown -R www-data:www-data /var/www/owncloud/config
 sudo chown -R www-data:www-data /var/www/owncloud/data
-sudo chown -R www-data:www-data /var/www/owncloud/apps
+sudo chown -R www-data:www-data /var/www/owncloud/apps*
 ----
 
 .Set correct permissions


### PR DESCRIPTION
When updating ownCloud, there is the need to update permissions on directories.
This PR fixes that all app directories are catched.

Backport to 10.13 and 10.12

@voroyam fyi (and thanks for catching)