### PR TITLE
clarify sharing bits

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -676,8 +676,11 @@ The permissions to set on the share.
 * 2 = update;
 * 4 = create;
 * 8 = delete;
-* 15 = read/write/delete;
 * 16 = share;
+
+Common example combinations are:
+
+* 15 = read/write/delete;
 * 31 = All permissions.
 
 | expireDate

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -680,7 +680,7 @@ The permissions to set on the share.
 
 Common example combinations are:
 
-* 15 = read/write/delete;
+* 15 = read/write(update and create)/delete;
 * 31 = All permissions.
 
 | expireDate

--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -676,7 +676,7 @@ The permissions to set on the share.
 * 2 = update;
 * 4 = create;
 * 8 = delete;
-* 15 = read/write;
+* 15 = read/write/delete;
 * 16 = share;
 * 31 = All permissions.
 


### PR DESCRIPTION
It is unclear, if only the listed numbers are supported. I'd think, that 1+2+4+8+16 are meant as bit patters that can be combined as needed. 15, 31 are probably just examples.

What does 'default for public link shares' mean? Is the 1 bit always added for these? I don't think so, as this would prevent building an anonymous file drop link.

See https://central.owncloud.org/t/share-files-via-api-without-delete-permissions/49350