### PR TITLE
Fix links mostly to the server release notes

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -105,7 +105,7 @@ ownCloud provides two encryption types:
 | *User-Key:*
 a| Every user has their own private/public key pairs, and the private key is protected by the user’s password.
 
-IMPORTANT: User-Key encryption has been deprecated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+IMPORTANT: User-Key encryption has been deprecated with https://doc.owncloud.com/docs_main/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 |===
 
 WARNING: These encryption types are *not compatible*.
@@ -284,7 +284,7 @@ You may only disable encryption by using the xref:configuration/server/occ_comma
 
 === Limitations of User-Key-Based Encryption 
 
-* Deprecated with xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
+* Deprecated with https://doc.owncloud.com/docs_main/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
 * Users added to groups cannot decrypt files on existing shares.
 * OnlyOffice will not work.
 * Impersonate will not work.

--- a/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/file_sharing_configuration.adoc
@@ -156,7 +156,7 @@ Check this option to limit the maximum expiration date to be the default. Users 
 === Automatically accept new incoming local user shares
 
 Disabling this option activates the "Pending Shares" feature. Users will be notified and have to accept new incoming user shares before they appear in the file list and are available for access giving them more control over their account. More information about
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#pending-shares[pending shares]
+https://doc.owncloud.com/docs_main/next/server_release_notes.html#pending-shares[pending shares]
 can be found in the release notes.
 
 === Allow resharing
@@ -182,7 +182,7 @@ is enabled, users can still share items with any users on any instances (_includ
 === Restrict users to only share with groups they are a member of
 
 When this option is enabled, users can only share with groups they are a member of. They can still share with all users of the instance but not with groups they are not a member of. To restrict sharing to users in groups the sharer is a member of, the option _Restrict users to only share with users in their groups_ can be used. More information about
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#more-granular-sharing-restrictions[granular sharing restrictions]
+https://doc.owncloud.com/docs_main/next/server_release_notes.html#more-granular-sharing-restrictions[granular sharing restrictions]
 can be found in the release notes.
 
 === Allow users to send mail notification for shared files to other users

--- a/modules/admin_manual/pages/configuration/user/custom_groups_app.adoc
+++ b/modules/admin_manual/pages/configuration/user/custom_groups_app.adoc
@@ -50,9 +50,8 @@ To specify the disallowed groups, list them against the `customgroups.disallowed
 
 Assigning custom group admins can only be done via the browser. In case the group admin has left the company and you need to set a different one, you temporarily must allow the xref:preventing-administrators-from-administering-custom-groups[ownCloud instance admins] access to groups if disallowed before. Then set one or more new group admins and change the instance admin setting back.
 
-
 == User Settings
 
-See the following image as example of user related settings and the xref:next@webui:classic_ui:files/webgui/custom_groups.adoc[Custom Groups] section in the user manual for details:
+See the following image as example of user related settings and the https://doc.owncloud.com/webui/next/classic_ui/personal_settings/custom_groups.html[Custom Groups] section in the user manual for details:
 
 image::configuration/user/custom_groups/user_settings_custom_groups.png[]

--- a/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/package_upgrade.adoc
@@ -11,7 +11,7 @@ IMPORTANT: This approach should not be used unattended nor in clustered setups.
 
 In general, we discourage upgrades with a Linux package manager because you might encounter unwanted side effects and you'll have to manage the PHP installation separately. For further information on upgrading PHP, see section xref:installation/manual_installation/manual_installation.adoc#prepare-your-server[Prepare Your Server]
 
-If you want to proceed anyway, read the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] for important information first.
+If you want to proceed anyway, read the https://doc.owncloud.com/docs_main/next/server_release_notes.html[release notes] for important information first.
 
 Before installing upgraded packages, perform the following steps: 
 
@@ -32,7 +32,7 @@ After the upgrade is finished, perform the following actions:
 include::partial$maintenance/major_release_note.adoc[]
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Address books please have a look at the
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc#changes-in-9-1[release notes] for important information about the needed migration steps during that upgrade.
+https://doc.owncloud.com/docs_main/next/server_release_notes.html#changes-in-9-1[release notes] for important information about the needed migration steps during that upgrade.
 
 == Upgrading Only ownCloud or the Complete System
 

--- a/modules/admin_manual/pages/maintenance/upgrading/update.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/update.adoc
@@ -8,7 +8,7 @@
 {description} It is useful for installations that do not have root access, such as shared hosting, for installations with a smaller number of users and data, and it automates xref:installation/manual_installation/manual_installation.adoc[manual installations].
 
 IMPORTANT: When upgrading from oC 9.0 to 9.1 with existing Calendars or Addressbooks please have a look at the
-xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] of oC 9.0 for important info about this migration.
+https://doc.owncloud.com/docs_main/next/server_release_notes.html[release notes] of oC 9.0 for important info about this migration.
 
 [CAUTION]
 ====

--- a/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
+++ b/modules/admin_manual/pages/maintenance/upgrading/upgrade.adoc
@@ -8,7 +8,7 @@ We recommend that you keep your ownCloud server up to date. When an update or up
 
 Before beginning an upgrade, please keep the following points in mind:
 
-* Review the xref:{latest-docs-version}@docs:ROOT:server_release_notes.adoc[release notes] for important information about the needed migration steps during that upgrade to help ensure a smooth upgrade process.
+* Review the https://doc.owncloud.com/docs_main/next/server_release_notes.html[release notes] for important information about the needed migration steps during that upgrade to help ensure a smooth upgrade process.
 * Check ownCloud's xref:installation/manual_installation/manual_installation_prerequisites.adoc[mandatory requirements] (such as PHP versions and extensions), which can change from one version to the next. Ensure that you review them and update or upgrade your server, if required, before upgrading ownCloud.
 * Upgrading is disruptive, as your ownCloud server will be put into
 xref:configuration/server/occ_command.adoc#maintenance-commands[maintenance mode].

--- a/modules/admin_manual/pages/qnap/index.adoc
+++ b/modules/admin_manual/pages/qnap/index.adoc
@@ -146,7 +146,7 @@ For more information on command-line access, see below.
 
 Besides logging in to ownCloud via the web interface, you can access it from iOS and Android devices by installing the respective apps, and there are desktop clients available for Windows, Mac OS X and various Linux distributions.
 
-For more information, check out the xref:next@docs:ROOT:client_releases.adoc[ownCloud Client Releases]
+For more information, check out the https://doc.owncloud.com/docs_main/next/client_releases.html[ownCloud App and Client Releases]
 
 == Using External Storage
 


### PR DESCRIPTION
Fix needed to get rid of xref errors because of upgrading to Antora 3.
Make them absolute references and no longer xrefs. Do not want to wait for the availability of Antora Atlas which would fix the issue.

Backport to 10.13 and 10.12