### PR TITLE
Update appliance installation.adoc

### DIFF
--- a/modules/admin_manual/pages/appliance/installation/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation/installation.adoc
@@ -104,7 +104,9 @@ image:appliance/setup/11.png[Navigate to Address]
 
 == Activate the Appliance
 
-The VM will show you this screen, showing the ip **address** you have to navigate to in order to **activate** your appliance
+The VM will show you this screen, showing the ip **address** you have to navigate to in order to **activate** your appliance.
+The freshly started appliance runs on a self-signed certificate. Your web browser most likely will warn you about this and ask for confirmation, before
+you can proceed. It is recommended to install a proper certificate later on.
 
 image:appliance/setup/12.png[Request License]
 

--- a/modules/admin_manual/pages/appliance/installation/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation/installation.adoc
@@ -105,8 +105,7 @@ image:appliance/setup/11.png[Navigate to Address]
 == Activate the Appliance
 
 The VM will show you this screen, showing the ip **address** you have to navigate to in order to **activate** your appliance.
-The freshly started appliance runs on a self-signed certificate. Your web browser most likely will warn you about this and ask for confirmation, before
-you can proceed. It is recommended to install a proper certificate later on.
+The freshly started appliance runs on a self-signed certificate. Your web browser most likely will warn you about this and ask for confirmation, before you can proceed. It is recommended to install a proper certificate later on.
 
 image:appliance/setup/12.png[Request License]
 

--- a/modules/admin_manual/pages/appliance/installation/installation.adoc
+++ b/modules/admin_manual/pages/appliance/installation/installation.adoc
@@ -42,9 +42,7 @@ and launch it. The example below shows this being done using VirtualBox.
 
 image:appliance/import-the-virtual-appliance.png[Importing the ownCloud X Trial Appliance OVA file into VirtualBox and accepting the software license agreement terms and conditions.]
 
-If you try to install an ownCloud appliance in your domain after
-removing an existing one, please remember to remove the original one
-from you DNS configuration.
+The recommended network mode for the ownCloud Appliance is bridged mode.
 
 Don’t Forget the *IP Address* and the *Administrator Password*. You will need them to use the Appliance.
 


### PR DESCRIPTION
I have no Idea, what problem the paragraph about removing DNS entries wants to solve. Suggest to drop that paragraph.

Instead, and much more important, we should recommend bridged mode. 

(I was testing with NAT and port forwarding today, but ran in all sorts of errors: the UCS 5 dashboard drops port numbers while redirecting, the internal DNS of UCS produces wrong mappings. etc..)