### PR TITLE
Changes necessary for the 10.14 branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "10.13"
+    latest_version = "10.14"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 10.14 branch.

* The 10.14 branch is already pushed and prepared and is included in the branch protection rules.

* When 10.14 (core) is finally out, the 10.12 branch can be archived, see step 3 in [Create a New Version Branch](https://github.com/owncloud/docs-server/blob/master/docs/new-version-branch.md)

* Note, that the 10.14 branch in this repo is already created, but the `latest` pointer on the web will be set to it automatically when the tag in core is set. This means, that in the docs homepage, `latest` will point to 10.13 until the tag in core is set accordingly. When merging this PR, 10.12 will be dropped from the web.

* Note that this PR must be merged **before** the 10.14 tag in core is set to avoid a 404 for `latest`.

* Note before merging this PR, we should take care that 10.12 has all necessary changes merged.

@pako81 @jnweiger fyi

@mmattel @EParzefall @phil-davis
Post merging this, we need to backport all relevant changes to 10.x