### PR TITLE
Update docs pertaining to the use of 'OWNCLOUD_TRUSTED_DOMAINS'

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -58,7 +58,7 @@ passwords. This example is for documentation only, and you should never use it.
 ....
 
 === Define list of trusted domains that users can log into
-Specifying trusted domains prevents host header poisoning. This parameter reperesents a white list of approved IP addresses and hostnames that this server is known by.
+Specifying trusted domains prevents host header poisoning. This parameter reperesents a white list of approved IP addresses and hostnames that this server is known by / is used to access it. Wildcards, slash notation and ports are not supported.
 
 Do not remove this, as it performs necessary security checks.
 Please consider that for backend processes like background jobs or occ commands,

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -58,7 +58,7 @@ passwords. This example is for documentation only, and you should never use it.
 ....
 
 === Define list of trusted domains that users can log into
-Specifying trusted domains prevents host header poisoning.
+Specifying trusted domains prevents host header poisoning. This parameter reperesents a white list of approved IP addresses and hostnames that this server is known by.
 
 Do not remove this, as it performs necessary security checks.
 Please consider that for backend processes like background jobs or occ commands,
@@ -73,6 +73,8 @@ the URL parameter in key `overwrite.cli.url` is used. For more details, please s
 	'otherdomain.example.org',
   ],
 ....
+
+NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be a comma delimited list with no white space. e.g. `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.  Wildcards and slash notation are not supported.
 
 === Define global list of CORS domains
 All users can use tools running CORS (Cross-Origin Resource Sharing) requests

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -74,7 +74,7 @@ the URL parameter in key `overwrite.cli.url` is used. For more details, please s
   ],
 ....
 
-NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be a comma delimited list with no white space. e.g. `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.  Wildcards and slash notation are not supported.
+NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be a comma delimited list with no white space. e.g. `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.  Wildcards, slash notation and ports are not supported.
 
 === Define global list of CORS domains
 All users can use tools running CORS (Cross-Origin Resource Sharing) requests

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -46,7 +46,7 @@ docker exec --user www-data <owncloud-container-name> occ <your-command>
 == Quick Evaluation
 
 NOTE: The commands and links provided in the following descriptions are intended to showcase basic docker usage, but we cannot take responsibility for their proper functioning.
-If you only want to take a peek and are content with SQLite as database, which is not supported by ownCloud for production purposes, try the following:
+If you only want to take a peek using your local machine and are content with SQLite as database, which is not supported by ownCloud for production purposes, try the following:
 
 [source,docker,subs="attributes+"]
 ----
@@ -64,7 +64,7 @@ With the command `docker ps` you can list your running docker containers and sho
 
 You can log in to your ownCloud instance via a browser at `pass:a[http://localhost:{std-port-http}]` with the preconfigured user `admin` and password `admin`.
 
-NOTE: Access only works with http, not https.
+NOTE: Access only works locally with http, not https.
 
 Now, if you like what you see but want a supported installation with MariaDB, you should remove the eval version before proceeding with the next section.
 
@@ -90,7 +90,7 @@ The configuration:
 * Uses separate _MariaDB_ and _Redis_ containers.
 * Mounts the data and MySQL data directories on the host for persistent storage.
 
-The following instructions assume you install locally. For remote access, the value of xref:configuration/server/config_sample_php_parameters.adoc#override-cli-url[OWNCLOUD_DOMAIN] and xref:configuration/server/config_sample_php_parameters.adoc#define-list-of-trusted-domains-that-users-can-log-into[OWNCLOUD_TRUSTED_DOMAINS] must be adapted.
+The following instructions assume you install locally. For remote access, the value of xref:configuration/server/config_sample_php_parameters.adoc#override-cli-url[OWNCLOUD_DOMAIN] and xref:configuration/server/config_sample_php_parameters.adoc#define-list-of-trusted-domains-that-users-can-log-into[OWNCLOUD_TRUSTED_DOMAINS] must be updated to represent the hostname(s) and/or IP addresses that the server is reachable at.
 
 . Create a new project directory.
 +


### PR DESCRIPTION
Provide additional information about the correct use and configuration of the trusted domains property when used in docker configurations.  Will hopefully reduce/resolve support requests relating to misuse of this value.