### PR TITLE
Change php-dev version used for Kerberos

### DIFF
--- a/modules/admin_manual/pages/enterprise/authentication/kerberos.adoc
+++ b/modules/admin_manual/pages/enterprise/authentication/kerberos.adoc
@@ -137,12 +137,12 @@ The administration server. This is typically the same as the LDAP/Active Directo
 
 * Check that you have the latest xref:installation/manual_installation/server_prep_ubuntu_22.04.adoc#updating-pear[pear] version installed.
 
-* Install, if not already done the `php-dev` environment:
+* Install, if not already done the `php-dev-<your version>` environment:
 +
 --
 [source,bash]
 ----
-sudo apt install php-dev
+sudo apt install php-dev-<your version>
 ----
 
 Check the existance of `phpize` with:


### PR DESCRIPTION
The current installation description will install all `php-dev` packages. So on newer systems this will install a complete php 8 stack as well even if there was only php 7.4 installed so far. So the description should be change to install the dev package of the appropriate version.