### PR TITLE
Add no vulnerability for two bootstrap CVE's

### DIFF
--- a/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
+++ b/modules/admin_manual/pages/configuration/server/security/dependency_notes.adoc
@@ -41,3 +41,7 @@ Component "select2" cannot be exploited
 * PDF
 ** CVE-2024-4367 +
 When app `files_pdfviewer` is enabled with xref:configuration/server/config_apps_sample_php_parameters.adoc#enable-scripting-in-pdf-files[disabled scripting], CVE-2024-4367 can not be exploited
+
+* Bootstrap
+** CVE-2024-6485 and CVE-2024-6484 +
+There is no vulnerability because affected components are not used by ownCloud


### PR DESCRIPTION
There is no vulnerability for CVE-2024-6485 and CVE-2024-6484

Backport to 10.15 and 10.14