### PR TITLE
Update caching_configuration.adoc

### DIFF
--- a/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
+++ b/modules/admin_manual/pages/configuration/server/caching_configuration.adoc
@@ -203,7 +203,7 @@ To use APCu, add this line to `config.php`:
 
 [source,php]
 ----
-'memcache.local' => '\OC\Memcache\APCu',
+'memcache.locking' => '\OC\Memcache\APCu',
 ----
 
 With that done, refresh your ownCloud admin page, and the cache warning should disappear.


### PR DESCRIPTION
The code "memcache.local" does nothing and I still get the warning about using db caching. With this set to "memcache.locking" like you show for similar other configs, that is the one that worked.