### PR TITLE
fix: migration is now split into sub commands

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -288,8 +288,8 @@ After all prerequisites, installations, configurations and the verification has 
 ----
 sudo -u www-data \
   php /var/www/owncloud/occ \
-  migrate:to-kiteworks \
-  $KW_ADMIN_USER
+  migrate:to-kiteworks:users \
+  $KW_ADMIN_USER [restricted]
 ----
 
 The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.


### PR DESCRIPTION
the command
occ migrate:to-kiteworks no longer exists.

The new sequence is:
1) occ migrate:to-kiteworks:init
2) occ migrate:to-kiteworks:verify
3) occ migrate:to-kiteworks:users
4) occ migrate:to-kiteworks:files
5) occ migrate:to-kiteworks:shares

I've just started a PR, this is incomplete...
The correct sequence of commands is internally locked. On can go back any type and repeat a previous command, but one cannot skip forward.

The signatures are:

 occ migrate:to-kiteworks:users --help
```
Description:
  Migrates ownCloud users to the configured Kiteworks instance. See also: https://doc.owncloud.com/server/latest/admin_manual/maintenance/migrating_to_kiteworks.html

Usage:
  migrate:to-kiteworks:users [options] [--] <kiteworks-admin> [<kiteworks-profile-for-guest-users>]

Arguments:
  kiteworks-admin                    
  kiteworks-profile-for-guest-users   [default: "restricted"]

Options:
  -k, --insecure                     
  -h, --help                         Display help for the given command. When no command is given display help for the list command
  -q, --quiet                        Do not output any message
  -V, --version                      Display this application version
      --ansi|--no-ansi               Force (or disable --no-ansi) ANSI output
  -n, --no-interaction               Do not ask any interactive question
      --no-warnings                  Skip global warnings, show command output only
  -v|vv|vvv, --verbose               Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

occ migrate:to-kiteworks:files --help
```
Description:
  Migrates ownCloud files and folders to the configured Kiteworks instance. See also: https://doc.owncloud.com/server/latest/admin_manual/maintenance/migrating_to_kiteworks.html

Usage:
  migrate:to-kiteworks:files [options] [--] <kiteworks-admin>

Arguments:
  kiteworks-admin       

Options:
  -k, --insecure        
...
```

occ migrate:to-kiteworks:shares --help
```
Description:
  Migrates ownCloud shares to the configured Kiteworks instance. See also: https://doc.owncloud.com/server/latest/admin_manual/maintenance/migrating_to_kiteworks.html

Usage:
  migrate:to-kiteworks:shares [options] [--] <kiteworks-admin>

Arguments:
  kiteworks-admin       

Options:
  -k, --insecure        
...
```

Note the new optional argument 
kiteworks-profile-for-guest-users   [default: "restricted"]
kw admins can define special profiles for guest users.