### PR TITLE
fix: correct typos and grammar in migrating_to_ocis docs

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
@@ -187,7 +187,7 @@ As the final step, continue with xref:#migrate-files-and-shares[Migrate Files an
 
 === Migration With LDAP Users
 
-In general, users and groups must be accessible to oCIS. This can be achieved either connecting oCIS to the same LDAP server, or by migrating users and groups from the LDAP server that OC10 is connected to to a different backend for oCIS.
+In general, users and groups must be accessible to oCIS. This can be achieved either by connecting oCIS to the same LDAP server, or by migrating users and groups from the LDAP server that OC10 uses into a different backend for oCIS.
 
 The following procedures are necessary for the data migration to be possible.
 

--- a/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
@@ -29,8 +29,8 @@ The following items are migrated:
 
 * Users and groups with their membership +
 Either automatically or manually depending on the LDAP server used
-* Files of enabled users from in each user's home directory (using rclone, which is bundled with the app) +
-The data transferred is added to the users personal Space
+* Files in each enabled user's home directory (using rclone, which is bundled with the app) +
+The data transferred is added to the user's personal Space
 * User shares, group shares, and link shares
 
 === What Is Not Migrated
@@ -91,7 +91,7 @@ sudo -u www-data \
 
 === oCIS
 
-See the https://doc.owncloud.com/[ownCloud Documentation] for how to setup an oCIS instance and more configuration details.
+See the https://doc.owncloud.com/[ownCloud Documentation] for how to set up an oCIS instance and more configuration details.
 
 [IMPORTANT]
 ====
@@ -111,17 +111,17 @@ AUTH_APP_ENABLE_IMPERSONATION: true
 
 == User and Group Migration
 
-No data migration can be initiated until users and groups are available on the oCis side. To avoid a failing data migration step, no user or group changes, such as adding, deleting or changing, must be applied after this migration step.
+No data migration can be initiated until users and groups are available on the oCIS side. To avoid a failing data migration step, no user or group changes, such as adding, deleting or changing, must be applied after this migration step.
 
 Different steps are required for the migration of users and groups, depending on their location in OC10, to make them accessible to oCIS.
 
 Consider that the xref:ocis:admin:deployment/services/s-list/idm.adoc[internal IDM] provided by oCIS, which is a mini LDAP, has a very limited scope and is mainly targeted at small Infinite Scale installations or testing. It should therefore not be used in production environments. For larger setups or production environments, it is highly recommended to use a “real” LDAP server or to switch to an external Identity Management Solution instead.
 
-To address these different requirements, migrating users and groups are divided into separate sections. A combination of local and LDAP-based users is not supported.
+To address these different requirements, the migration of users and groups is divided into separate sections. A combination of local and LDAP-based users is not supported.
 
 === Migrate With Local Users
 
-These steps describe the migration of local OC10 users and groups to an external LDAP or to the embedded oCIS IDM - where no external LDAP is used.
+These steps describe the migration of local OC10 users and groups to an external LDAP or to the embedded oCIS IDM — where no external LDAP is used.
 
 ==== Migrate Local Users to LDAP
 
@@ -214,7 +214,7 @@ oCIS Requirements::
 In addition to the `auth-app` requirements, verify the following oCIS environment variables:
 
 * `OCIS_LDAP_USER_ENABLED_ATTRIBUTE` +
-The environment variable must exist and not be false. The default value uses the ownCloud schema which is unlikely to be present in your LDAP.
+The environment variable must exist and not be false. The default value uses the ownCloud schema, which is unlikely to be present in your LDAP.
 * `OCIS_LDAP_USER_SCHEMA_ID` and `OCIS_LDAP_GROUP_SCHEMA_ID` +
 These environment variables should be set appropriately (for example `entryUUID`).
 * `OCIS_ADMIN_USER_ID` +


### PR DESCRIPTION
Fixes the documentation typo reported in owncloud/migrate_to_ocis#30 (a doubled word in the _Migration With LDAP Users_ section) and, while reviewing the whole page, a handful of other language issues.

### Changes
- **Reported typo** — "...connected **to to** a different backend..." reworded to "...the LDAP server that OC10 **uses into** a different backend..." (also fixed the missing "by" so the "either … or" clauses are parallel).
- `oCis` → `oCIS` — consistent product capitalization.
- `how to setup` → `how to set up` — "set up" is the verb.
- "Files of enabled users **from in** each user's home directory" → "Files in each enabled user's home directory" — fixes the broken "from in" and the redundant phrasing.
- "the **users** personal Space" → "the **user's** personal Space" — possessive apostrophe.
- "oCIS IDM **-** where no external LDAP is used" → em dash `—`, consistent with the rest of the page.
- "migrating users and groups **are** divided into separate sections" → "the migration of users and groups **is** divided…" — subject/verb clarity.
- Added a comma before the non-restrictive "which" in the `OCIS_LDAP_USER_ENABLED_ATTRIBUTE` note.

No content/meaning changes — language and consistency only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)