### PR TITLE
Config to Docs run: Remove the web-updater (II)

### DIFF
--- a/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+++ b/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
@@ -2310,16 +2310,6 @@ The web based updater is enabled by default.
 'upgrade.disable-web' => false,
 ....
 
-=== Explicitly enable the web updater - used by /updater/
-By default, it is disabled.
-
-==== Code Sample
-
-[source,php]
-....
-'web-updater.enabled' => false,
-....
-
 === Define whether to enable automatic update of market apps
 Set to `false` to disable.
 


### PR DESCRIPTION
References:  #1471 (Config to Docs run: Remove the web-updater)

An error sneaked in via the referenced PR, this is the correction for the removal.

Backport to 10.15