### PR TITLE
Config to docs run based on recent config sample changes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -1407,19 +1407,19 @@ Default is 50. Set to -1 for no limit.
 ....
 
 === Define the maximum dimensions of the original image for preview generation
-In contrast to `preview_max_x` and `preview_max_x` which define the maximum
+In contrast to `preview_max_x` and `preview_max_y` which define the maximum
 dimensions of generated previews, this setting limits the original image's size.
 
 Original images bigger than the defined dimension will not be processed.
 
 Value represents the maximum dimension in the format width x height
-Default is 6016x4000.
+Default is 6016x6016.
 
 ==== Code Sample
 
 [source,php]
 ....
-'preview_max_dimensions' => '6016x4000',
+'preview_max_dimensions' => '6016x6016',
 ....
 
 === Define the custom path for the LibreOffice / OpenOffice binary
@@ -2533,5 +2533,20 @@ This could happen in earlier versions of the openidconnect app when using the we
 [source,php]
 ....
 'loginPolicy.groupLoginPolicy.forbidMap' => [],
+....
+
+=== Enable Sending Telemetry Reports
+Telemetry data is a subset of the config report as produced by the command `occ configreport:generate`.
+
+* If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
+* If set to false, no telemetry reports are sent.
+
+Default: true
+
+==== Code Sample
+
+[source,php]
+....
+'telemetry.enabled' => true,
 ....
 


### PR DESCRIPTION
Fixes: #1347 ([QA] configreport new feature needs documentation: telemetry)

Adds changes from core into config.sample via a config to docs run.

Renders fine locally.

Backport to 10.15

Only merge if the referenced core PR from the issue is merged.