### PR TITLE
Fix including wrong filter example

### DIFF
--- a/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
+++ b/modules/developer_manual/pages/webdav_api/search/_search_files.adoc
@@ -54,9 +54,8 @@ In the example below, you can see how to filter out any file that has not been f
 
 [source,xml]
 ----
-include::example$core/webdav_api/search/request/search_files/minimal_request_body.xml[indent=0]
+include::example$core/webdav_api/search/request/filter_files/minimal_filter_files_report_request_body.xml[indent=0]
 ----
-
 
 ==== Limiting The Number Of Results Returned
 


### PR DESCRIPTION
Fixes: #1394 (Wrong code example for 'filter-rules')

Easy fix 😄 

Backport to 10.15 and 10.14