### PR TITLE
remove references to templateeditor in email_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/email_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/email_configuration.adoc
@@ -295,7 +295,7 @@ NOTE: Immediately after pressing the btn:[Send email] button, as described befor
 
 == Using Email Templates
 
-NOTE: You have to install and enable a custom theme in order to use and customize email templates. Additionally you need to have the {oc-marketplace-url}/apps/templateeditor[Mail Template Editor] app installed and enabled.
+NOTE: You have to install and enable a custom theme in order to use and customize email templates.
 
 Most emails sent from ownCloud are based on editable email templates, which are a mixture of PHP and HTML. The currently available templates are:
 
@@ -347,16 +347,6 @@ Most emails sent from ownCloud are based on editable email templates, which are 
 | `core/templates/internalaltmail.php`
 |=======================================================================
 
-In addition to providing the email templates, this feature enables you to apply any pre-configured themes to the email. To modify an email template to users:
-
-1.  Log in as the admin user.
-2.  Navigate to menu:Settings[Admin > General > Mail Templates].
-3.  Select a template from the drop-down menu.
-+
-NOTE: If you don't see the drop down menu but instead _You need to activate own theme to edit email templates_, you haven't installed and configured a custom theme yet.
-
-4.  Make any desired modifications to the template.
-
 The templates are written in PHP and HTML, and are already loaded with the relevant variables such as _username_, _share links_, and _filenames_. You can, if you are careful, edit these — even without knowing PHP or HTML. Don’t touch any of the code, but it’s OK to edit the text portions of the messages.
 
 For example, this the lost password mail template:
@@ -380,5 +370,3 @@ If you did not ask for a password reset, ignore this message.
 ----
 
 Again, be very careful to change nothing but the message text, because the tiniest coding error will break the template.
-
-NOTE: You can edit the templates directly in the template text box, or you can copy and paste them to a text editor for modification and then copy and paste them back to the template text box for use when you are done.


### PR DESCRIPTION
The app templateeditor is dropped. All editing of templates should be done in a custom theme.

See https://github.com/owncloud/templateeditor/issues/154