### PR TITLE
Updates config.sample and some docker related text

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -61,14 +61,14 @@ passwords. This example is for documentation only, and you should never use it.
 Specifying trusted domains prevents host header poisoning.
 
 This parameter reperesents a white list of approved IP addresses and
-hostnames that this server is known by / is used to access it.
+hostnames that this server is known by / is used to access.
 Wildcards, slash notation and ports are not supported.
 Do not remove this, as it performs necessary security checks.
 Please consider that for backend processes like background jobs or occ commands,
 the URL parameter in key `overwrite.cli.url` is used. For more details, please see that key.
 
 NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be
-a comma delimited list without white space. like `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.
+a comma-delimited list without white spaces, like `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.
 Wildcards, slash notation and ports are not supported.
 
 ==== Code Sample

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -60,9 +60,16 @@ passwords. This example is for documentation only, and you should never use it.
 === Define list of trusted domains that users can log into
 Specifying trusted domains prevents host header poisoning.
 
+This parameter reperesents a white list of approved IP addresses and
+hostnames that this server is known by / is used to access it.
+Wildcards, slash notation and ports are not supported.
 Do not remove this, as it performs necessary security checks.
 Please consider that for backend processes like background jobs or occ commands,
 the URL parameter in key `overwrite.cli.url` is used. For more details, please see that key.
+
+NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be
+a comma delimited list without white space. like `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.
+Wildcards, slash notation and ports are not supported.
 
 ==== Code Sample
 

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -44,7 +44,7 @@ docker exec --user www-data <owncloud-container-name> occ <your-command>
 
 NOTE: The commands and links provided in the following descriptions are intended to showcase basic docker usage, but we cannot take responsibility for their proper functioning.
 
-For testing purposes or a quick hands-on to get familiar with the look and feel, ownCloud provides a container using the SQLite database. Note that SQLite is not supported by ownCloud for production purposes. To setup such a testing instance, run the following command:
+For testing purposes or a quick hands-on to get familiar with the look and feel, ownCloud provides a container using the SQLite database. Note that SQLite is not supported by ownCloud for production purposes. To set up such a testing instance, run the following command:
 
 [source,docker,subs="attributes+"]
 ----

--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -29,10 +29,7 @@ Grant docker command privileges to certain users by adding them to the group `do
 sudo usermod -aG docker <your-user>
 ----
 
-[NOTE]
-====
-The changes via `usermod` only take effect after the docker users log in. So you may have to log out and log in again or possibly reboot before you can run docker commands.
-====
+NOTE: The changes via `usermod` only take effect after the docker users log in. So you may have to log out and log in again or possibly reboot before you can run docker commands.
 
 Users not added to the `docker` group can run docker commands with a preceding `sudo`. In this section `sudo` is generally omitted before docker commands since we assume you have created a docker user, which is also the only way to run ownCloud's command-line interface `occ` in a docker container. For more information on `occ`, see section xref:configuration/server/occ_command.adoc[Using the occ Command].
 
@@ -46,7 +43,8 @@ docker exec --user www-data <owncloud-container-name> occ <your-command>
 == Quick Evaluation
 
 NOTE: The commands and links provided in the following descriptions are intended to showcase basic docker usage, but we cannot take responsibility for their proper functioning.
-If you only want to take a peek and are content with SQLite as database, which is not supported by ownCloud for production purposes, try the following:
+
+For testing purposes or a quick hands-on to get familiar with the look and feel, ownCloud provides a container using the SQLite database. Note that SQLite is not supported by ownCloud for production purposes. To setup such a testing instance, run the following command:
 
 [source,docker,subs="attributes+"]
 ----
@@ -64,9 +62,9 @@ With the command `docker ps` you can list your running docker containers and sho
 
 You can log in to your ownCloud instance via a browser at `pass:a[http://localhost:{std-port-http}]` with the preconfigured user `admin` and password `admin`.
 
-NOTE: Access only works with http, not https.
+NOTE: Access only works locally with http, not https.
 
-Now, if you like what you see but want a supported installation with MariaDB, you should remove the eval version before proceeding with the next section.
+If the outcome meets the expectations but a supported installation with MariaDB is targeted, remove the eval version before proceeding with the next section.
 
 [source,docker]
 ----
@@ -80,7 +78,7 @@ This removes the container if you used the option `--rm` as suggested in the exa
 docker rm oc-eval
 ----
 
-If you now run `docker ps` again, the entry for oc-eval should be gone.
+When running `docker ps` again, the entry for `oc-eval` should be gone.
 
 == Docker Compose
 
@@ -90,7 +88,7 @@ The configuration:
 * Uses separate _MariaDB_ and _Redis_ containers.
 * Mounts the data and MySQL data directories on the host for persistent storage.
 
-The following instructions assume you install locally. For remote access, the value of xref:configuration/server/config_sample_php_parameters.adoc#override-cli-url[OWNCLOUD_DOMAIN] and xref:configuration/server/config_sample_php_parameters.adoc#define-list-of-trusted-domains-that-users-can-log-into[OWNCLOUD_TRUSTED_DOMAINS] must be adapted.
+The following instructions assume you install locally. For remote access, the value of xref:configuration/server/config_sample_php_parameters.adoc#override-cli-url[OWNCLOUD_DOMAIN] and xref:configuration/server/config_sample_php_parameters.adoc#define-list-of-trusted-domains-that-users-can-log-into[OWNCLOUD_TRUSTED_DOMAINS] must be updated to represent the hostname(s) and/or IP addresses that the server is reachable at.
 
 . Create a new project directory.
 +


### PR DESCRIPTION
Supercedes: #1184 (Update docs pertaining to the use of 'OWNCLOUD_TRUSTED_DOMAINS') 

* Update config.sample file via a `config-to-docs` run
* Update the docker description

Backport to 10.13 and 10.12