### PR TITLE
Update appliance firewall.adoc

### DIFF
--- a/modules/admin_manual/pages/appliance/configuration/firewall.adoc
+++ b/modules/admin_manual/pages/appliance/configuration/firewall.adoc
@@ -7,11 +7,8 @@ If you are using Google as your DNS server (IP=8.8.8.8), you have to permit acce
 
 Firewall Rules:
 
-- 176.9.114.147
-- 5.9.68.237
 - 8.8.8.8
 - docker.software-univention.de
 - marketplace.owncloud.com
 - owncloud.com
-- owncloud.org
 - software-univention.de


### PR DESCRIPTION
owncloud.org can be safely removed, we no longer use that domain.

176.9.114.147 has an invalid self singned certificate. It seem to be a hetzner machine. Without specifying a very good reason we should not ask anybody to trust this machine. I have no idea, by whom it is operated.

5.9.68.237 has a cert that identifies as "int.owncloud.com"; most likely it is also obsolete.