### PR TITLE
Codename Zion is internal. Use 8.6 instead

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_kiteworks.adoc
@@ -160,7 +160,7 @@ For ease of migrating external mounts, the admin should:
 
 === Kiteworks
 
-* As a major prerequisite, the Kiteworks instance *must* be running on the "Zion" release or higher.
+* As a major prerequisite, the Kiteworks instance *must* be running version 8.6 or higher.
 
 * You need to login into the Kiteworks appliance as role *System Admin*.
 // The kiteworks satellite service must be activated and available to the system admin user account.


### PR DESCRIPTION
I wasn't aware that codenames are internal use only. Sorry.