### PR TITLE
Config to Docs run: Remove the web-updater

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -2310,6 +2310,16 @@ The web based updater is enabled by default.
 'upgrade.disable-web' => false,
 ....
 
+=== Explicitly enable the web updater - used by /updater/
+By default, it is disabled.
+
+==== Code Sample
+
+[source,php]
+....
+'web-updater.enabled' => false,
+....
+
 === Define whether to enable automatic update of market apps
 Set to `false` to disable.
 
@@ -2535,13 +2545,14 @@ This could happen in earlier versions of the openidconnect app when using the we
 'loginPolicy.groupLoginPolicy.forbidMap' => [],
 ....
 
-=== Enable Sending Telemetry Reports
+=== Enable Sending Telemetry Reports for Enterprise Customers
 Telemetry data is a subset of the config report as produced by the command `occ configreport:generate`.
 
-* If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
-* If set to false, no telemetry reports are sent.
+* If set to true and an enterprise license key is installed, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
+* If set to false or the configreport app is disabled, no telemetry reports are sent
 
 Default: true
+For community servers (without a license key) telemetry reports are never sent.
 
 ==== Code Sample
 


### PR DESCRIPTION
References: https://github.com/owncloud/core/pull/41385 (fix: web updater is now disabled by default)

Remove the `web-updater` config option from config sample.
(Note that all the other text changes are coming from any changes made in core maybe in other PR's and are ok to merge)

Currently on draft until the referenced PR gets merged.

Needs backport to 10.15