### PR TITLE
Remove or adapt support links

### DIFF
--- a/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
+++ b/modules/admin_manual/pages/configuration/integration/ms-teams.adoc
@@ -151,4 +151,4 @@ https://cloud.example.com/apps/msteamsbridge
 
 == Support
 
-If you encounter problems with the integration of ownCloud and Teams, please contact us via eMail at support@owncloud.com or look for answers to those problems at the {oc-central-url}[Forum]
+If you encounter problems with the integration of ownCloud and Teams, please contact ownCloud support or look for answers to those problems at the {oc-central-url}[Forum]

--- a/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/core_commands/_config_reports_commands.adoc
@@ -25,7 +25,7 @@ Alternatively, you could generate the report and email it all in one command, by
 {occ-command-example-prefix} configreport:generate | mail \
     -s "configuration report" \
     -r <the email address to send from> \
-    support@owncloud.com
+    <the email address to send to>
 ----
 
 NOTE: These commands are not available in xref:maintenance-commands[single-user (maintenance) mode].

--- a/modules/admin_manual/pages/installation/system_requirements.adoc
+++ b/modules/admin_manual/pages/installation/system_requirements.adoc
@@ -57,7 +57,7 @@ For _best performance_, _stability_, _support_, and _full functionality_ we offi
 | Operating System (64bit)
 | * Debian 10
 * Red Hat Enterprise Linux 7, 8 and 9 +
-including all 100% compatible derivatives (please note Red Hat Enterprise Linux 9 support is Enterprise only. Contact support@owncloud.com for more information)
+including all 100% compatible derivatives (please note Red Hat Enterprise Linux 9 support is Enterprise only. Contact ownCloud support for more information)
 * SUSE Linux Enterprise Server 12 with SP4/5 and 15
 * Ubuntu 20.04 and 22.04
 * openSUSE Leap 15.2


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/101 (Remove or adapt support and survey links)

This PR finalizes the removal / adaption of support links. No survey links have been found.

Backport to 10.15 and 10.14