### PR TITLE
Revert "doc: review migrating to kiteworks"

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -34,9 +34,9 @@ At Kiteworks, the email address will be used as the user name.
 * The content of the users home directory. +
 The data of the home directory can be encrypted. In that case, data will be gathered, decrypted and transferred via a secured channel to the Kiteworks instance.
 * User shares received. +
-As long as they reference content from another user's home.
+As long they reference content from another users home.
 * User shares granted. +
-As long as they reference content from the user's home.
+As long they reference content from the users home.
 * Share permissions. +
 Will be translated into Kiteworks predefined roles.
 * Guest users. +
@@ -74,26 +74,26 @@ The following limitations impact the migration process:
 
 There are some conceptual differences between the products. See the list below for important ones _affecting the migration_ where the difference to ownCloud, if not otherwise stated, is highlighted. This list will help to identify topics addressing files, folders and shares after the migration. Note that this section does not cover using the Kiteworks instance. 
 
-* Kiteworks cannot have files in the top level of a user's home, only folders. +
+* Kiteworks cannot have files in the toplevel of a user's home, only folders. +
 The migration process will therefore copy all files from the users ownCloud home directory into a folder named `ownCloud` on the Kiteworks users top level data structure.
 
 * Kiteworks handles expiry dates for shares created differently. During a migration, expiry dates for ownCloud shares are ignored.
 
-* Shares on the ownCloud side that have been rejected by the share receiver are still potential active shares as they can be accepted at any time. This means that these shares are also migrated and the receiving share user will see them on the Kiteworks side.
+* Shares on the ownCloud side that have been rejected by the share receiver are still potential active shares as they can be accepted at any time. This means, that these shares are also migrated and the receiving share user will see them on the Kiteworks side.
 
 * In Kiteworks, received shares are shown at:
 ** Individually shared files: in the `Shared with me` sidebar, not in the main file view.
 ** Folders: in the main files view (outside of the ownCloud folder tree), but not in the `Shared with me` sidebar.
 
-* The filesystem on the Kiteworks side is _case-insensitive_.
-** Filename conflicts can happen during migration, and a migration log (csv file) will list issues that must be solved by the user.
+* The filesystem on the Kiteworks side is _case insensitive_.
+** Filename conflicts can happen during migration and a migration log (csv file) will list issues that must be solved by the user.
 
 * Kiteworks has the following files and folder naming rules:
 ** File and folder names cannot contain one of the following characters: `*:"/\|<>`.
 ** Folder names can't begin or end with a period.
 
 +
-These rules are ineffective during the migration and this helps to complete it. But it may result in syncing issues to Windows clients. Affected files and folders can be renamed by the user. Naming rules will then be automatically enforced.
+These rules are ineffective during the migration and helps to complete it. But it may result in syncing issues to Windows clients. Affected files and folders can be renamed by the user. Naming rules will then be automatically enforced.
 
 == Prerequisites
 
@@ -103,7 +103,7 @@ To be prepared for the migration, both sides need to match the prerequisites. Pl
 
 [IMPORTANT]
 ====
-* As a major prerequisite, the ownCloud instance *must* be running on release 10.14 or higher. If this requirement is not met, migration cannot be started as the necessary app checks the minimum version.
+* As a major prerequisite, the ownCloud instance *must* be running on release 10.14 or higher. If this requirement is not met, migration can not be started as the necessary app checks the minimum version.
 
 * *Shell/SSH access to your server running ownCloud* is required. +
 `occ` commands need to be issued.
@@ -120,12 +120,12 @@ The `occ migrate:to-kiteworks:verify` step will point out missing email addresse
 
 ==== Installing Required Components
 
-In all examples using the `occ` command we assume, that ownCloud is installed at `/var/www/owncloud`. Adapt the path according to your environment.
+In all examples using the `occ` command we assume, that ownCloud is installed at `/var/www/owncloud`. Adapt the path according your environment.
 
 * You must install and enable the migration app.
 ** First, copy the app into the ownClouds `apps` or `apps-external` folder, preferably the latter, if it exists.
-** Set the correct user and group permissions according to your environment.
-** Finally, enable it with the following command:
+** Set the correct user and group permissions according your environment.
+** Finally enable it with the following command:
 +
 [source,bash]
 ----
@@ -141,23 +141,23 @@ External mount points are not part of the automatic migration. See the following
 * To migrate any external mount, the https://www.kiteworks.com/enterprise-connect/[Kiteworks Enterprise Connect] license is required.
 * If an external mount is encrypted, it must be decrypted first.
 * Follow the Kiteworks instructions to (re)connect an external mount.
-* Federated shares need, by their nature, individual treatment, no general advice can be given.
+* Federated shares need by their nature individual treatment, no general advice can be given.
 
 For ease of migrating external mounts, the admin should:
 
 * For admin created mounts, make a list of mounts with their settings and their sharing configuration.
-* For user created external mounts, the administrator is responsible to instruct users how to migrate, including how to re-setup sharing.
+* For user created external mounts, the administrator is responsible to instruct users how to migrate including how to re-setup sharing.
 
 === Kiteworks
 
-* As a major prerequisite, the Kiteworks instance *must* be running on the "Venice" release or higher. If this requirement is not met, migration cannot be started.
+* As a major prerequisite, the Kiteworks instance *must* be running on the "Venice" release or higher. If this requirement is not met, migration can not be started.
 
 * You need to login into the Kiteworks appliance as role *System Admin*.
 // The kiteworks satellite service must be activated and available to the system admin user account.
 
 * The Kiteworks system must provide sufficient disk space for the data to be migrated. The ownCloud xref:migration-verification[occ migrate:to-kiteworks:verify] step will report the estimated disk space needed.
 
-* Ensure sufficient quota settings in the Kiteworks user profiles.
+* Assure sufficient quota settings in the Kiteworks user profiles.
 
 * If it is planned to integrate Kiteworks into LDAP:
 +
@@ -169,7 +169,7 @@ IMPORTANT: We recommend to have the Kiteworks PCN connected and configured to an
 * If it is planned to use a virus scanner in Kiteworks:
 +
 --
-IMPORTANT: We recommend having the Kiteworks PCN configured using a virus scanner _before_ starting the migration. This way, infected files will be put under quarantine already during migration.
+IMPORTANT: We recommend to have the Kiteworks PCN configured using a virus scanner _before_ starting the migration. This way, infected files will be put under quarantine already during migration.
 --
 
 * In the Kiteworks Admin Console, click btn:[Create Custom Application]:
@@ -191,7 +191,7 @@ Note that you only see the secret once, remember it!
 +
 These two values are needed to initialize the xref:migration-initialization[ownCloud migration app].
 
-Finally, you have the following Kiteworks values that are needed for the next steps. We recommend having them saved as shell variables for ease of use. In the upcoming examples, the following names represent the corresponding values:
+Finally, you have the following Kiteworks values that are needed for the next steps. We recommend to have them saved as shell variables for ease of use. In the upcoming examples, the following names represent the corresponding values:
 
 * Host name or IP address +
 `KW_HOST`
@@ -217,7 +217,7 @@ NOTE: Both the verification and migration command need the initialisation step u
 
 === Migration Initialization
 
-The migration initialization is a mandatory step and will create a json file that is used to create a so-called "Satellite" - a trusted partner - on the Kiteworks instance.
+The migration initialization is a mandatory step and will create a json file that is used to create a so called "Satellite" - a trusted partner - on the Kiteworks instance.
 
 [source,bash]
 ----
@@ -325,7 +325,7 @@ As you can see above, there is `Duplicate` notice for a file and another one for
 
 If there are case conflicts reported in the shell and/or the migration log, the ownCloud admin must solve them to continue the migration. 
 
-For reported conflicts, the admin should impersonate the user with the conflict and solve it by renaming the file or directory according to the Kiteworks naming rules. After fixing all open issues, the migration can be restarted and all formerly conflicted files or folders will get migrated.
+For reported conflicts, the admin should impersonate the user with the conflict and solve it by renaming the file or directory according the Kiteworks naming rules. After fixing all open issues, the migration can be restarted and all formerly conflicted files or folders will get migrated.
 
 == Tuning Transfer Performance
 
@@ -361,4 +361,4 @@ The graphs show results from a test system.
 
 * The left half of the graphs show the default setting with 4 parallel transfers.
 * The right half of the graphs first show `RCLONE_TRANSFERS=10`, then close to the end using `RCLONE_TRANSFERS=32` with peaking CPU usage at near 100%.
-* During the last section, as shown in the graphs, 100 files (total of 8 MB) were uploaded per minute. The default setting would achieve only about 20 files per minute.
+* During the last section as shown in the graphs, 100 files (total of 8 MB) were uploaded per minute. The default setting would achieve only about 20 files per minute.


### PR DESCRIPTION
Reverts owncloud/docs-server#1327

There was a conflict issue where old text sneaked in that was formerly removed.
The backports need to be deleted too and the language fixes need to be redone post merging.

@phil-davis Sorry for the inconvinience...