### PR TITLE
Config-to-Docs run

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
@@ -26,7 +26,7 @@ These configurations may conflict with identical keys already set in additional 
 
 == App: Activity
 
-Possible keys: `activity_expire_days` DAYS
+Possible key: `activity_expire_days` DAYS
 
 === Define the retention for activities of the activity app
 
@@ -39,9 +39,9 @@ Possible keys: `activity_expire_days` DAYS
 
 == App: Admin Audit
 
-Possible keys: `log.conditions` ARRAY
+Possible key: `log.conditions` ARRAY
 
-Possible keys: `admin_audit.groups` ARRAY
+Possible key: `admin_audit.groups` ARRAY
 
 === Configure the path to the log file
 
@@ -69,9 +69,9 @@ Possible keys: `admin_audit.groups` ARRAY
 
 == App: Files Antivirus
 
-Possible keys: `files_antivirus.av_path` STRING
+Possible key: `files_antivirus.av_path` STRING
 
-Possible keys: `files_antivirus.av_cmd_options` STRING
+Possible key: `files_antivirus.av_cmd_options` STRING
 
 === Default path to the _clamscan_ command line anti-virus scanner.
 
@@ -99,7 +99,7 @@ See the documentation for more details.
 
 == App: Files Versions
 
-Possible keys: `versions_retention_obligation` STRING
+Possible key: `versions_retention_obligation` STRING
 
 Use following values to configure the retention behaviour. Replace `D` with the number of days.
 
@@ -125,11 +125,11 @@ Disable Versions; no files will be deleted.
 
 == App: Firstrunwizard
 
-Possible keys: `customclient_desktop` URL
+Possible key: `customclient_desktop` URL
 
-Possible keys: `customclient_android` URL
+Possible key: `customclient_android` URL
 
-Possible keys: `customclient_ios` URL
+Possible key: `customclient_ios` URL
 
 === Define the download links for ownCloud clients
 Configuring the download links for ownCloud clients,
@@ -149,15 +149,15 @@ as seen in the first-run wizard and on Personal pages
 
 == App: Kerberos
 
-Possible keys: `kerberos.keytab` STRING
+Possible key: `kerberos.keytab` STRING
 
-Possible keys: `kerberos.suppress.timeout` INTEGER
+Possible key: `kerberos.suppress.timeout` INTEGER
 
-Possible keys: `kerberos.domain` STRING
+Possible key: `kerberos.domain` STRING
 
-Possible keys: `kerberos.login.buttonName` STRING
+Possible key: `kerberos.login.buttonName` STRING
 
-Possible keys: `kerberos.login.autoRedirect` BOOL
+Possible key: `kerberos.login.autoRedirect` BOOL
 
 === Kerberos keytab File Location
 Path to the 'keytab' file to use, defaults to '/etc/krb5.keytab'.
@@ -213,9 +213,9 @@ If set to true, the login page will immediately try to log in via Kerberos.
 
 == App: LDAP
 
-Possible keys: `ldapIgnoreNamingRules` `doSet` or `false`
+Possible key: `ldapIgnoreNamingRules` `doSet` or `false`
 
-Possible keys: `user_ldap.enable_medial_search` BOOL
+Possible key: `user_ldap.enable_medial_search` BOOL
 
 === Define parameters for the LDAP app
 
@@ -229,7 +229,7 @@ Possible keys: `user_ldap.enable_medial_search` BOOL
 
 == App: Market
 
-Possible keys: `appstoreurl` URL
+Possible key: `appstoreurl` URL
 
 === Define the download URL for apps
 
@@ -244,7 +244,7 @@ Possible keys: `appstoreurl` URL
 
 Note: This app is for Enterprise customers only.
 
-Possible keys: `metrics_shared_secret` STRING
+Possible key: `metrics_shared_secret` STRING
 
 === Secret to use the Metrics dashboard
 You have to set a Metrics secret to use the dashboard. You cannot use the dashboard
@@ -265,17 +265,17 @@ config.php file. Please see the occ command documentation for more information.
 
 Note: This app is for Enterprise customers only.
 
-Possible keys: `wopi.token.key` STRING
+Possible key: `wopi.token.key` STRING
 
-Possible keys: `wopi.proxy.key` STRING
+Possible key: `wopi.proxy.key` STRING
 
-Possible keys: `wopi.office-online.server` URL
+Possible key: `wopi.office-online.server` URL
 
-Possible keys: `wopi_group` STRING
+Possible key: `wopi_group` STRING
 
-Possible keys: `wopi.proxy.url` URL
+Possible key: `wopi.proxy.url` URL
 
-Possible keys: `wopi.business-flow.enabled` STRING
+Possible key: `wopi.business-flow.enabled` STRING
 
 === Random Keys Created by the ownCloud Admin
 Both, `wopi.token.key` and `wopi.proxy.key` are random keys created by the ownCloud admin.
@@ -347,7 +347,7 @@ To use this option, you need at least ownCloud’s Microsoft Office Online app v
 
 == App: Microsoft Teams Bridge
 
-Possible keys: `msteamsbridge` ARRAY
+Possible key: `msteamsbridge` ARRAY
 
 Sub key: `loginButtonName` STRING
 
@@ -368,9 +368,9 @@ name can be freely set based on your requirements.
 
 == App: OpenID Connect (OIDC)
 
-Possible keys: `openid-connect` ARRAY
+Possible key: `openid-connect` ARRAY
 
-Possible keys: `openid-connect.basic_auth_guest_only` BOOL
+Possible key: `openid-connect.basic_auth_guest_only` BOOL
 
 
 **Configure OpenID Connect - all possible sub-keys**
@@ -577,7 +577,7 @@ another auth mechanisms (such as OIDC).
 
 == App: Richdocuments
 
-Possible keys: `collabora_group` STRING
+Possible key: `collabora_group` STRING
 
 === Define the group name for users allowed to use Collabora
 Please note, only one group can be defined. Default = empty = no restriction.
@@ -591,7 +591,7 @@ Please note, only one group can be defined. Default = empty = no restriction.
 
 == App: S3 Primary Object Storage
 
-Possible keys: `objectstore` ARRAY
+Possible key: `objectstore` ARRAY
 
 === Configure the access parameters for a particular S3 provider.
 
@@ -615,132 +615,43 @@ See the "S3 Compatible Object Storage as Primary Storage Location" documentation
 
 Note: This app is for Enterprise customers only.
 
-Possible keys: `wnd.listen.reconnectAfterTime` INTEGER
+Possible key: `wnd.activity.registerExtension` BOOL
 
-Possible keys: `wnd.logging.enable` BOOL
+Possible key: `wnd.activity.sendToSharees` BOOL
 
-Possible keys: `wnd.fileInfo.parseAttrs.mode` STRING
+Possible key: `wnd.connector.opts.timeout` INTEGER
 
-Possible keys: `wnd.in_memory_notifier.enable` BOOL
+Possible key: `wnd.errorCodes.passwordReset` ARRAY
 
-Possible keys: `wnd.permissionmanager.cache.size` INTEGER
+Possible key: `wnd.fileInfo.parseAttrs.mode` STRING
 
-Possible keys: `wnd2.cachewrapper.ttl` INTEGER
+Possible key: `wnd.groupmembership.checkUserFirst` BOOL
 
-Possible keys: `wnd.activity.registerExtension` BOOL
+Possible key: `wnd.in_memory_notifier.enable` BOOL
 
-Possible keys: `wnd.activity.sendToSharees` BOOL
+Possible key: `wnd.kerberos.servers` ARRAY
 
-Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
+Possible key: `wnd.listen_events.smb_acl` BOOL
 
-Possible keys: `wnd.connector.opts.timeout` INTEGER
+Possible key: `wnd.listen.reconnectAfterTime` INTEGER
 
-Possible keys: `wnd2.cachewrapper.normalize` BOOL
+Possible key: `wnd.logging.enable` BOOL
+
+Possible key: `wnd.permissionmanager.cache.size` INTEGER
+
+Possible key: `wnd2.cachewrapper.normalize` BOOL
+
+Possible key: `wnd2.cachewrapper.ttl` INTEGER
 
 *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely.
-
-=== Mandatory Listener Reconnect to the Database
-The listener will reconnect to the DB after given seconds. This will
-prevent the listener to crash if the connection to the DB is closed after
-being idle for a long time.
-
-==== Code Sample
-
-[source,php]
-....
-'wnd.listen.reconnectAfterTime' => 28800,
-....
-
-=== Enable Additional Debug Logging for the WND App
-
-==== Code Sample
-
-[source,php]
-....
-'wnd.logging.enable' => false,
-....
-
-=== The Way File Attributes for Folders and Files will be Handled
-There are 3 possible values: "none", "stat" and "getxattr":
-
-- "stat". This is the default if the option is missing or has an invalid value.
-  This means that the file attributes will be evaluated only for files, NOT for folders.
-  Folders will be shown even if the "hidden" file attribute is set.
-
-- "none". This means that the file attributes won't be evaluated in any case. Both
-  hidden files and folders will be shown, and you can write on read-only files
-  (the action is available in ownCloud, but it will fail in the SMB server).
-
-- "getxattr". This means that file attributes will always be evaluated. However, due to
-  problems in recent libsmbclient versions (4.11+, it might be earlier) it will cause
-  malfunctions in ownCloud; permissions are wrongly evaluated. So far, this mode works
-  with libsmbclient 4.7 but not with 4.11+ (not tested with any version in between).
-
-Note that the ACLs (if active) will be evaluated and applied on top of this mechanism.
-
-==== Code Sample
-
-[source,php]
-....
-'wnd.fileInfo.parseAttrs.mode' => 'stat',
-....
-
-=== Enable or Disable the WND In-Memory Notifier for Password Changes
-Having this feature enabled implies that whenever a WND process detects a
-wrong password in the storage - maybe the password has changed in the
-backend - all WND storages that are in-memory will be notified in order to reset
-their passwords if applicable and not to requery again.
-
-The intention is to prevent a potential password lockout for the user in the backend.
-As with PHP lower than 7.4, this feature can take a lot of memory resources.
-This is because WND keeps the storage access and its caches in-memory.
-With PHP 7.4 or above, the memory usage has been reduced significantly.
-Alternatively, you can disable this feature completely.
-
-==== Code Sample
-
-[source,php]
-....
-'wnd.in_memory_notifier.enable' => true,
-....
-
-=== Maximum Number of Items for the Cache Used by the WND Permission Managers
-A higher number implies that more items are allowed, increasing the memory usage.
-
-Real memory usage per item varies because it depends on the path being cached.
-Note that this is an in-memory cache used per request.
-Multiple mounts using the same permission manager will share the same
-cache, limiting the maximum memory that will be used.
-
-==== Code Sample
-
-[source,php]
-....
-'wnd.permissionmanager.cache.size' => 512,
-....
-
-=== TTL for the WND2 Caching Wrapper
-Time to Live (TTL) in seconds to be used to cache information for the WND2 (collaborative)
-cache wrapper implementation. The value will be used by all WND2 storages. Although the
-cache isn't exactly per user but per storage id, consider the cache to be per user, because
-it will be like that for common use cases. Data will remain in the cache and won't
-be removed by ownCloud. Aim for a low TTL value in order to not fill the memcache
-completely. In order to properly disable caching, use -1 or any negative value. 0 (zero)
-isn't considered a valid TTL value and will also disable caching.
-
-==== Code Sample
-
-[source,php]
-....
-'wnd2.cachewrapper.ttl' => 1800,  // 30 minutes
-....
 
 === Enable to Push WND Events to the Activity App
 Register WND as extension into the Activity app in order to send information about what
 the `wnd:process-queue` command is doing. The activity sent will be based on what
 the `wnd:process-queue` detects, and the activity will be sent to each affected user. There
-won't be any activity being sent outside of the `wnd:process-queue` command. `wnd:listen` +
-`wnd:process-queue` + `activity app` are required for this to work properly. See `wnd.activity.sendToSharees`
+won't be any activity being sent outside of the `wnd:process-queue` command.
+
+`wnd:listen` + `wnd:process-queue` + `activity app` are required for this to work properly. See `wnd.activity.sendToSharees`
 below for information on how to send activities for shared resources. Please consider
 that this can have a performance impact when changes are sent to many users.
 
@@ -764,6 +675,71 @@ be ignored. This flag depends on the `wnd.activity.registerExtension` and has th
 'wnd.activity.sendToSharees' => false,
 ....
 
+=== The Timeout (in ms) for All the Operations Against the Backend
+The same timeout will be applied for all the connections.
+
+Increase it if requests to the server sometimes time out. This can happen when SMB3
+encryption is selected and smbclient is overwhelming the server with requests.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.connector.opts.timeout' => 20000,  // 20 seconds
+....
+
+=== Reset the Password When Receiving Any of the Following Error Codes.
+
+By default, we will reset the password with error code 13, which means
+access denied. Depending on circumstances, you might want to add the
+error code 1, which means an operation not permitted (although there could
+be cases where this "operation not permitted" might not be caused by a wrong
+password).
+
+Some examples:
+
+- `'wnd.errorCodes.passwordReset' => [13],`
+- `'wnd.errorCodes.passwordReset' => [13, 1],`
+
+The password reset feature can be disabled by providing an empty list
+
+- `'wnd.errorCodes.passwordReset' => [],`
+
+Note that disabling the password reset feature can lead to an account lockout
+if such feature is enabled in the target windows / samba machine.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.errorCodes.passwordReset' => [13],
+....
+
+=== The Way File Attributes for Folders and Files will be Handled
+There are 3 possible values: `none`, `stat` and `getxattr`:
+
+- `stat`. This is the default if the option is missing or has an invalid value.
+  This means that the file attributes will be evaluated only for files, NOT for folders.
+  Folders will be shown even if the "hidden" file attribute is set.
+
+- `none`. This means that the file attributes won't be evaluated in any case. Both
+  hidden files and folders will be shown, and you can write on read-only files
+  (the action is available in ownCloud, but it will fail in the SMB server).
+
+- `getxattr`. This means that file attributes will always be evaluated. However, due to
+  problems in recent libsmbclient versions (4.11+, it might be earlier) it will cause
+  malfunctions in ownCloud; permissions are wrongly evaluated. So far, this mode works
+  with libsmbclient 4.7 but not with 4.11+ (not tested with any version in between).
+
+Note that the ACLs (if active) will be evaluated and applied on top of this mechanism.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.fileInfo.parseAttrs.mode' => 'stat',
+....
+
 === Make the Group Membership Component Assume that the ACL Contains a User
 The WND app doesn't know about the users or groups associated with ACLs. This
 means that an ACL containing "admin" might refer to a user called "admin" or a
@@ -785,18 +761,140 @@ recommended to enable this option only if there are a high number of ACLs target
 'wnd.groupmembership.checkUserFirst' => false,
 ....
 
-=== The timeout (in ms) for all the operations against the backend.
+=== Enable or Disable the WND In-Memory Notifier for Password Changes
+Having this feature enabled implies that whenever a WND process detects a
+wrong password in the storage - maybe the password has changed in the
+backend - all WND storages that are in-memory will be notified in order to reset
+their passwords if applicable and not to requery again.
 
-The same timeout will be applied for all the connections.
-
-Increase it if requests to the server sometimes time out. This can happen when SMB3
-encryption is selected and smbclient is overwhelming the server with requests.
+The intention is to prevent a potential password lockout for the user in the backend.
+As with PHP lower than 7.4, this feature can take a lot of memory resources.
+This is because WND keeps the storage access and its caches in-memory.
+With PHP 7.4 or above, the memory usage has been reduced significantly.
+Alternatively, you can disable this feature completely.
 
 ==== Code Sample
 
 [source,php]
 ....
-'wnd.connector.opts.timeout' => 20000,  // 20 seconds
+'wnd.in_memory_notifier.enable' => true,
+....
+
+=== A Map of Servers With the Required Kerberos Data
+
+A map of servers with the required data to get the Kerberos credentials
+in order to access them.
+
+Each key of the map must be unique and identifies a server. This ID will
+be used in the web UI to configure the mount points to use the Kerberos
+authentication. You can use any ID (choose one meaningful and easy to remember).
+
+The data contained in each key is as follows:
+
+- `ockeytab` (required): The location of the keytab file that ownCloud
+will use to access to the mounts using that server ID. The keytab must
+be for a service account with special privileges, in particular, it must
+be able to impersonate the users. It is highly recommended that the password
+for this service account doesn't expire, otherwise you will have to replace
+the file manually before the expiration.
+
+- `ocservice` (required): The name of the service of the account. This matches
+the SPN of the Windows / Samba account. It usually is in the form "HTTP/<server>",
+but it might be different.
+
+- `usermapping` (optional): The ownCloud-to-windows user mapping to be used. See below
+for available options. If no user mapping is provided, the `Noop` mapping will
+be used. The mapping data contains the type of mapping and the parameters, if any.
+
+- `ccachettl` (optional): The time (in seconds) that the credential cache
+will be considered as valid from the ownCloud's side. This TTL MUST be
+lower than the actual TTL. Once the TTL is over, new credentials will be
+requested automatically. The default TTL is 9 hours, which is less than
+the 10 hours set by Windows by default.
+
+Available mapping types:
+
+- `Noop`: Do not perform any mapping. The ownCloud user ID will be
+returned without changes, so it's expected that the ownCloud user ID
+matches the Windows / Samba user ID.
+
+- `RemoveDomain`: Remove the domain (if any) from the ownCloud user ID.
+This means that "user001@my.dom.com" will map to "user001". Note that
+it's assumed that all users belong to the same domain, otherwise
+"user001@my.dom.com" will be mapped to the same windows user as
+"user001@not.mine.eu".
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.kerberos.servers' => [
+  'server1' => [
+	'ockeytab' => '/var/www/owncloud/octest1.mountain.tree.prv.keytab',
+	'ocservice' => 'HTTP/octest1.mountain.tree.prv',
+	'usermapping' => ['type' => 'Noop'],
+	'ccachettl' => 60 * 60 * 9,
+  ],
+  'server11' => [
+	'ockeytab' => '/var/www/owncloud/octest1.mountain.tree.prv.keytab',
+	'ocservice' => 'HTTP/octest1.mountain.tree.prv',
+	'usermapping' => ['type' => 'RemoveDomain'],
+	'ccachettl' => 60 * 60 * 9,
+  ],
+  'server2' => [
+	'ockeytab' => '/var/www/owncloud/octest0.desert.sand.prv.keytab',
+	'ocservice' => 'HTTP/octest0.desert.sand.prv',
+	'usermapping' => ['type' => 'CustomFile', 'params' => ['mapfile' => '/var/www/owncloud/ocwin_krb5_map.json']],
+	'cachettl' => 3600,
+  ],
+],
+....
+
+=== Listen to the Events Triggered by the smb_acl App
+The current use is to update the WND storages (with "login credentials,
+saved in DB" authentication) when an ACL changes via the smb_acl app
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.listen_events.smb_acl' => false,
+....
+
+=== Mandatory Listener Reconnect to the Database
+The listener will reconnect to the DB after given seconds. This will
+prevent the listener to crash if the connection to the DB is closed after
+being idle for a long time.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.listen.reconnectAfterTime' => 28800,
+....
+
+=== Enable Additional Debug Logging for the WND App
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.logging.enable' => false,
+....
+
+=== Maximum Number of Items for the Cache Used by the WND Permission Managers
+A higher number implies that more items are allowed, increasing the memory usage.
+
+Real memory usage per item varies because it depends on the path being cached.
+Note that this is an in-memory cache used per request.
+Multiple mounts using the same permission manager will share the same
+cache, limiting the maximum memory that will be used.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd.permissionmanager.cache.size' => 512,
 ....
 
 === Manage UTF-8 Glyph Normalization on macOS
@@ -819,11 +917,27 @@ As a mandatory prerequisite, the mount point setting `Compatibility with Mac NFD
 'wnd2.cachewrapper.normalize' => false,
 ....
 
+=== TTL for the WND2 Caching Wrapper
+Time to Live (TTL) in seconds to be used to cache information for the WND2 (collaborative)
+cache wrapper implementation. The value will be used by all WND2 storages. Although the
+cache isn't exactly per user but per storage id, consider the cache to be per user, because
+it will be like that for common use cases. Data will remain in the cache and won't
+be removed by ownCloud. Aim for a low TTL value in order to not fill the memcache
+completely. In order to properly disable caching, use -1 or any negative value. 0 (zero)
+isn't considered a valid TTL value and will also disable caching.
+
+==== Code Sample
+
+[source,php]
+....
+'wnd2.cachewrapper.ttl' => 1800,  // 30 minutes
+....
+
 == App: Workflow / Tagging
 
 Note: This app is for Enterprise customers only.
 
-Possible keys: `workflow.retention_engine` STRING
+Possible key: `workflow.retention_engine` STRING
 
 === Provide Advanced Management of File Tagging
 Enables admins to specify rules and conditions (file size, file mimetype, group membership and more)

--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -61,14 +61,14 @@ passwords. This example is for documentation only, and you should never use it.
 Specifying trusted domains prevents host header poisoning.
 
 This parameter reperesents a white list of approved IP addresses and
-hostnames that this server is known by / is used to access.
+hostnames that this server is known by / is used to access it.
 Wildcards, slash notation and ports are not supported.
 Do not remove this, as it performs necessary security checks.
 Please consider that for backend processes like background jobs or occ commands,
 the URL parameter in key `overwrite.cli.url` is used. For more details, please see that key.
 
 NOTE: When defined via the `OWNCLOUD_TRUSTED_DOMAINS` property in docker, the values should be
-a comma-delimited list without white spaces, like `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.
+a comma delimited list without white space. like `OWNCLOUD_TRUSTED_DOMAINS=localhost,10.10.1.1`.
 Wildcards, slash notation and ports are not supported.
 
 ==== Code Sample
@@ -1222,6 +1222,11 @@ Defaults to an empty array
 		'users' => ['user1'],
 		'apps' => ['files_mediaviewer'],
 		'logfile' => '/tmp/mediaviewer.log'
+	],
+	[
+		# special sql query logging
+		'apps' => ['core/sql'],
+		'logfile' => __DIR__ . '/../data/sql.jsonl'
 	],
   ],
 ....


### PR DESCRIPTION
References: https://github.com/owncloud/core/pull/41104 (docs: add missing WND Kerberos settings to config.apps.sample)

Config to Docs run to get recent changes from core.

Backport to 10.13 and 10.12