### PR TITLE
added compelte ldaps doc, step by step

### DIFF
--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -45,36 +45,36 @@ Start with the Server tab. You may configure multiple servers if you have them. 
 LDAPS encrypts the connection between your LDAP server and ownCloud via SSL/TLS.
 
 1. For LDAPS you need a LDAP server with certificates. 
-  1.For Windows server install the "Active Directory Certificate Services (AD CS)" role and configure it as a company CA.
+  1. For Windows Server, install the "Active Directory Certificate Services (AD CS)" role and configure it as a company CA.
   2. Then export the CA certificate using this method:
-    1. open certutil with admin privileges, and execute the following command. "ca_name" is just a placeholder for the certificate name, you can adjust it.
+    1. Open certutil with admin privileges and execute the following command where "ca_name" is just a placeholder for the certificate name. Adjust it accordingly.
     2. certutil -ca.cert ca_name.cer
-    This was ensures you have the right certificate for configuring LDAPS.
-    3. copy the certificate ca_name.cer to your ownCloud server, and convert it using the following command:
+    This ensures you have the right certificate for configuring LDAPS.
+    3. Copy the certificate ca_name.cer to your ownCloud server, and convert it using the following command:
     4. openssl x509 -inform der -in ca_name.cer -out certificate.pem
-    5. double check with cat certificate.pem the output is the same on you had with certutil
-  3. Now, move the certificate to /etc/ldap/certs/ (on Ubuntu) or /etc/openldap/certs/ (on centOS) (you have to create the "certs" folder inside those directories beforehand)
-  4. (only for centOS) Change permissions with chown so the ldap client can access the certificate: "chown centos:centos certificate.pem"
-  5. Edit the ldap.conf inside the ldap directory, add
+    5. Double-check with `cat certificate.pem`. The output is the same one you had with `certutil`.
+  3. Now, move the certificate to /etc/ldap/certs/ (on Ubuntu) or /etc/openldap/certs/ (on centOS). You have to create the "certs" folder inside those directories beforehand.
+  4. Only for centOS: Change permissions with `chown` so the ldap client can access the certificate: `chown centos:centos certificate.pem`
+  5. Edit the ldap.conf inside the ldap directory:
    Ubuntu 
    TLS_CACERT      /etc/ldap/certs/certificate.pem
    centOS 
    TLS_CACERT      /etc/openldap/certs/certificate.pem
-  6. restart the web server
-If you have a openLDAP server: 
-1. you need to import the ssl certificate from openLDAP to ownCloud server, 
-2. put it in the /etc/ldap/certs/ or /etc/openldap/certs/ folder, depending if you have Ubuntu or centOs
-3. include it in your ldap.conf 
+  6. Restart the web server.
+If you have a openLDAP server, perform the following steps: 
+1. Import the ssl certificate from openLDAP to ownCloud server.
+2. Put it in the /etc/ldap/certs/ or /etc/openldap/certs/ folder, depending on whether you have Ubuntu or centOS.
+3. Include it in your ldap.conf:
    Ubuntu 
    TLS_CACERT      /etc/ldap/certs/certificate.pem
    centOS 
    TLS_CACERT      /etc/openldap/certs/certificate.pem
-4. restart the web server.
+4. Restart the web server.
 Now you have to configure the ownCloud LDAP app:
-1. if you were using ldap with port 389 you have to change the port to 636 and add ldaps:// to your ldap host in the server tab.
-2. click on "Test BaseDN" and you should see a green light and a number of entries that were found in your ldap.
+1. If you were using LDAP with port 389, you have to change the port to 636 and add ldaps:// to your LDAP host in the server tab.
+2. Click on "Test BaseDN" and you should see a green light and a number of entries that were found in your LDAP.
 
-Now you have ldapS, your ldap traffic is encrypted with a SSL certificate.
+Now you have LDAPS and your LDAP traffic is encrypted with a SSL certificate.
 
 
 image::apps/user_ldap/ldap-wizard/server-tab.png[LDAP Wizard - Server Tab, width=500]

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -40,44 +40,111 @@ First, install the {oc-marketplace-url}/apps/user_ldap[LDAP Integration] app. Th
 
 Start with the Server tab. You may configure multiple servers if you have them. At a minimum, you must supply the LDAP server's hostname. If your server requires authentication, enter your credentials on this tab.
 
+image::apps/user_ldap/ldap-wizard/server-tab.png[LDAP Wizard - Server Tab, width=500]
+
 ==== LDAPS Configuration
 
 LDAPS encrypts the connection between your LDAP server and ownCloud via SSL/TLS.
 
-1. For LDAPS you need a LDAP server with certificates. 
-  1. For Windows Server, install the "Active Directory Certificate Services (AD CS)" role and configure it as a company CA.
-  2. Then export the CA certificate using this method:
-    1. Open certutil with admin privileges and execute the following command where "ca_name" is just a placeholder for the certificate name. Adjust it accordingly.
-    2. certutil -ca.cert ca_name.cer
-    This ensures you have the right certificate for configuring LDAPS.
-    3. Copy the certificate ca_name.cer to your ownCloud server, and convert it using the following command:
-    4. openssl x509 -inform der -in ca_name.cer -out certificate.pem
-    5. Double-check with `cat certificate.pem`. The output is the same one you had with `certutil`.
-  3. Now, move the certificate to /etc/ldap/certs/ (on Ubuntu) or /etc/openldap/certs/ (on centOS). You have to create the "certs" folder inside those directories beforehand.
-  4. Only for centOS: Change permissions with `chown` so the ldap client can access the certificate: `chown centos:centos certificate.pem`
-  5. Edit the ldap.conf inside the ldap directory:
-   Ubuntu 
+For LDAPS you need a LDAP server with certificates::
+
+{empty}
+
+. For Windows Server, install the _Active Directory Certificate Services (AD CS)_ role and configure it as a company CA.
+. Export the CA certificate using this method:
+.. Open `certutil` with admin privileges and execute the following command where `ca_name` is just a placeholder for the certificate name. Adjust it accordingly.
++
+--
+[source,plaintext]
+----
+certutil -ca.cert ca_name.cer
+----
+This ensures you have the right certificate for configuring LDAPS.
+--
+. Copy the certificate `ca_name.cer` to your ownCloud server.
+. Do the following tasks on the ownCloud server.
+.. Convert the certificate with:
++
+--
+[source,plaintext]
+----
+openssl x509 -inform der -in ca_name.cer -out certificate.pem
+----
+--
+.. Double-check with:
++
+--
+[source,bash]
+----
+cat certificate.pem
+----
+The output is the same one you had with `certutil`.
+--
+
+Move the Certificate::
+
+Move the certificate to `/etc/ldap/certs/` (on Ubuntu) or `/etc/openldap/certs/ (on centOS)`. You have to create the `certs` folder inside those directories beforehand.
+
+. Only for `centOS`: +
+Change permissions with `chown` so the ldap client can access the certificate:
++
+--
+[source,bash]
+----
+chown centos:centos certificate.pem
+----
+--
+. Edit the `ldap.conf` file inside the ldap directory:
++
+--
+.Ubuntu
+[source,plaintext]
+---- 
    TLS_CACERT      /etc/ldap/certs/certificate.pem
-   centOS 
+----
+.centOS 
+[source,plaintext]
+---- 
    TLS_CACERT      /etc/openldap/certs/certificate.pem
-  6. Restart the web server.
-If you have a openLDAP server, perform the following steps: 
-1. Import the ssl certificate from openLDAP to ownCloud server.
-2. Put it in the /etc/ldap/certs/ or /etc/openldap/certs/ folder, depending on whether you have Ubuntu or centOS.
-3. Include it in your ldap.conf:
-   Ubuntu 
+----
+--
+. Restart the web server.
+
+If you have a openLDAP server, perform the following steps::
+
+{empty}
+
+. Import the ssl certificate from openLDAP to ownCloud server.
+. Put it in the /etc/ldap/certs/ or /etc/openldap/certs/ folder, depending on whether you have Ubuntu or centOS.
+. Include it in your `ldap.conf`:
++
+--
+.Ubuntu
+[source,plaintext]
+---- 
    TLS_CACERT      /etc/ldap/certs/certificate.pem
-   centOS 
+----
+.centOS 
+[source,plaintext]
+---- 
    TLS_CACERT      /etc/openldap/certs/certificate.pem
-4. Restart the web server.
-Now you have to configure the ownCloud LDAP app:
-1. If you were using LDAP with port 389, you have to change the port to 636 and add ldaps:// to your LDAP host in the server tab.
-2. Click on "Test BaseDN" and you should see a green light and a number of entries that were found in your LDAP.
+----
+--
+. Restart the web server.
 
-Now you have LDAPS and your LDAP traffic is encrypted with a SSL certificate.
+{empty}
 
+Configure the ownCloud LDAP app::
 
-image::apps/user_ldap/ldap-wizard/server-tab.png[LDAP Wizard - Server Tab, width=500]
+. Finalize LDAPS via section xref:server-configurations[Server Configurations] below:
+.. If you were using LDAP with port 389, you have to change the port to 636 and add `ldaps://` to your LDAP host in the server tab.
+.. Click on menu:Test BaseDN[] and you should see a green light and a number of entries that were found in your LDAP.
+
+LDAPS is prepared::
+
+Finally you have LDAPS configured and your LDAP traffic is encrypted with a SSL certificate.
+
+==== Server Configurations
 
 Server Configuration::
   Configure one or more LDAP servers.
@@ -115,7 +182,7 @@ The name as DN of a user who has permissions to do searches in the LDAP director
 
 Example:
 
-[width=100,cols="80%,30%",options=header]
+[width=100,cols="70%,30%",options=header]
 |===
 | User DN
 | LDAP Directory

--- a/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
+++ b/modules/admin_manual/pages/configuration/user/user_auth_ldap.adoc
@@ -44,9 +44,38 @@ Start with the Server tab. You may configure multiple servers if you have them. 
 
 LDAPS encrypts the connection between your LDAP server and ownCloud via SSL/TLS.
 
-1. First you need the Windows Server CA certificate in the `pem` format with `.crt` suffix
-2. Import the certificate to `/usr/local/share/ca-certificates/`
-3. Execute `update-ca-certificates`
+1. For LDAPS you need a LDAP server with certificates. 
+  1.For Windows server install the "Active Directory Certificate Services (AD CS)" role and configure it as a company CA.
+  2. Then export the CA certificate using this method:
+    1. open certutil with admin privileges, and execute the following command. "ca_name" is just a placeholder for the certificate name, you can adjust it.
+    2. certutil -ca.cert ca_name.cer
+    This was ensures you have the right certificate for configuring LDAPS.
+    3. copy the certificate ca_name.cer to your ownCloud server, and convert it using the following command:
+    4. openssl x509 -inform der -in ca_name.cer -out certificate.pem
+    5. double check with cat certificate.pem the output is the same on you had with certutil
+  3. Now, move the certificate to /etc/ldap/certs/ (on Ubuntu) or /etc/openldap/certs/ (on centOS) (you have to create the "certs" folder inside those directories beforehand)
+  4. (only for centOS) Change permissions with chown so the ldap client can access the certificate: "chown centos:centos certificate.pem"
+  5. Edit the ldap.conf inside the ldap directory, add
+   Ubuntu 
+   TLS_CACERT      /etc/ldap/certs/certificate.pem
+   centOS 
+   TLS_CACERT      /etc/openldap/certs/certificate.pem
+  6. restart the web server
+If you have a openLDAP server: 
+1. you need to import the ssl certificate from openLDAP to ownCloud server, 
+2. put it in the /etc/ldap/certs/ or /etc/openldap/certs/ folder, depending if you have Ubuntu or centOs
+3. include it in your ldap.conf 
+   Ubuntu 
+   TLS_CACERT      /etc/ldap/certs/certificate.pem
+   centOS 
+   TLS_CACERT      /etc/openldap/certs/certificate.pem
+4. restart the web server.
+Now you have to configure the ownCloud LDAP app:
+1. if you were using ldap with port 389 you have to change the port to 636 and add ldaps:// to your ldap host in the server tab.
+2. click on "Test BaseDN" and you should see a green light and a number of entries that were found in your ldap.
+
+Now you have ldapS, your ldap traffic is encrypted with a SSL certificate.
+
 
 image::apps/user_ldap/ldap-wizard/server-tab.png[LDAP Wizard - Server Tab, width=500]
 


### PR DESCRIPTION
for a support case we tested the ldaps configuration in ownCloud, which depends on the certificate you import from the windows server, you have to import the right one in the right format, then change the format and place it in the right place on the ownCloud server, in the ldap client directory, and specify in the configuration that the client should use exactly that certificate.

we need also a warning or a note that the protocol has to be entered and can not be omitted with ldaps, you have to add ldaps:// to the host name of your ldap server. We have this as a note in the webUI but the not is very small and easy to overlook. I overlooked it, the customer did as well. Not a good solution. 

I added the steps for centOS. I know this is a ubuntu only doc, but we have many customers who have centOS and open support cases with us, we have to know how to configure ldaps with centOS. I can't see a way around it. Except that we state that we don't support centOS and the customers have to get support from their OS vendor. 

let me know what you thing and I am always available for testing and completing the guide.

The visual representation of this as well as the wording can be improved, my focus was on the technical correctness. 