### PR TITLE
fix: mark version 'next' as prerelease

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,7 @@
 name: server
 title: ownCloud Server
 version: next
+prerelease: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/partials/nav.adoc


### PR DESCRIPTION
References: https://github.com/owncloud/docs/pull/5082 (feat: add /latest/ URL redirect to current stable version)

This PR adds a necessary requirement for the referenced PR.