### PR TITLE
Fix PCN to PDN leftover

### DIFF
--- a/modules/admin_manual/partials/nav.adoc
+++ b/modules/admin_manual/partials/nav.adoc
@@ -140,7 +140,7 @@
 *** Encryption
 **** xref:admin_manual:maintenance/encryption/migrating-from-user-key-to-master-key.adoc[Migrating from User Key to Master Key Encryption]
 *** xref:admin_manual:maintenance/migrating.adoc[Migrating to a Different Server]
-*** xref:admin_manual:maintenance/migrating_to_kiteworks.adoc[Migrating to Kiteworks PCN]
+*** xref:admin_manual:maintenance/migrating_to_kiteworks.adoc[Migrating to Kiteworks PDN]
 
 ** Enterprise
 *** Authentication


### PR DESCRIPTION
Fixes a naming leftover `PCN` --> `PDN`

Backport to 10.15 and 10.14