### PR TITLE
Fix two build error messages in dev docs

### DIFF
--- a/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
+++ b/modules/developer_manual/pages/core/apis/ocs-share-api.adoc
@@ -898,14 +898,23 @@ Remove the given share.
 
 [cols="20%,80%"]
 |===
-|Endpoint |`{endpoint-uri}/<share_id>`
-|Method |DELETE
+| Endpoint
+| `{endpoint-uri}/<share_id>`
+
+| Method
+| DELETE
 |===
 
 [cols=",,",options="header",]
 |===
-| Attribute | Type | Description
-| share_id | int | The share's unique id
+| Attribute
+| Type
+
+| Description
+| share_id
+
+| int
+| The share's unique id
 |===
 
 ==== Status Codes
@@ -1012,28 +1021,59 @@ include::example$core/scripts/responses/shares/delete-share-failure.xml[]
 Update a given share.
 Only one value can be updated per request.
 
-[cols=",,"]
+[cols=","]
 |===
-|Endpoint |`{endpoint-uri}/<share_id>`
-|Method |PUT
+| Endpoint
+| `{endpoint-uri}/<share_id>`
+
+| Method
+| PUT
 |===
 
 ==== Request Arguments
 
-[cols=",,",options="header",]
+[cols=",,",options="header"]
 |===
-| Argument | Type | Description
-| name | string | A (human-readable) name for the share, which can
-| | | be up to 64 characters in length
-| share_id | int | The share's unique id
-| permissions | int | Update permissions
-| | | (see xref:create-a-new-share[the create share section] above)
-| password | string | Updated password for a public link share
-| publicUpload | boolean | Enable (true) / disable (false)
-| | | public upload for public link shares.
-| expireDate | string | Set an expire date for the user, group or public link share.
-| | | This argument expects a well-formatted date string,
-| | | such as: `YYYY-MM-DD'
+| Argument
+| Type
+| Description
+
+| name
+| string
+| A (human-readable) name for the share, which can
+
+|
+|
+| be up to 64 characters in length
+
+| share_id
+| int
+| The share's unique id
+
+| permissions
+| int
+| Update permissions
+
+|
+|
+| (see xref:create-a-new-share[the create share section] above)
+
+| password
+| string
+| Updated password for a public link share
+
+| publicUpload
+| boolean
+| Enable (true) / disable (false)
+
+|
+|
+| public upload for public link shares.
+
+| expireDate
+| string
+a| Set an expire date for the user, group or public link share. +
+This argument expects a well-formatted date string such as: `YYYY-MM-DD`
 |===
 
 NOTE: Only one of the update parameters can be specified at once.

--- a/modules/developer_manual/pages/general/codingguidelines.adoc
+++ b/modules/developer_manual/pages/general/codingguidelines.adoc
@@ -172,7 +172,9 @@ The most important labels and their meaning:
 | #dev:unit_testing #dev:public_API and so on.
 | These tags indicate development-specific tools like those for testing and public developer-facing API’s impacted by the issue or which the PR is related
 
-| Feature tags: #feature:something. These tags indicate the features across apps and components which are impacted by the issue or which the PR is related to
+| Feature tags:
+| #feature:something.
+| These tags indicate the features across apps and components which are impacted by the issue or which the PR is related to
 |===
 
 === Labels showing the state of the issue or PR (numbered 1-6)


### PR DESCRIPTION
Found while testing fixing `package.json` for updating proper installation of antora (our way is outdated).

There are table warnings that tables were not correctly defined - this is fixed now.

Backporting to 10.15, 10.14 and 10.13 necessary