### PR TITLE
Fix faulty xrefs found during the antora upgrade

### DIFF
--- a/modules/admin_manual/pages/installation/apps_supported.adoc
+++ b/modules/admin_manual/pages/installation/apps_supported.adoc
@@ -9,7 +9,7 @@
 * Collaborative Tags
 * Comments
 * xref:configuration/files/encryption/encryption_configuration.adoc[Encryption]
-* xref:ration/server/external_sites.adoc[External Sites]
+* xref:configuration/server/external_sites.adoc[External Sites]
 * xref:configuration/files/external_storage/index.adoc[External Storage]
 * xref:configuration/files/federated_cloud_sharing_configuration.adoc[Federated File Sharing] (allows file sharing across ownCloud instances)
 * Federation (allows username auto-complete across ownCloud instances)


### PR DESCRIPTION
These xrefs have been identified to cause errors and needed a fix.

Backport to 10.13 and 10.12