### PR TITLE
docs: use twofactor_totp as market:install example

### DIFF
--- a/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
+++ b/modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc
@@ -28,8 +28,8 @@ Applications can be installed both from {oc-marketplace-url}/[the ownCloud Marke
 == Install Apps From The Marketplace
 
 To install an application from the Marketplace, you need to supply the app’s id, which can be found in the app’s Marketplace URL.
-For example, the URL for _Two factor backup codes_ is {oc-marketplace-url}/apps/twofactor_backup_codes.
-So its app id is `twofactor_backup_codes`.
+For example, the URL for _2-Factor Authentication_ is {oc-marketplace-url}/apps/twofactor_totp.
+So its app id is `twofactor_totp`.
 
 [source,docker,subs="attributes+"]
 ----
@@ -60,7 +60,7 @@ Only `zip`, `gzip`, and `bzip2` archives are supported.
 [source,docker,subs="attributes+"]
 ----
 # Install an app from the marketplace.
-{occ-command-example-prefix-docker} market:install twofactor_backup_codes
+{occ-command-example-prefix-docker} market:install twofactor_totp
 
 # Install an app from a local archive.
 {occ-command-example-prefix-docker} market:install -l /mnt/data/richdocuments-2.0.0.tar.gz


### PR DESCRIPTION
## Summary

`owncloud/twofactor_backup_codes` has been [archived and is no longer maintained](https://github.com/owncloud/twofactor_backup_codes/pull/61).

Investigation showed the app was **never documented as a feature** — no dedicated page, not in the supported-apps list, and the 2FA docs use a different app (`twofactor_totp`) as their example. Its only appearance in the docs is as the **worked example** for finding an app id and running `occ market:install` in `_market_commands.adoc`.

This swaps that example to **`twofactor_totp`** (marketplace name "2-Factor Authentication"), which is actively maintained, a real Marketplace app, and already the canonical 2FA app referenced elsewhere in these docs — so the tutorial no longer points readers at an archived app.

## Changes

`modules/admin_manual/pages/configuration/server/occ_commands/app_commands/_market_commands.adoc`:
- App-id example: `twofactor_backup_codes` → `twofactor_totp`
- `market:install` usage example: `twofactor_backup_codes` → `twofactor_totp`

No pages to delete — the app had no feature documentation.

Refs: owncloud/docs#5121

🤖 Generated with [Claude Code](https://claude.com/claude-code)