### PR TITLE
Restructure dependency warnings/notes

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -8,8 +8,6 @@
 
 {description} If you know about any issues which were not patched yet or which are not included in this list, please notify us at mailto:security@owncloud.com[].
 
-Note that automatic scanners may still report false positives for jQuery even if the CVE's have been addressed as the scanners just look for the version shipped.
-
 == Fixed Issues
 
 * jQuery

--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -2,13 +2,13 @@
 :toc:right
 :page-aliases: configuration/server/security/jquery_warnings.adoc
 
-:description: The following list of dependencies can be reported as vulnerable but either have been fixed in the ownCloud code base or do not apply.
+:description: The following list of dependencies may be reported as vulnerable but either have been fixed in the ownCloud codebase or do not apply.
 
 == Introduction
 
 {description}
 
-If you know about any issues which were not patched yet or which are not included in this list, please notify us at mailto:security@owncloud.com[].
+If you are aware of any issues that have not yet been patched or which are not included in this list, please notify us at mailto:security@owncloud.com[].
 
 == Fixed Issues
 

--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -2,13 +2,13 @@
 :toc:right
 :page-aliases: configuration/server/security/jquery_warnings.adoc
 
-:description: While ownCloud is using an older version of jQuery, we have fixed the known vulnerabilities in the patches listed below. We closely follow any security related news regarding the library for any new issues.
+:description: In some areas ownCloud is not using the latest version of dependency which could lead to vulnerabiltiy scanners to detect insecure components in ownCloud. Please find below a list of libraries which can be reported as vulnerably but have been fixed in the ownCloud code base or do not apply.
 
 == Introduction
 
-{description}
+{description} If you know about any issues which were not patched yet or which are not included in this list, please notify us at mailto:security@owncloud.com[].
 
-Note that automatic scanners may still report false positives even if the CVE's have been addressed as the scanners just look at the jQuery version shipped.
+Note that automatic scanners may still report false positives for jQuery even if the CVE's have been addressed as the scanners just look for the version shipped.
 
 == Fixed Issues
 
@@ -41,5 +41,3 @@ Component "select2" cannot be exploited
 * PDF
 ** CVE-2024-4367 +
 When app `files_pdfviewer` is enabled with xref:configuration/server/config_apps_sample_php_parameters.adoc#enable-scripting-in-pdf-files[disabled scripting], CVE-2024-4367 can not be exploited
-
-If you know about any issues which were not patched yet or which are not included in this list please notify us at mailto:security@owncloud.com[security@owncloud.com].

--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -2,11 +2,13 @@
 :toc:right
 :page-aliases: configuration/server/security/jquery_warnings.adoc
 
-:description: In some areas ownCloud is not using the latest version of dependency which could lead to vulnerabiltiy scanners to detect insecure components in ownCloud. Please find below a list of libraries which can be reported as vulnerably but have been fixed in the ownCloud code base or do not apply.
+:description: The following list of dependencies can be reported as vulnerable but either have been fixed in the ownCloud code base or do not apply.
 
 == Introduction
 
-{description} If you know about any issues which were not patched yet or which are not included in this list, please notify us at mailto:security@owncloud.com[].
+{description}
+
+If you know about any issues which were not patched yet or which are not included in this list, please notify us at mailto:security@owncloud.com[].
 
 == Fixed Issues
 

--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -1,13 +1,12 @@
-= jQuery Warnings
+= Package Dependency Notes
 :toc:right
+:page-aliases: configuration/server/security/jquery_warnings.adoc
 
 :description: While ownCloud is using an older version of jQuery, we have fixed the known vulnerabilities in the patches listed below. We closely follow any security related news regarding the library for any new issues.
 
 == Introduction
 
 {description}
-
-NOTE: *The jQuery version shipped inside ownCloud is secure.*
 
 Note that automatic scanners may still report false positives even if the CVE's have been addressed as the scanners just look at the jQuery version shipped.
 

--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -1,4 +1,4 @@
-= Package Dependency Notes
+= Dependency Notes
 :toc:right
 :page-aliases: configuration/server/security/jquery_warnings.adoc
 
@@ -34,11 +34,11 @@ https://github.com/owncloud/core/pull/39451[patched in 10.9.0]
 ** CVE-2022-31160 +
 Component "checkboxradio" is not used by ownCloud
 
+* Select2
 ** CVE-2016-10744 +
 Component "select2" cannot be exploited
 
-* Apps
-
+* PDF
 ** CVE-2024-4367 +
 When app `files_pdfviewer` is enabled with xref:configuration/server/config_apps_sample_php_parameters.adoc#enable-scripting-in-pdf-files[disabled scripting], CVE-2024-4367 can not be exploited
 

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -102,7 +102,7 @@
 ***** xref:admin_manual:configuration/server/security/password_policy.adoc[Password policy]
 ***** xref:admin_manual:configuration/server/security_setup_warnings.adoc[Security Setup Warnings]
 ***** xref:admin_manual:configuration/server/security/hsmdaemon/index.adoc[The HSM (Hardware Security Module) Daemon]
-***** xref:admin_manual:configuration/server/security/jquery_warnings.adoc[jQuery Warnings]
+***** xref:admin_manual:configuration/server/security/dependency_notes.adoc[Package Dependency Notes]
 **** xref:admin_manual:configuration/server/oc_server_tuning.adoc[Server Tuning]
 **** xref:admin_manual:configuration/server/thirdparty_php_configuration.adoc[Third Party PHP Configuration]
 **** xref:admin_manual:configuration/server/virus-scanner-support.adoc[Virus Scanner Support]

--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -102,7 +102,7 @@
 ***** xref:admin_manual:configuration/server/security/password_policy.adoc[Password policy]
 ***** xref:admin_manual:configuration/server/security_setup_warnings.adoc[Security Setup Warnings]
 ***** xref:admin_manual:configuration/server/security/hsmdaemon/index.adoc[The HSM (Hardware Security Module) Daemon]
-***** xref:admin_manual:configuration/server/security/dependency_notes.adoc[Package Dependency Notes]
+***** xref:admin_manual:configuration/server/security/dependency_notes.adoc[Dependency Notes]
 **** xref:admin_manual:configuration/server/oc_server_tuning.adoc[Server Tuning]
 **** xref:admin_manual:configuration/server/thirdparty_php_configuration.adoc[Third Party PHP Configuration]
 **** xref:admin_manual:configuration/server/virus-scanner-support.adoc[Virus Scanner Support]


### PR DESCRIPTION
The original page and url name is misleading now as it originally focused on jquery only.
Now we have added apps, which are not jquery related, the page name and headline got updated.
The text also got revised.

Backport to 10.15 and 10.14