### PR TITLE
docs: bump latest-server-download-version to 10.16.4

### DIFF
--- a/global-attributes.yml
+++ b/global-attributes.yml
@@ -27,7 +27,7 @@
 #   server
     latest-server-version: '10.15'
     previous-server-version: '10.14'
-    latest-server-download-version: '10.16.2'
+    latest-server-download-version: '10.16.4'
     current-server-version: '10.15'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
     oc-install-package-url: 'https://download.owncloud.com/server/stable/?sort=time&order=asc'

--- a/site.yml
+++ b/site.yml
@@ -28,7 +28,7 @@ asciidoc:
     # as they are just here for the test build
     latest-server-version: 'next@'   # do not change, soft set, correctly defined via antora.yml
     previous-server-version: 'next@' # do not change, soft set, correctly defined via antora.yml
-    latest-server-download-version: '10.16.2'
+    latest-server-download-version: '10.16.4'
     current-server-version: 'next@'         # do not change, soft set, correctly defined via antora.yml
   extensions:
     - ./ext-asciidoc/tabs.js


### PR DESCRIPTION
## Summary

Bump `latest-server-download-version` from `10.16.2` to `10.16.4`.

10.16.4 is the current stable Classic release ([published 2026-07-29](https://github.com/owncloud/core/releases/tag/v10.16.4)) and is a **security release** — it carries a critical fix for the legacy chunked WebDAV upload path bypassing the filename blacklist (owncloud/core#41763).

The attribute was still at `10.16.2`, so the Docker install example pointed admins at an image two patch releases behind, including past that fix. It was already missed for 10.16.3.

## Changes

- `global-attributes.yml` — `10.16.2` → `10.16.4`
- `site.yml` — same, kept in sync

## Consumers

- `modules/admin_manual/examples/installation/docker/dot.env` → `OWNCLOUD_IMAGE={latest-server-download-version}`
- `modules/admin_manual/pages/installation/installing_with_docker.adoc` → the `OWNCLOUD_IMAGE` example cell

`latest-server-version`, `current-server-version` and `previous-server-version` are deliberately untouched — those are docs-branch versions, overridden per branch via `antora.yml`'s `{page-component-version}`, not package versions.

> Note: the live site loads attributes from `owncloud/docs`'s `global-attributes.yml`, so a matching bump there is needed for the published pages to change. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
