### PR TITLE
Fix download link address for upgrades to be the same as in wget command below

### DIFF
--- a/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/manual_upgrade.adoc
@@ -83,7 +83,7 @@ If you have made changes in `.user.ini` located at the webroot of ownCloud, you 
 
 === Download the Latest Release
 
-Download the latest {oc-complete-base-url}[ownCloud server release] to the same location where your previous instance is located, in this example the default directory `/var/www/`.
+Download the latest {oc-complete-base-url}/{oc-complete-name}.tar.bz2[ownCloud Server release] to the same location where your previous instance is located, in this example the default directory `/var/www/`.
 
 [source,bash,subs="attributes+"]
 ----


### PR DESCRIPTION
On request of @voroyam to improve customer experience 😄 

Backport to 10.12 and 10.13