### PR TITLE
Remove meaningless index pages from the admin navigation

### DIFF
--- a/modules/admin_manual/pages/configuration/index.adoc
+++ b/modules/admin_manual/pages/configuration/index.adoc
@@ -1,4 +1,0 @@
-= Configuration
-
-In this section, you will find all the information you need for configuring ownCloud. 
-

--- a/modules/admin_manual/pages/troubleshooting/index.adoc
+++ b/modules/admin_manual/pages/troubleshooting/index.adoc
@@ -1,5 +1,0 @@
-:section-title: Troubleshooting
-:section-preamble-ender: to troubleshoot ownCloud 
-
-include::partial$section_page.adoc[]
-

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -4,7 +4,8 @@
 ** xref:admin_manual:useful_pages.adoc[Useful Pages]
 ** xref:admin_manual:faq/index.adoc[FAQ]
 ** xref:admin_manual:gdpr.adoc[GDPR]
-** xref:admin_manual:installation/index.adoc[Installation]
+
+** Installation
 *** xref:admin_manual:installation/deployment_considerations.adoc[Deployment Considerations]
 *** xref:admin_manual:installation/deployment_recommendations.adoc[Deployment Recommendations]
 **** xref:admin_manual:installation/deployment_recommendations/nfs.adoc[NFS]
@@ -31,7 +32,7 @@
 **** xref:admin_manual:installation/letsencrypt/using_letsencrypt.adoc[Using Letsencrypt]
 **** xref:admin_manual:installation/letsencrypt/apache.adoc[Apache]
 
-** xref:admin_manual:configuration/index.adoc[Configuration]
+** Configuration
 *** xref:admin_manual:configuration/database/index.adoc[Database]
 **** xref:admin_manual:configuration/database/db_conversion.adoc[Database Conversion]
 **** xref:admin_manual:configuration/database/linux_database_configuration.adoc[Database Configuration]
@@ -200,7 +201,7 @@
 **** xref:admin_manual:enterprise/user_management/user_auth_shibboleth.adoc[Shibboleth Integration]
 **** xref:admin_manual:enterprise/user_management/saml_2.0_sso.adoc[SAML 2.0 Based SSO]
 
-** xref:admin_manual:troubleshooting/index.adoc[Troubleshooting]
+** Troubleshooting
 *** xref:admin_manual:troubleshooting/general_troubleshooting.adoc[General Troubleshooting]
 *** xref:admin_manual:troubleshooting/path_filename_length.adoc[Path and Filename Length Limitations]
 *** xref:admin_manual:troubleshooting/providing_logs_and_config_files.adoc[Retrieve Log Files and Configuration Settings]


### PR DESCRIPTION
Fixes #1138 (Loop in the next -> next -> next ... chain)

This PR removes meaningless index pages to nav headings as we have in other main nav entries.

Backport to 10.13 and 10.12
