### PR TITLE
fix: select encryption type is obsolete

### DIFF
--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -95,20 +95,9 @@ When using a HSM, see the additional information provided at xref:configuration/
 
 == Encryption Types
 
-ownCloud provides two encryption types:
+ownCloud only provides the master key encryption type. There is only one key (or key pair) and all files are encrypted using that key pair.
 
-[width="90%",cols="20%,80%",]
-|===
-| *Master Key:*
-| There is only one key (or key pair) and all files are encrypted using that key pair.
-
-| *User-Key:*
-a| Every user has their own private/public key pairs, and the private key is protected by the user’s password.
-
-IMPORTANT: User-Key encryption has been deprecated with https://doc.owncloud.com/docs_main/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
-|===
-
-WARNING: These encryption types are *not compatible*.
+IMPORTANT: User-Key encryption has been deprecated with https://doc.owncloud.com/docs_main/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]. Existing installations using this method must xref:maintenance/encryption/migrating-from-user-key-to-master-key.adoc[migrate] to master key encryption.
 
 == Before Enabling Encryption
 
@@ -190,15 +179,6 @@ Then enable encryption, using the following command:
 {occ-command-example-prefix} encryption:enable
 ----
 
-After that, enable the master key, using the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} encryption:select-encryption-type masterkey
-----
-
-NOTE: The master key mode has to be set up in a newly created instance.
-
 Finally, encrypt all data, using the following command:
 
 [source,bash,subs="attributes+"]
@@ -274,63 +254,6 @@ Take it out of single-user mode when you are finished, by using the following co
 ====
 You may only disable encryption by using the xref:configuration/server/occ_command.adoc#encryption[occ Encryption Commands]. Make sure you have backups of all encryption keys, including those for all your users if user key encryption was selected.
 ====
-
-== User-Key-Based Encryption (Deprecated )
-
-=== Limitations of User-Key-Based Encryption 
-
-* Deprecated with https://doc.owncloud.com/docs_main/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[ownCloud release 10.7]
-* Users added to groups cannot decrypt files on existing shares.
-* OnlyOffice will not work.
-* Impersonate will not work.
-* OAuth2 will not work.
-* Elasticsearch will not work.
-* Users getting access to an external storage which already contains encrypted files cannot get access to said files for reasons such as the group case above.
-* When having data shared with a group and group membership changes after the share is established, subsequently added users will not be able to open the shared data unless the owner will share it again.
-
-=== Enabling User-Key-Based Encryption From the Command-line
-
-To avoid any issues on a running instance, put your server in single user mode with the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} maintenance:singleuser --on
-----
-
-If not already done, enable the default encryption module app, using the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} app:enable encryption
-----
-
-After that, enable encryption, using the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} encryption:enable
-----
-
-Then, enable the user-key, using the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} encryption:select-encryption-type user-keys
-----
-
-Finally, encrypt all data, using the following command:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} encryption:encrypt-all --yes
-----
-
-Now you can turn off the single user mode:
-
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} maintenance:singleuser --off
-----
 
 === View Current Encryption Status
 

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration.adoc
@@ -139,11 +139,6 @@ To enable the encryption app, run the following command:
 {occ-command-example-prefix} encryption:enable
 ----
 
-[source,bash,subs="attributes+"]
-----
-{occ-command-example-prefix} encryption:select-encryption-type masterkey -y
-----
-
 If the encryption app is successfully enabled, you should see the following confirmations:
 
 [source,plaintext]

--- a/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
+++ b/modules/admin_manual/pages/configuration/files/encryption/encryption_configuration_quick_guide.adoc
@@ -10,8 +10,7 @@ This quick guide gives a brief summary of the commands needed without going into
 
 === Overview
 
-- The **recommended** type of encryption.
-- Best to activate on new instances with no data.
+- Matef key is default when enabled on new instances.
 - If you have existing data, use the **occ encryption:encrypt-all** command. Depending on the amount of existing data and the location, this operation can take a long time.
 
 === Activate Master Key-Based Encryption
@@ -21,7 +20,6 @@ This quick guide gives a brief summary of the commands needed without going into
 {occ-command-example-prefix} maintenance:singleuser --on
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} encryption:enable
-{occ-command-example-prefix} encryption:select-encryption-type masterkey -y
 {occ-command-example-prefix} encryption:encrypt-all --yes
 {occ-command-example-prefix} maintenance:singleuser --off
 ----

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_encryption_commands.adoc
@@ -18,9 +18,9 @@ encryption
  encryption:migrate                  Initial migration to encryption 2.0
  encryption:recreate-master-key      Replace existing master key with new one. Encrypt the
                                      file system with newly created master key
- encryption:select-encryption-type   Select the encryption type. The encryption types available
-                                     are: masterkey and user-keys. There is also no way to
-                                     disable it again.
+ encryption:select-encryption-type   Select the encryption type. Only `masterkey` is available.
+                                     Note that this setting is only necessary when migration from user
+                                     key encryption. New encryptions will autmatically use master key.
  encryption:set-default-module       Set the encryption default module
  encryption:show-key-storage-root    Show current key storage root
  encryption:status                   Lists the current status of encryption

--- a/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/hsmdaemon/index.adoc
@@ -515,7 +515,6 @@ Enable the HSM mode and enable encryption by running the commands in the followi
 ----
 {occ-command-example-prefix} app:enable encryption
 {occ-command-example-prefix} config:app:set encryption hsm.url --value 'http://localhost:8513'
-{occ-command-example-prefix} encryption:select-encryption-type masterkey
 {occ-command-example-prefix} encryption:enable
 ----
 

--- a/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
+++ b/modules/admin_manual/pages/maintenance/encryption/migrating-from-user-key-to-master-key.adoc
@@ -5,16 +5,10 @@
 
 == Introduction
 
-Why should you move away from User Key-based encryption?
+IMPORTANT: User Key Encryption has been deprecated with ownCloud Server 10.7, see the corresponding https://doc.owncloud.com/server_release_notes.html#deprecation-note-for-user-key-storage-encryption[release notes] for details. Though you can continue to use this solution, it is no longer selectable and existing User Key Encryption must be migrated to Master Key Encryption.
 
-While it is a bit more secure than a central encryption approach, User key-based encryption has some disadvantages. 
-It blocks some additional functions such as the integration of an online editor like LibreOffice or OnlyOffice into
-ownCloud and can cause problems when sharing files with groups. 
-See xref:configuration/files/encryption/encryption_configuration.adoc#limitations-of-user-key-based-encryption[Limitations of User-Key Based Encryption] for more details.
-Therefore Master-key-based encryption is now the recommended setup for all new installations.
-
-NOTE: User key-based encryption is planned to be removed from ownCloud in the near future.
-As an existing customer, you will be able to continue to use this solution as long as ownCloud 10.x is supported.
+The reason disabling User key-based encryption is because of some disadvantages. It blocks some additional functions such as the integration of an online editor like LibreOffice or OnlyOffice into ownCloud and can cause problems when sharing files with groups. 
+See xref:configuration/files/encryption/encryption_configuration.adoc#limitations-of-user-key-based-encryption[Limitations of User-Key Based Encryption] for more details. Master-key-based encryption is therefore now the recommended and only available setup for all new installations.
 
 == Pre-Conditions
 
@@ -40,8 +34,7 @@ There are several steps you need to follow to ensure a smooth and complete trans
 
 === Disable User Key-based Encryption
 
-The first part of the migration process is to decrypt all files and to disable encryption in ownCloud,
-which requires three commands to be executed. These commands are:
+The first part of the migration process is to decrypt all files and to disable encryption in ownCloud, which requires three commands to be executed. These commands are:
 
 . xref:configuration/server/occ_command.adoc#encryption[`occ encryption:decrypt-all`],
 . xref:configuration/server/occ_command.adoc#encryption[`occ encryption:disable`] and
@@ -56,28 +49,22 @@ You can see an example of calling the commands listed below, configured to requi
   {occ-command-example-prefix} app:disable --no-interaction encryption
 ----
 
-NOTE: The decryption of the files by the ownCloud administrator requires the current passwords of all users!
-This only works when users have enabled password recovery and if an admin recovery password is available.
+NOTE: The decryption of the files by the ownCloud administrator requires the current passwords of all users! This only works when users have enabled password recovery and if an admin recovery password is available.
 
 === Remove the Encryption Records from the ownCloud Database
 
-Once your ownCloud files are unencrypted, and encryption has been disabled, you need to remove
-the encryption records from the database. There is, currently, no `occ` command to handle this,
-so it has to be done manually. Specifically, you need to remove all records from the `oc_appconfig`
-table where the `appid` column is set to `encryption`.
+Once your ownCloud files are unencrypted, and encryption has been disabled, you need to remove the encryption records from the database. There is, currently, no `occ` command to handle this, so it has to be done manually. Specifically, you need to remove all records from the `oc_appconfig` table where the `appid` column is set to `encryption`.
 
-In the examples below, you can see how to do this using MySQL.
-If you are not using MySQL, please use the commands specific to your database vendor.
+In the examples below, you can see how to do this using MySQL. If you are not using MySQL, please use the commands specific to your database vendor.
 
 [source,sql]
 ----
 SELECT * FROM `oc_appconfig` WHERE `appid` LIKE 'encryption'
 ----
 
-=== Remove the `files_encryption` Directory
+=== Remove the files_encryption Directory
 
-With the database updated, next, the `files_encryption` directory needs to be removed.
-Below is an example of how to do so, to save you time.
+With the database updated, next, the `files_encryption` directory needs to be removed. Below is an example of how to do so, to save you time.
 
 [source,bash]
 ----
@@ -87,8 +74,7 @@ find ./data* -name files_encryption -exec rm -rvf {} \;
 
 === Encrypt the Filesystem Using Master Key-based Encryption
 
-Now, your ownCloud files can be encrypted using Master Key-based encryption.
-This requires the following steps:
+Now, your ownCloud files can be encrypted using Master Key-based encryption. This requires the following steps:
 
 . The encryption app needs to be enabled
 . Encryption needs to be enabled
@@ -107,13 +93,15 @@ The following example shows how to do this on the command line.
 
 == Verify the Encrypted Files
 
-With the files encrypted using Master Key-based encryption, you should now verify that everything worked properly.
-To do so, run a `SELECT` query in your database which returns all files from the `oc_appconfig` table where
-the `appid` column is set to `encryption`. You should see a number of records, as in the output of the example below.
+With the files encrypted using Master Key-based encryption, you should now verify that everything worked properly. To do so, run a `SELECT` query in your database which returns all files from the `oc_appconfig` table where the `appid` column is set to `encryption`. You should see a number of records, as in the output of the example below.
 
 [source,sql]
 ----
 select * from `oc_appconfig` where appid='encryption';
+----
+
+[source,plaintext]
+----
 encryption|recoveryKeyId|recoveryKey_73facda6
 encryption|publicShareKeyId|pubShare_73facda6
 encryption|masterKeyId|master_73facda6


### PR DESCRIPTION
Only master-key is supported now so the command is not available anymore.

Related Change: https://github.com/owncloud/encryption/pull/389

Backport to 10.14 and 10.13