### PR TITLE
Update backup.adoc

### DIFF
--- a/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
+++ b/modules/admin_manual/pages/maintenance/backup_and_restore/backup.adoc
@@ -113,6 +113,7 @@ PGPASSWORD="password" \
   pg_dump [db_name] \
   -h [server] \
   -U [username] \
+  -F tar \
   -f owncloud-dbbackup_`date +"%Y%m%d"`.bak
 ----
 


### PR DESCRIPTION
The current instructions for creating a backup of an Owncloud Postgres database with pg_dump do not include the tag `-F tar`. As a result, Postgres will dump a text file by default. 

Text file dumps don't work with pg_restore, which is how Owncloud recommends the Postgres database be restored. Indeed, restoring from a tar is a lot more reliable than trying to feed a text file to psql.

This change simply adds the flag `-F tar` to the pg_dump instruction, so that pg_dump will produce a tar, which will work with pg_restore.
