### PR TITLE
docs: drop redundant '10' from 'ownCloud Classic 10' in migration/acceptance docs

### DIFF
--- a/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
+++ b/modules/admin_manual/pages/maintenance/migrating_to_ocis.adoc
@@ -1,17 +1,17 @@
 = Migrating to ownCloud Infinite Scale
 :toc: right
 :toclevels: 3
-:description: This guide describes how to migrate an ownCloud Classic 10 instance to ownCloud Infinite Scale (oCIS) using the migrate-to-ocis app and its occ commands.
+:description: This guide describes how to migrate an ownCloud Classic instance to ownCloud Infinite Scale (oCIS) using the migrate-to-ocis app and its occ commands.
 
 == Introduction
 
 {description}
 
-The migration transfers users, groups, files, and shares from an ownCloud Classic 10 instance to a target oCIS instance in a series of sequential steps. The ownCloud Classic server is not modified by the migration — it remains operational throughout most of the process.
+The migration transfers users, groups, files, and shares from an ownCloud Classic instance to a target oCIS instance in a series of sequential steps. The ownCloud Classic server is not modified by the migration — it remains operational throughout most of the process.
 
 == Overview
 
-The migration works with an app to be installed on the ownCloud Classic 10 side. The app is provided by ownCloud as part of the guided migration. Please contact {oc-support-url}[ownCloud support] to get it.
+The migration works with an app to be installed on the ownCloud Classic side. The app is provided by ownCloud as part of the guided migration. Please contact {oc-support-url}[ownCloud support] to get it.
 
 Both instances need to be fully configured and running, and they must be reachable from each other.
 
@@ -57,7 +57,7 @@ External mount data is excluded by the file migration step. These mounts must be
 
 == Prerequisites
 
-=== ownCloud Classic 10
+=== ownCloud Classic
 
 [IMPORTANT]
 ====

--- a/modules/developer_manual/pages/testing/acceptance-tests.adoc
+++ b/modules/developer_manual/pages/testing/acceptance-tests.adoc
@@ -116,7 +116,7 @@ These can be convenient when a longer list of files is needed, e.g., in a UI tes
 
 === Preparing to Run Acceptance Tests
 
-This is a concise guide to running acceptance tests on ownCloud Classic 10.
+This is a concise guide to running acceptance tests on ownCloud Classic.
 Before you can do so, you need to meet a few prerequisites available; these are
 
 * ownCloud


### PR DESCRIPTION
## What

Strips the redundant `10` from bare `ownCloud Classic 10` in the migration-to-oCIS guide and the acceptance-tests intro, where it denotes the product as the migration source / generic context (the product is now named **ownCloud Classic**).

## Why

Raised in review of the 10.15 backport (#1552, by @phil-davis). The same lines exist on master, so this keeps master consistent with the backport branches (10.15 #1552, 10.16 #1551 — both updated).

## Kept intentionally (meaningful version references)

- `Starting with ownCloud Classic 10` (developer/database)
- theming: `Before ownCloud Classic 10` / `deprecated in ... 10` / `upcoming ownCloud Classic 11`
- WND listener for `ownCloud Classic 10`
- migration `10 -> 11` steps

Part of owncloud/docs#5111

🤖 Generated with [Claude Code](https://claude.com/claude-code)