### PR TITLE
fix: correct broken xrefs in useful_pages (#1541)

### DIFF
--- a/modules/admin_manual/pages/useful_pages.adoc
+++ b/modules/admin_manual/pages/useful_pages.adoc
@@ -11,7 +11,7 @@
 
 Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available ones.
 
-* xref:server:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
-* xref:server:admin_manual:configuration/server/occ_command.adoc[OCC Commands]
-* xref:server:admin_manual:configuration/server/caching_configuration.adoc#small-organization-single-server-setup[File Locking and Caching Configuration]
-* xref:server:admin_manual:maintenance/upgrading/manual_upgrade.adoc[Manual Upgrade]
+* xref:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
+* xref:admin_manual:configuration/server/occ_command.adoc[OCC Commands]
+* xref:admin_manual:configuration/server/caching_configuration.adoc#small-organization-single-server-setup[File Locking and Caching Configuration]
+* xref:admin_manual:maintenance/upgrading/manual_upgrade.adoc[Manual Upgrade]


### PR DESCRIPTION
## Problem

On `useful_pages.html` the **Installation with Docker** link renders as a dead on-page anchor instead of a real link:

```
https://doc.owncloud.com/server/next/admin_manual/useful_pages.html#server:admin_manual:installation/installing_with_docker.adoc
```

Fixes #1541

## Root cause

The four links in `useful_pages.adoc` carried a `server:` component prefix **without a version coordinate**:

```asciidoc
xref:server:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
```

Per Antora's resolution rules, a *component-qualified* xref with no version resolves against the **latest non-prerelease** version of that component. Since `next` is flagged `prerelease: true` in `antora.yml`, in the multi-version production build (`owncloud/docs`) these xrefs resolved against the current **release** rather than `next`.

`installing_with_docker.adoc` was newly added/renamed in `next` (from `installation/docker/index.adoc`) in #1511, so the target did not exist in the release version. Antora could not resolve it and emitted a self-anchor fallback — exactly the broken URL reported in the issue.

This is why the page builds clean locally: a local build only contains `next`, so "latest" == `next`, where the file exists.

## Fix

`useful_pages.adoc` itself lives in the `server` component, so dropping the `server:` prefix makes these **same-component** xrefs resolve against the current page's version (where every target exists). This also matches how all other references to these pages are written across the repo.

```diff
-* xref:server:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
+* xref:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
```

> Note: the previous `{latest-server-version}@server:` form (removed in #1511) could not be restored, because `latest-server-version` is defined **unquoted** in `antora.yml` and parses as a YAML object, rendering as `[object Object]`. See follow-up below.

## Verification

Local Antora build confirms all four links now render as proper anchors with **no** `[object Object]` and **no** `#server:admin_manual` self-anchor fallback:

- `installation/installing_with_docker.html` ✅ (the reported link)
- `configuration/server/occ_command.html` ✅
- `configuration/server/caching_configuration.html#small-organization-single-server-setup` ✅
- `maintenance/upgrading/manual_upgrade.html` ✅

## Follow-up (out of scope)

The broken `latest-server-version` attribute (`[object Object]` from unquoted YAML in `antora.yml`) also leaks into `public_link_shares.html` and the `collabora_secure_view` references. That's a separate defect worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)