### PR TITLE
Update previews_configuration.adoc - PreviewProvider clarification

### DIFF
--- a/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
@@ -106,7 +106,7 @@ cat resources/config/mimetypemapping.dist.json | grep image
 
 == Preview Format Requirements
 
-The following providers require the php `imagick` extension:
+The following providers require the php `imagick` extension to be enabled and (check `phpinfo();`) compiled with support for these formats:
 
 [source,plaintext]
 ----

--- a/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/previews_configuration.adoc
@@ -106,7 +106,7 @@ cat resources/config/mimetypemapping.dist.json | grep image
 
 == Preview Format Requirements
 
-The following providers require the php `imagick` extension to be enabled and (check `phpinfo();`) compiled with support for these formats:
+The following providers require the php `imagick` extension to be enabled (check `phpinfo();`) and compiled with support for these formats:
 
 [source,plaintext]
 ----


### PR DESCRIPTION
Hinting at enabled imagic is not sufficient. imagic may or may not have builtin support for all of these. E.g.: Currently our docker image have an imagick that neither supports SVG nor PDF.

Compare https://github.com/owncloud/core/issues/41185