### PR TITLE
Update Kiteworks migration documentation

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_command.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_command.adoc
@@ -366,6 +366,8 @@ include::./occ_commands/app_commands/_market_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_metrics_commands.adoc[leveloffset=+2]
 
+include::./occ_commands/app_commands/_migrate_to_kitworks_commands.adoc[leveloffset=+2]
+
 include::./occ_commands/app_commands/_password_policy_commands.adoc[leveloffset=+2]
 
 include::./occ_commands/app_commands/_ransomware_protection_commands.adoc[leveloffset=+2]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
@@ -1,0 +1,179 @@
+= Migrate to Kiteworks
+
+The _Migrate to Kiteworks_ app is not available on the ownCloud marketplace. If you plan a migration, get in touch with {oc-support-url}[ownCloud support] for more details.
+
+See the xref:maintenance/migrating_to_kiteworks.adoc[Migrating to Kiteworks Private Content Network] documentation for the sequence and details of the migration including the description how to get the required parameters for the commands.
+
+Note that the arguments in the description below are noted like when defining them as environment variables as proposed in the migration document.
+
+The following commands manage the migration of ownCloud to Kiteworks:
+
+[source,plaintext]
+----
+ migrate:to-kiteworks
+  migrate:to-kiteworks:init            Initialize the migration process.
+  migrate:to-kiteworks:verify          Verifies the ownCloud instance to be ready for migration.
+  migrate:to-kiteworks:users           Migrates ownCloud users to the configured Kiteworks instance.
+  migrate:to-kiteworks:files           Migrates ownCloud files and folders to the configured Kiteworks instance.
+  migrate:to-kiteworks:shares          Migrates ownCloud shares to the configured Kiteworks instance.
+  migrate:to-kiteworks:disable-users   Disables users in Kiteworks.
+----
+
+== Initialize the Migration Process
+
+To start the migration, it must be initialized first:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:init $KW_HOST $KW_APPLICATION_ID "$KW_SECRET"
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_HOST
+| The IP address, hostname or URL to reach the Kiteworks instance
+
+| $KW_APPLICATION_ID
+| Client application ID
+
+| $KW_SECRET
+| Secret key
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-f --force`
+| 
+|===
+
+== Verify That the Migration can be Started
+
+After initialisation, the migration must be verified to be ready:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:verify $KW_ADMIN_USER
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_ADMIN_USER
+| The Kiteworks admin users eMail address
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-k, --insecure`
+| Allow insecure (untrusted) certificates. Used for testing purposes.
+|===
+
+== Migrate Users
+
+After verification, migrating users can be started:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:users $KW_ADMIN_USER $KW_PROFILE_GUEST
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_ADMIN_USER
+| The Kiteworks admin users eMail address
+
+| $KW_PROFILE_GUEST
+| The Kiteworks guest user profile, defaults to "restricted"
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-k, --insecure`
+| Allow insecure (untrusted) certificates. Used for testing purposes.
+|===
+
+== Migrate Files
+
+After migrating users, migrating files can be started:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:files $KW_ADMIN_USER
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_ADMIN_USER
+| The Kiteworks admin users eMail address
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-k, --insecure`
+| Allow insecure (untrusted) certificates. Used for testing purposes.
+|===
+
+== Migrate Shares
+
+After migrating files, shares can be migrated. Note that when initiating this step, migrating files and users cant be run again:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:shares $KW_ADMIN_USER
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_ADMIN_USER
+| The Kiteworks admin users eMail address
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-k, --insecure`
+| Allow insecure (untrusted) certificates. Used for testing purposes.
+|===
+
+== Disable Users in Kiteworks
+
+After migrating shares, the final step can be processed. This is to disable migrated users in Kiteworks that are disabled in ownCloud:
+
+[source,bash,subs="attributes+"]
+----
+{occ-command-example-prefix} migrate:to-kiteworks:disable-users $KW_ADMIN_USER
+----
+
+=== Arguments
+
+[width="100%",cols="20%,70%",]
+|===
+| $KW_ADMIN_USER
+| The Kiteworks admin users eMail address
+|===
+
+=== Options
+
+[width="100%",cols="20%,70%",]
+|===
+| `-k, --insecure`
+| Allow insecure (untrusted) certificates. Used for testing purposes.
+|===

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
@@ -47,7 +47,7 @@ To start the migration, it must be initialized first:
 [width="100%",cols="20%,70%",]
 |===
 | `-f --force`
-| 
+| Normally, init is protected against accidentially overwriting an existing kiteworks connection. Use --force to do so.
 |===
 
 == Verify That the Migration can be Started

--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_migrate_to_kitworks_commands.adoc
@@ -4,7 +4,7 @@ The _Migrate to Kiteworks_ app is not available on the ownCloud marketplace. If 
 
 See the xref:maintenance/migrating_to_kiteworks.adoc[Migrating to Kiteworks Private Content Network] documentation for the sequence and details of the migration including the description how to get the required parameters for the commands.
 
-Note that the arguments in the description below are noted like when defining them as environment variables as proposed in the migration document.
+Note that the argument `$KW_ADMIN_USER` in the description below is noted like when defining it as environment variable as proposed in the migration document.
 
 The following commands manage the migration of ownCloud to Kiteworks:
 
@@ -25,20 +25,20 @@ To start the migration, it must be initialized first:
 
 [source,bash,subs="attributes+"]
 ----
-{occ-command-example-prefix} migrate:to-kiteworks:init $KW_HOST $KW_APPLICATION_ID "$KW_SECRET"
+{occ-command-example-prefix} migrate:to-kiteworks:init KW_HOST KW_APPLICATION_ID "KW_SECRET"
 ----
 
 === Arguments
 
 [width="100%",cols="20%,70%",]
 |===
-| $KW_HOST
+| KW_HOST
 | The IP address, hostname or URL to reach the Kiteworks instance
 
-| $KW_APPLICATION_ID
+| KW_APPLICATION_ID
 | Client application ID
 
-| $KW_SECRET
+| KW_SECRET
 | Secret key
 |===
 
@@ -64,7 +64,7 @@ After initialisation, the migration must be verified to be ready:
 [width="100%",cols="20%,70%",]
 |===
 | $KW_ADMIN_USER
-| The Kiteworks admin users eMail address
+| The Kiteworks admin users email address
 |===
 
 === Options
@@ -89,9 +89,9 @@ After verification, migrating users can be started:
 [width="100%",cols="20%,70%",]
 |===
 | $KW_ADMIN_USER
-| The Kiteworks admin users eMail address
+| The Kiteworks admin users email address
 
-| $KW_PROFILE_GUEST
+| KW_PROFILE_GUEST
 | The Kiteworks guest user profile, defaults to "restricted"
 |===
 
@@ -117,7 +117,7 @@ After migrating users, migrating files can be started:
 [width="100%",cols="20%,70%",]
 |===
 | $KW_ADMIN_USER
-| The Kiteworks admin users eMail address
+| The Kiteworks admin users email address
 |===
 
 === Options
@@ -142,7 +142,7 @@ After migrating files, shares can be migrated. Note that when initiating this st
 [width="100%",cols="20%,70%",]
 |===
 | $KW_ADMIN_USER
-| The Kiteworks admin users eMail address
+| The Kiteworks admin users email address
 |===
 
 === Options
@@ -167,7 +167,7 @@ After migrating shares, the final step can be processed. This is to disable migr
 [width="100%",cols="20%,70%",]
 |===
 | $KW_ADMIN_USER
-| The Kiteworks admin users eMail address
+| The Kiteworks admin users email address
 |===
 
 === Options

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -196,7 +196,7 @@ Note that you only see the secret once, remember it!
 +
 These two values are needed to initialize the xref:migration-initialization[ownCloud migration app].
 
-Finally, you have the following Kiteworks values that are needed for the next steps. We recommend having them saved as shell variables for ease of use. In the upcoming examples, the following names represent the corresponding values:
+Finally, you have the following Kiteworks values that are needed for the next steps. In the upcoming examples, the following names represent the corresponding values:
 
 * Host name or IP address +
 `KW_HOST`
@@ -209,6 +209,8 @@ Finally, you have the following Kiteworks values that are needed for the next st
 
 * Secret key +
 `KW_SECRET`
+
+NOTE: We recommend having the values saved as shell variables as proposed for ease of use in the following commands. 
 
 == Migration Steps
 
@@ -223,6 +225,8 @@ After the above prerequisites have been met, the migration process can be starte
 ** Disable users
 
 NOTE: Both the verification and migration commands need the initialisation step upfront to properly communicate with the Kiteworks instance.
+
+Details for commands used can be found in the xref:configuration/server/occ_command.adoc#migrate-to-kiteworks[Migrate to Kiteworks] occ command description.
 
 === Migration Initialization
 
@@ -303,7 +307,6 @@ After all prerequisites, installations, configurations and the verification has 
 
 The migration step transferring files will naturally take its time depending on the amount of data and bandwidth available. All other steps will complete relative quickly as only metadata is transferred.
 
-
 Note that the migration of users and especially files can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped.
 
 ==== Migrate Users
@@ -315,8 +318,11 @@ Issue the following command to start migrating users:
 sudo -u www-data \
   php /var/www/owncloud/occ \
   migrate:to-kiteworks:users \
-  $KW_ADMIN_USER
+  $KW_ADMIN_USER \
+  $KW_PROFILE_GUEST (optional)
 ----
+
+Note that you can optionally add a Kiteworks guest user profile that will be assigned to guest users defined in owncloud when migrating.
 
 The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
 

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -23,7 +23,7 @@ The migration process consists of these steps:
 * Verify upcoming migration steps.
 * Run the migration.
 
-For the planning, the ownCloud instance can stay productive during the migration process. Migration can be interrupted and restarted. For the final step, before shutting down the ownCloud instance, it is recommended to put it into maintenance mode to have a clean final transfer.
+For the planning, the ownCloud instance can stay productive during the migration process. Migration can be interrupted and restarted. For the last step, which is migrating shares, you must put the instance into maintenance mode to have a clean final transfer. Afterwards you can finally shut down the ownCloud instance.
 
 === Migrated Items
 
@@ -31,16 +31,18 @@ The following items will be migrated. In some cases, special rules apply as note
 
 * Ordinary users. +
 At Kiteworks, the email address will be used as the user name.
+* Guest users. +
+Will be translated into Kiteworks user profile `restricted`.
+* Disabled users. +
+Disabled users cant login, but may contain shares to be migrated.
 * The content of the users home directory. +
 The data of the home directory can be encrypted. In that case, data will be gathered, decrypted and transferred via a secured channel to the Kiteworks instance.
 * User shares received. +
 As long as they reference content from another user's home.
 * User shares granted. +
-As long as they reference content from the user's home.
+As long as they reference content from the user's home. Note that shares in the same hierarchy are only created if they have higher permissions. Shares with identical permissions are in this case not created.
 * Share permissions. +
 Will be translated into Kiteworks predefined roles.
-* Guest users. +
-Will be translated into Kiteworks user profile `restricted`.
 
 === Items Excluded from the Migration
 
@@ -169,7 +171,7 @@ IMPORTANT: We recommend having the Kiteworks PCN connected and configured to an 
 * If it is planned to use a virus scanner in Kiteworks:
 +
 --
-IMPORTANT: We recommend having the Kiteworks PCN configured using a virus scanner _before_ starting the migration. This way, infected files will be put under quarantine already during migration.
+IMPORTANT: We recommend having the Kiteworks PCN configured using a virus scanner _before_ starting the migration. This way, infected files that have not been covered by ownCloud will be put under quarantine already during migration.
 --
 
 * In the Kiteworks Admin Console, navigate to menu:Application Setup[Client and Plugins > API]. Then click btn:[Create Custom Application]:
@@ -215,8 +217,12 @@ After the above prerequisites have been met, the migration process can be starte
 * Initialization
 * Verification
 * Migration
+** Migrate users
+** Migrate files
+** Migrate shares
+** Disable users
 
-NOTE: Both the verification and migration command need the initialisation step upfront to properly communicate with the Kiteworks instance.
+NOTE: Both the verification and migration commands need the initialisation step upfront to properly communicate with the Kiteworks instance.
 
 === Migration Initialization
 
@@ -236,7 +242,7 @@ As output, a file named `mft-owncloud-migration.json` is created in the ownCloud
 
 {empty} +
 
-[role=center,width=80%,cols="^.^50%,^.^50%",options="header"]
+[.center,width=80%,cols="^.^50%,^.^50%",options="header"]
 |===
 a| Navigate to menu:System Setup[Satellite Servers] 
 a| Add a new Satellite
@@ -282,18 +288,53 @@ This instance is NOT ready to be migrated to Kiteworks!
 
 === Migration
 
-After all prerequisites, installations, configurations and the verification has passed, you can initiate the migration process. This process may take some time to copy all files to the new system. Note that a migration run can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped. For a possible improvement of transfer performance, read the xref:tuning-transfer-performance[Tuning Transfer Performance] section below. Issue the following command to start the migration:
+After all prerequisites, installations, configurations and the verification has passed, you can initiate the migration process. The migration is split into four parts which are:
+
+[,subs="+callouts,macros,attributes+"]
+----
+1. Migrate users <1>
+2. Migrate files <1>
+3. Migrate shares <2>
+4. Disable users <3>
+----
+<1> These steps migrate all ordinary, guest and disabled users and files. You can rerun these steps to migrate any items that were not part when the respective step was called. Note that the steps must be made in that order.
+<2> This step is a breaking change and migrates all shares. When this step has run, the former steps cant be run again.
+<3> This step finalizes the migration by disabling all users on Kiteworks that are disabled on ownCloud.
+
+The migration step transferring files will naturally take its time depending on the amount of data and bandwidth available. All other steps will complete relative quickly as only a few or metadata is transferred.
+
+
+Note that the migration of users and especially files can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped.
+
+==== Migrate Users
+
+Issue the following command to start migrating users:
 
 [source,bash]
 ----
 sudo -u www-data \
   php /var/www/owncloud/occ \
-  migrate:to-kiteworks \
+  migrate:to-kiteworks:users \
   $KW_ADMIN_USER
 ----
 
 The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
-During the migration process, a log file named `migrate-kiteworks-<timestamp>.csv` is created in the ownCloud root folder. This file contains:
+
+==== Migrate Files
+
+Issue the following command to start migrating files:
+
+[source,bash]
+----
+sudo -u www-data \
+  php /var/www/owncloud/occ \
+  migrate:to-kiteworks:files \
+  $KW_ADMIN_USER
+----
+
+For a possible improvement of transfer performance when migrating files, read the xref:tuning-transfer-performance[Tuning Transfer Performance] section below.
+
+The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job. During the migration process, a log file named `migrate-kiteworks-<timestamp>.csv` is created in the ownCloud root folder. This file contains:
 
 * General `rclone` responses and errors,
 * `rclone` responses for user migration,
@@ -301,7 +342,8 @@ During the migration process, a log file named `migrate-kiteworks-<timestamp>.cs
 
 If `rclone` errors at one point, it tries to finish running transfers but will stop afterwards. 
 
-.Example for migration issues reported
+Example for migration issues reported::
++
 [source,plaintext]
 ----
 Issues did arise when migrating files and folders.
@@ -312,7 +354,8 @@ Once resolved please re-run the migration process again.
 Migration will stop here now until no more conflicts exist.
 ----
 
-.Examples for case conflicts noted in the migration log file:
+Examples for case conflicts noted in the migration log file::
++
 [source,plaintext]
 ----
 NOTICE,user1,user1@example.com,"2024/04/03 15:20:27
@@ -323,6 +366,38 @@ NOTICE,user2,user2@example.com,"2024/04/03 15:20:32
 ----
 
 As you can see above, there is `Duplicate` notice for a file and another one for a directory name. `Duplicate` notices are logged for case conflicts. A conflict takes place because a file or directory that has been migrated earlier is in conflict with the name of the reported object. The conflicts for the particular users need to be resolved within ownCloud. When this is done, the migration can be restarted. `rclone` will compare both sides to identify already migrated objects and will continue with those objects that have not been migrated yet.
+
+==== Migrate Shares
+
+IMPORTANT: When running this command, you cant run the `migrate:files` command anymore!
+
+Issue the following command to start migrating shares:
+
+[source,bash]
+----
+sudo -u www-data \
+  php /var/www/owncloud/occ \
+  migrate:to-kiteworks:shares \
+  $KW_ADMIN_USER
+----
+
+The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
+
+==== Disable Users
+
+When there are disabled users on the ownCloud side, these users will be migrated as ordinary users to Kitworks but are enabled. This is due the fact that a disabled user can provide shares. As final step, run this command to disable users at Kitworks that are diabled at ownCloud.
+
+Issue the following command to start disable users:
+
+[source,bash]
+----
+sudo -u www-data \
+  php /var/www/owncloud/occ \
+  migrate:to-kiteworks:disable-users \
+  $KW_ADMIN_USER
+----
+
+The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
 
 ==== Solving Case Conflicts
 
@@ -343,7 +418,7 @@ The following example command is using 32 parallel transfers:
 sudo -u www-data \
   RCLONE_TRANSFERS=32 \
   php /var/www/owncloud/occ \
-  migrate:to-kiteworks \
+  migrate:to-kiteworks:files \
   $KW_ADMIN_USER
 ----
 
@@ -351,7 +426,7 @@ Such a setting can greatly speed up the transfer of many small files, but can al
 
 {empty} +
 
-[role=center,width=80%,cols="^.^50%,^.^50%",options="header"]
+[.center,width=80%,cols="^.^50%,^.^50%",options="header"]
 |===
 | Data IO System Utilization
 | CPU System Utilization

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -275,7 +275,8 @@ sudo -u www-data \
 
 Here are some possible verification output examples:
 
-.Example 1 - ready to migrate
+Example 1 - ready to migrate::
++
 [source,plaintext]
 ----
 Activating the Kiteworks satellite ....
@@ -286,7 +287,8 @@ Total disk storage: 13.4 MB
 Congratulations - this instance is ready to be migrated to Kiteworks!
 ----
 
-.Example 2 - failure
+Example 2 - failure::
++
 [source,plaintext]
 ----
 Activating the Kiteworks satellite ....

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -51,14 +51,18 @@ The following items are NOT migrated. These items need to be migrated manually:
 * External mounts like +
 `WND`, `SMB`, `Google Drive`, etc. +
 This includes admin mounts and user created mounts. See the xref:external-mount-points[ownCloud prerequisites] section for a special note. 
+
 * S3 primary object store (S3 for the users home) cannot be migrated for the time being.
 +
 --
 IMPORTANT: If you have configured S3 primary as your storage location for the users home, get in touch with {oc-support-url}[ownCloud support].
 --
+
 * Federated shares. +
 Federated shares are, in terms of data migration, like special external mounts, see above.
-* Public links.
+
+* Public links. +
+They are not supported on Kiteworks and skipped during the migration process.
 
 == Limitations
 
@@ -71,8 +75,6 @@ The following limitations impact the migration process:
 * When group shares have been defined, groups will not get created in Kiteworks. Instead, each member of the group will get an individual user share to the object shared.
 
 * In ownCloud, users can login either using their display name, login name or email address. Kiteworks only allows login using the email address. The presence of the users email address in ownCloud, which must be unique, is therefore a mandatory requirement.
-
-* Expiry dates for shares are not migrated.
 
 == Conceptual Differences
 
@@ -158,7 +160,7 @@ For ease of migrating external mounts, the admin should:
 
 === Kiteworks
 
-* As a major prerequisite, the Kiteworks instance *must* be running on the "Venice" release or higher.
+* As a major prerequisite, the Kiteworks instance *must* be running on the "Zion" release or higher.
 
 * You need to login into the Kiteworks appliance as role *System Admin*.
 // The kiteworks satellite service must be activated and available to the system admin user account.
@@ -207,7 +209,7 @@ Finally, you have the following Kiteworks values that are needed for the next st
 * Host name or IP address +
 `KW_HOST`
 
-* Admin users eMail address +
+* Admin users email address +
 `KW_ADMIN_USER`
 
 * Client application ID +
@@ -216,7 +218,7 @@ Finally, you have the following Kiteworks values that are needed for the next st
 * Secret key +
 `KW_SECRET`
 
-NOTE: We recommend having the values saved as shell variables as proposed for ease of use in the following commands. 
+NOTE: Consider saving `KW_ADMIN_USER` as shell variable for ease of use in the following commands. 
 
 == Migration Steps
 
@@ -243,9 +245,9 @@ The migration initialization is a mandatory step and will create a json file tha
 sudo -u www-data php \
   /var/www/owncloud/occ \
   migrate:to-kiteworks:init \
-  $KW_HOST \
-  $KW_APPLICATION_ID \
-  "$KW_SECRET"
+  KW_HOST \
+  KW_APPLICATION_ID \
+  "KW_SECRET"
 ----
 
 As output, a file named `mft-owncloud-migration.json` is created in the ownCloud root folder. Use this file now to create a new satellite on the Kiteworks instance. The satellite must be switched to STATUS btn:[ON].
@@ -293,7 +295,7 @@ Example 2 - failure::
 ----
 Activating the Kiteworks satellite ....
 Verifying users ...
-No Email for user alex - it cannot be migrated to Kiteworks!
+No email for user alex - it cannot be migrated to Kiteworks!
 Please make sure all users meet the requirements.
 This instance is NOT ready to be migrated to Kiteworks!
 ----
@@ -327,10 +329,10 @@ sudo -u www-data \
   php /var/www/owncloud/occ \
   migrate:to-kiteworks:users \
   $KW_ADMIN_USER \
-  $KW_PROFILE_GUEST (optional)
+  KW_PROFILE_GUEST (optional)
 ----
 
-Note that you can optionally add a Kiteworks guest user profile that will be assigned to guest users defined in owncloud when migrating.
+Note that you can optionally add a Kiteworks guest user profile that will be assigned to guest users defined in ownCloud when migrating. If this is not assigned, the default `restricted` will be used.
 
 The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
 
@@ -346,9 +348,9 @@ sudo -u www-data \
   $KW_ADMIN_USER
 ----
 
-For a possible improvement of transfer performance when migrating files, read the xref:tuning-transfer-performance[Tuning Transfer Performance] section below.
+// For a possible improvement of transfer performance when migrating files, read the xref:tuning-transfer-performance[Tuning Transfer Performance] section below.
 
-The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job. During the migration process, a log file named `migrate-kiteworks-<timestamp>.csv` is created in the ownCloud root folder. This file contains:
+The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job. During the migration process, a log file named `migrate-kiteworks-files.csv` is created in the ownCloud root folder. This file contains:
 
 * General `rclone` responses and errors,
 * `rclone` responses for user migration,
@@ -395,7 +397,7 @@ sudo -u www-data \
   $KW_ADMIN_USER
 ----
 
-The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job.
+The command does not require user interaction. It can be run e.g. as a screen session so that reported issues can be seen directly or as a background job. During the migration process, a log file named `migrate-kiteworks-shares.csv` is created in the ownCloud root folder.
 
 ==== Disable Users
 
@@ -419,6 +421,7 @@ If there are case conflicts reported in the shell and/or the migration log, the 
 
 For reported conflicts, the admin should impersonate the user with the conflict and solve it by renaming the file or directory according to the Kiteworks naming rules. After fixing all open issues, the migration can be restarted and all formerly conflicted files or folders will get migrated.
 
+////
 == Tuning Transfer Performance
 
 By default, rclone transfers 4 files in parallel. This creates little load on the target system, but may take a longer time to complete. This is especially true when anticipating mostly small files with sizes of about 10KB instead of large files with sizes of 10 MB or above.
@@ -454,3 +457,4 @@ The graphs show results from a test system.
 * The left half of the graphs show the default setting with 4 parallel transfers.
 * The right half of the graphs first show `RCLONE_TRANSFERS=10`, then close to the end using `RCLONE_TRANSFERS=16` with peaking CPU usage at near 100%.
 * During the last section, as shown in the graphs, 100 files (total of 8 MB) were uploaded per minute. The default setting would achieve only about 20 files per minute.
+////

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -297,11 +297,11 @@ After all prerequisites, installations, configurations and the verification has 
 3. Migrate shares <2>
 4. Disable users <3>
 ----
-<1> These steps migrate all ordinary, guest and disabled users and files. You can rerun these steps to migrate any items that were not part when the respective step was called. Note that the steps must be made in that order.
+<1> These steps migrate all ordinary, guest and disabled users and files. You can rerun these steps to migrate any items that did not exist, or failed to migrate when the respective step was called. Note that the steps must be made in that order.
 <2> This step is a breaking change and migrates all shares. When this step has run, the former steps cant be run again.
 <3> This step finalizes the migration by disabling all users on Kiteworks that are disabled on ownCloud.
 
-The migration step transferring files will naturally take its time depending on the amount of data and bandwidth available. All other steps will complete relative quickly as only a few or metadata is transferred.
+The migration step transferring files will naturally take its time depending on the amount of data and bandwidth available. All other steps will complete relative quickly as only metadata is transferred.
 
 
 Note that the migration of users and especially files can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped.
@@ -385,7 +385,7 @@ The command does not require user interaction. It can be run e.g. as a screen se
 
 ==== Disable Users
 
-When there are disabled users on the ownCloud side, these users will be migrated as ordinary users to Kitworks but are enabled. This is due the fact that a disabled user can provide shares. As final step, run this command to disable users at Kitworks that are diabled at ownCloud.
+When there are disabled users on the ownCloud side, these users will be migrated as ordinary users to Kiteworks but are enabled. This is due the fact that a disabled user can provide shares. As a final step, run this command to disable users at Kiteworks that are disabled at ownCloud.
 
 Issue the following command to start disable users:
 

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -64,6 +64,8 @@ Federated shares are, in terms of data migration, like special external mounts, 
 
 The following limitations impact the migration process:
 
+* The ownCloud migration app provided is only functional on `amd64` platforms.
+
 * While ownCloud fully respects letter casing for file and folder names, Kiteworks does not distinguish casings. If case conflicts happen during the migration process, a migration log file describing rclone responses and casing conflicts for files or directories is created. The ownCloud admin must resolve the conflicts to finalize the migration. For details see the xref:migration[Migration] description.
 
 * When group shares have been defined, groups will not get created in Kiteworks. Instead, each member of the group will get an individual user share to the object shared.

--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -40,7 +40,7 @@ The data of the home directory can be encrypted. In that case, data will be gath
 * User shares received. +
 As long as they reference content from another user's home.
 * User shares granted. +
-As long as they reference content from the user's home. Note that shares in the same hierarchy are only created if they have higher permissions. Shares with identical permissions are in this case not created.
+As long as they reference content from the user's home. A share where all permissions are already granted thru a parent folder are considered redundant and are not created.
 * Share permissions. +
 Will be translated into Kiteworks predefined roles.
 
@@ -64,40 +64,42 @@ Federated shares are, in terms of data migration, like special external mounts, 
 
 The following limitations impact the migration process:
 
-* The ownCloud migration app provided is only functional on `amd64` platforms.
+* The ownCloud migration app is only functional on `amd64` platforms.
 
-* While ownCloud fully respects letter casing for file and folder names, Kiteworks does not distinguish casings. If case conflicts happen during the migration process, a migration log file describing rclone responses and casing conflicts for files or directories is created. The ownCloud admin must resolve the conflicts to finalize the migration. For details see the xref:migration[Migration] description.
+* While ownCloud fully respects letter casing for file and folder names, Kiteworks does not distinguish casing. If case conflicts happen during the migration process, a migration log file describing rclone responses and casing conflicts for files or directories is created. The ownCloud admin must resolve the conflicts to finalize the migration. For details see the xref:migration[Migration] description.
 
 * When group shares have been defined, groups will not get created in Kiteworks. Instead, each member of the group will get an individual user share to the object shared.
 
-* Users have been able to login to ownCloud using either their display name, login name or email address. Kiteworks only allows login using the email address. The presence of the users email address in ownCloud is therefore a mandatory requirement.
+* In ownCloud, users can login either using their display name, login name or email address. Kiteworks only allows login using the email address. The presence of the users email address in ownCloud, which must be unique, is therefore a mandatory requirement.
 
-* Expiry dates for shares are not supported.
+* Expiry dates for shares are not migrated.
 
 == Conceptual Differences
 
 There are some conceptual differences between the products. See the list below for important ones _affecting the migration_ where the difference to ownCloud, if not otherwise stated, is highlighted. This list will help to identify topics addressing files, folders and shares after the migration. Note that this section does not cover using the Kiteworks instance. 
 
 * Kiteworks cannot have files in the top level of a user's home, only folders. +
-The migration process will therefore copy all files from the users ownCloud home directory into a folder named `ownCloud` on the Kiteworks users top level data structure.
+The migration process will therefore copy the entire hierarchy of the ownClouds user home into a folder named `ownCloud` on the Kiteworks users top level data structure.
 
 * Kiteworks handles expiry dates for shares created differently. During a migration, expiry dates for ownCloud shares are ignored.
 
 * Shares on the ownCloud side that have been rejected by the share receiver are still potential active shares as they can be accepted at any time. This means that these shares are also migrated and the receiving share user will see them on the Kiteworks side.
 
 * In Kiteworks, received shares are shown at:
-** Individually shared files: in the `Shared with me` sidebar, not in the main file view.
-** Folders: in the main files view (outside of the ownCloud folder tree), but not in the `Shared with me` sidebar.
+** *Individually shared files*: +
+in the `Shared with me` sidebar, not in the main file view.
+** *Folders*: +
+in the main files view (outside of the ownCloud folder tree), but not in the `Shared with me` sidebar.
 
 * The filesystem on the Kiteworks side is _case-insensitive_.
-** Filename conflicts can happen during migration, and a migration log (csv file) will list issues that must be solved by the user.
+** Filename conflicts can happen during migration, and a migration log will list issues that must be solved by the admin.
 
 * Kiteworks has the following files and folder naming rules:
-** File and folder names cannot contain one of the following characters: `*:"/\|<>`.
+** File and folder names cannot contain the following characters: `*?:"/\|<>`.
 ** Folder names can't begin or end with a period.
 
 +
-These rules are ineffective during the migration and this helps to complete it. But it may result in syncing issues to Windows clients. Affected files and folders can be renamed by the user. Naming rules will then be automatically enforced.
+These rules are ineffective during the migration and this helps to complete it. But it may result in syncing issues to Windows clients. Affected files and folders can be renamed by the user. Naming rules will then be  enforced.
 
 == Prerequisites
 
@@ -109,6 +111,8 @@ To be prepared for the migration, both sides need to match the prerequisites. Pl
 ====
 * As a major prerequisite, the ownCloud instance *must* be running on release 10.14 or higher. If this requirement is not met, migration cannot be started as the necessary app checks the minimum version.
 
+* For all migration steps, the ownCloud instance must run in normal operation mode. Migration is not possible if ownCloud is in maintenance mode.
+
 * *Shell/SSH access to your server running ownCloud* is required. +
 `occ` commands need to be issued.
 
@@ -119,7 +123,7 @@ To be prepared for the migration, both sides need to match the prerequisites. Pl
 * All users must have an email address and they must be unique. +
 The `occ migrate:to-kiteworks:verify` step will point out missing email addresses. These must be rectified before any migration can start.
 
-* We recommend installing and enabling, if not already present and enabled, the {oc-marketplace-url}/apps/impersonate[Impersonate] app. This app can be used to solve file and folder case conflicts that can be reported during the migration process.
+* We recommend installing and enabling, if not already present and enabled, the {oc-marketplace-url}/apps/impersonate[Impersonate] app. This app can be used for example to solve file and folder case conflicts that can be reported during the migration process.
 ====
 
 ==== Installing Required Components
@@ -154,7 +158,7 @@ For ease of migrating external mounts, the admin should:
 
 === Kiteworks
 
-* As a major prerequisite, the Kiteworks instance *must* be running on the "Venice" release or higher. If this requirement is not met, migration cannot be started.
+* As a major prerequisite, the Kiteworks instance *must* be running on the "Venice" release or higher.
 
 * You need to login into the Kiteworks appliance as role *System Admin*.
 // The kiteworks satellite service must be activated and available to the system admin user account.
@@ -244,7 +248,7 @@ sudo -u www-data php \
   "$KW_SECRET"
 ----
 
-As output, a file named `mft-owncloud-migration.json` is created in the ownCloud root folder. Upload this file when adding a new satellite on the Kiteworks instance. The satellite must be switched to STATUS btn:[ON].
+As output, a file named `mft-owncloud-migration.json` is created in the ownCloud root folder. Use this file now to create a new satellite on the Kiteworks instance. The satellite must be switched to STATUS btn:[ON].
 
 {empty} +
 
@@ -259,7 +263,7 @@ a| image::maintenance/migrate_kiteworks/kiteworks-new-satellite.png[Kiteworks ad
 
 === Migration Verification
 
-A potential migration *must* be verified upfront with a positive ready message as response. This command will also output the required space capacity needed on the Kiteworks side. The verify command currently cannot report problematic file or folder names. These are reported only during the migration process. Note that any issue reported must be solved and a verification needs to be redone before the final migration can start.
+A migration *must* be verified upfront with a positive ready message as response. This command will also output a rough estimate of the required space capacity needed on the Kiteworks side. The verify command currently cannot report problematic file or folder names. These are reported only during the migration process. Note that any issue reported must be solved and a verification needs to be redone before the migration can start.
 
 [source,bash]
 ----
@@ -304,12 +308,12 @@ After all prerequisites, installations, configurations and the verification has 
 4. Disable users <3>
 ----
 <1> These steps migrate all ordinary, guest and disabled users and files. You can rerun these steps to migrate any items that did not exist, or failed to migrate when the respective step was called. Note that the steps must be made in that order.
-<2> This step is a breaking change and migrates all shares. When this step has run, the former steps cant be run again.
+<2> This step is a *breaking change* and migrates all shares. When this step has run, the former steps cant be run again.
 <3> This step finalizes the migration by disabling all users on Kiteworks that are disabled on ownCloud.
 
 The migration step transferring files will naturally take its time depending on the amount of data and bandwidth available. All other steps will complete relative quickly as only metadata is transferred.
 
-Note that the migration of users and especially files can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped.
+NOTE: All migration steps, especially files, can be interrupted harmlessly at any time. Starting a new migration run will continue where the previous one stopped.
 
 ==== Migrate Users
 
@@ -377,7 +381,7 @@ As you can see above, there is `Duplicate` notice for a file and another one for
 
 ==== Migrate Shares
 
-IMPORTANT: When running this command, you cant run the `migrate:files` command anymore!
+IMPORTANT: When running this command, you cant run the `migrate:files|users` command anymore!
 
 Issue the following command to start migrating shares:
 
@@ -393,7 +397,7 @@ The command does not require user interaction. It can be run e.g. as a screen se
 
 ==== Disable Users
 
-When there are disabled users on the ownCloud side, these users will be migrated as ordinary users to Kiteworks but are enabled. This is due the fact that a disabled user can provide shares. As a final step, run this command to disable users at Kiteworks that are disabled at ownCloud.
+The migrate users step migrates all users as enabled users even they were disabled ownCloud users. This is needed so that a disabled user can provide shares. As a final step, run this command to disable users at Kiteworks that are disabled at ownCloud.
 
 Issue the following command to start disable users:
 
@@ -419,12 +423,12 @@ By default, rclone transfers 4 files in parallel. This creates little load on th
 
 Performance can be tuned with the environment variable `RCLONE_TRANSFERS` which defines the number of concurrent file uploads.
 
-The following example command is using 32 parallel transfers:
+The following example command is using 16 parallel transfers:
 
 [source,bash]
 ----
 sudo -u www-data \
-  RCLONE_TRANSFERS=32 \
+  RCLONE_TRANSFERS=16 \
   php /var/www/owncloud/occ \
   migrate:to-kiteworks:files \
   $KW_ADMIN_USER
@@ -446,5 +450,5 @@ a| image::maintenance/migrate_kiteworks/kiteworks-system-load-cpu.png[Kiteworks 
 The graphs show results from a test system.
 
 * The left half of the graphs show the default setting with 4 parallel transfers.
-* The right half of the graphs first show `RCLONE_TRANSFERS=10`, then close to the end using `RCLONE_TRANSFERS=32` with peaking CPU usage at near 100%.
+* The right half of the graphs first show `RCLONE_TRANSFERS=10`, then close to the end using `RCLONE_TRANSFERS=16` with peaking CPU usage at near 100%.
 * During the last section, as shown in the graphs, 100 files (total of 8 MB) were uploaded per minute. The default setting would achieve only about 20 files per minute.


### PR DESCRIPTION
Fixes: #1319 (Improvements to kiteworks migration guide)
Supersedes: #1362 (fix: migration is now split into sub commands)

Fixes the migration documentation based on the referenced issue.

Currently visible on [staging](https://doc.staging.owncloud.com/server/next/admin_manual/maintenance/migrating_to_kiteworks.html).