### PR TITLE
docs: require explicit docker image versions

### DIFF
--- a/modules/admin_manual/pages/installation/docker/index.adoc
+++ b/modules/admin_manual/pages/installation/docker/index.adoc
@@ -5,6 +5,10 @@
 :linux-server-doc-url: https://docs.linuxserver.io/faq
 :docker-compose-build-url: https://docs.docker.com/compose/compose-file/build/
 :description: ownCloud can be installed using the official ownCloud Docker image.
+// the image version documented on this branch. this is intentionally a literal
+// and not an attribute, because the global -version attributes track the latest
+// release of the product and not this branch.
+:docker-image-version: 10.15.3
 
 == Introduction
 
@@ -48,10 +52,10 @@ For testing purposes or a quick hands-on to get familiar with the look and feel,
 
 [source,docker,subs="attributes+"]
 ----
-docker run --rm --name oc-eval -d -p{std-port-http}:{std-port-http} owncloud/server
+docker run --rm --name oc-eval -d -p{std-port-http}:{std-port-http} owncloud/server:{docker-image-version}
 ----
 
-This starts a docker container with the name "oc-eval" in the background (option `-d`). `owncloud/server` is the docker image downloaded from Docker Hub. If you don't start the container with option `-d`, the logs will be displayed in the shell. If you are running it in the background as in the example above, you can display the logs with the command:
+This starts a docker container with the name "oc-eval" in the background (option `-d`). `owncloud/server:{docker-image-version}` is the docker image downloaded from Docker Hub. Always name an explicit version tag, see the note on the `OWNCLOUD_VERSION` setting below. If you don't start the container with option `-d`, the logs will be displayed in the shell. If you are running it in the background as in the example above, you can display the logs with the command:
 
 [source,docker]
 ----
@@ -115,7 +119,7 @@ include::example$installation/docker/docker-compose.yml[]
 [source,bash,subs="attributes+"]
 ----
 cat << EOF > .env
-OWNCLOUD_VERSION={latest-server-version}
+OWNCLOUD_VERSION={docker-image-version}
 OWNCLOUD_DOMAIN=localhost:{std-port-http}
 OWNCLOUD_TRUSTED_DOMAINS=localhost
 ADMIN_USERNAME=admin
@@ -133,8 +137,9 @@ Only a few settings are required, these are:
 | Example
 
 | `OWNCLOUD_VERSION`
-| The ownCloud version
-| `latest`
+| The ownCloud version. +
+Always use an explicit version, never `latest`.
+| `{docker-image-version}`
 
 | `OWNCLOUD_DOMAIN`
 | The ownCloud domain
@@ -156,6 +161,8 @@ Only a few settings are required, these are:
 | The HTTP port to bind to
 | `{std-port-http}`
 |===
+
+NOTE: Pin `OWNCLOUD_VERSION` to a full version like `{docker-image-version}`. Do not use the `latest` tag: it does not necessarily point to the release line documented here, so a container restart can pull a different version than you expect.
 
 NOTE: `ADMIN_USERNAME` and `ADMIN_PASSWORD` will not change between deploys even if you change the
 values in the .env file. To change them, you'll need to do `docker volume prune`, which

--- a/modules/admin_manual/pages/useful_pages.adoc
+++ b/modules/admin_manual/pages/useful_pages.adoc
@@ -11,8 +11,10 @@
 
 Note that this section always points to the latest server version available. In case you need a different version, select your topic and manually switch to one of the available ones.
 
-* xref:{latest-server-version}@server:admin_manual:installation/index.adoc[Manual Installation]
-* xref:{latest-server-version}@server:admin_manual:installation/docker/index.adoc[Installation with Docker]
+// note that these targets must use the page paths of the *latest* server
+// version, not this branch's: the latest version is a docker-only release and
+// has reorganized its installation and upgrading pages accordingly.
+* xref:{latest-server-version}@server:admin_manual:installation/installing_with_docker.adoc[Installation with Docker]
 * xref:{latest-server-version}@server:admin_manual:configuration/server/occ_command.adoc[OCC Commands]
 * xref:{latest-server-version}@server:admin_manual:configuration/server/caching_configuration.adoc#small-organization-single-server-setup[File Locking and Caching Configuration]
-* xref:{latest-server-version}@server:admin_manual:maintenance/manual_upgrade.adoc[Manual Upgrade]
+* xref:{latest-server-version}@server:admin_manual:maintenance/upgrading/manual_upgrade.adoc[Manual Upgrade]

--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -31,9 +31,9 @@ Pull any or all of these Docker containers:
 ----
 docker pull selenium/standalone-chrome:3.141.59-oxygen
 docker pull selenium/standalone-chrome-debug:3.141.59-oxygen
-docker pull selenium/standalone-firefox
-docker pull selenium/standalone-firefox-debug
-docker pull inbucket/inbucket
+docker pull selenium/standalone-firefox:3.141.59-oxygen
+docker pull selenium/standalone-firefox-debug:3.141.59-oxygen
+docker pull inbucket/inbucket:3.1.1
 ----
 
 * A `vnc` viewer installed (in order to view the browser action as the UI tests run). For example:
@@ -62,7 +62,7 @@ taken to do the test.
 
 [source,console]
 ----
-docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug
+docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:3.141.59-oxygen
 ----
 
 Ports on the Selenium Docker IP address are mapped to `localhost` so they can be accessed by the tests and the `vnc` viewer.
@@ -71,7 +71,7 @@ Ports on the Selenium Docker IP address are mapped to `localhost` so they can be
 
 [source]
 ----
-docker run -p 2500:2500 -p 9000:9000 inbucket/inbucket
+docker run -p 2500:2500 -p 9000:9000 inbucket/inbucket:3.1.1
 ----
 
 Ports on the InBucket docker IP address are mapped to `localhost` so they can be accessed by the tests.

--- a/modules/developer_manual/pages/testing/ui-testing.adoc
+++ b/modules/developer_manual/pages/testing/ui-testing.adoc
@@ -31,9 +31,9 @@ Pull any or all of these Docker containers:
 ----
 docker pull selenium/standalone-chrome:3.141.59-oxygen
 docker pull selenium/standalone-chrome-debug:3.141.59-oxygen
-docker pull selenium/standalone-firefox:3.141.59-oxygen
-docker pull selenium/standalone-firefox-debug:3.141.59-oxygen
-docker pull inbucket/inbucket:3.1.1
+docker pull selenium/standalone-firefox
+docker pull selenium/standalone-firefox-debug
+docker pull inbucket/inbucket
 ----
 
 * A `vnc` viewer installed (in order to view the browser action as the UI tests run). For example:
@@ -62,7 +62,7 @@ taken to do the test.
 
 [source,console]
 ----
-docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:3.141.59-oxygen
+docker run -p 4445:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-chrome-debug
 ----
 
 Ports on the Selenium Docker IP address are mapped to `localhost` so they can be accessed by the tests and the `vnc` viewer.
@@ -71,7 +71,7 @@ Ports on the Selenium Docker IP address are mapped to `localhost` so they can be
 
 [source]
 ----
-docker run -p 2500:2500 -p 9000:9000 inbucket/inbucket:3.1.1
+docker run -p 2500:2500 -p 9000:9000 inbucket/inbucket
 ----
 
 Ports on the InBucket docker IP address are mapped to `localhost` so they can be accessed by the tests.


### PR DESCRIPTION
Every documented `owncloud/server` reference on this branch now carries an
explicit version tag, and `latest` is no longer presented as a valid option. Same
change as owncloud/docs-server#1576 (10.16) and #1575 (master).

`owncloud/server:latest` does not track the release line documented here — it
follows whatever the newest published image happens to be — so a reader copying
the examples, or a container restart, can end up on a different version than the
documentation describes. There are also no rolling major or minor tags
(`owncloud/server:10.15` and `:10` both 404 on Docker Hub), so a full version is
the only correct thing to name.

This applies to `owncloud/server` only. An earlier revision of this PR also
pinned the selenium and inbucket images in the UI testing guide; those pins are
reverted, since they fix no documented-version mismatch and nothing in this repo
keeps them current.

## Changes

`modules/admin_manual/pages/installation/docker/index.adoc`

* Adds a `docker-image-version` page attribute set to the literal `10.15.3`, the
  top of this release line. This intentionally does *not* reuse
  `{latest-server-version}`: that is a global site attribute tracking the latest
  release of the product, and the value that wins is the aggregator's
  (`owncloud/docs` `global-attributes.yml`), not this branch's `antora.yml` — which
  is why the published page currently renders `OWNCLOUD_VERSION=10.16` here.
* Tags the quick-evaluation `docker run` (`owncloud/server:10.15.3`); it was
  untagged, which resolves to `latest`.
* `OWNCLOUD_VERSION` in the `.env` example now names the explicit version, and the
  required-settings table no longer gives `latest` as its example value.
* Adds a note explaining why `OWNCLOUD_VERSION` must be pinned.

`modules/admin_manual/pages/useful_pages.adoc`

* Fixes the xrefs into the *latest* server version, which the page deliberately
  targets but addressed with this branch's page paths. The 11.0 release is
  docker-only and reorganized accordingly, so three of the five links break as
  soon as `latest-server-version` advances.

## Testing

`npm run antora-local` (Node 22, as pinned by this branch's `ci.yml`) builds with
no errors and no warnings. The rendered page shows `OWNCLOUD_VERSION=10.15.3`,
`owncloud/server:10.15.3`, and no occurrence of `latest` in the settings table.
The `10.15.3` tag was verified present on Docker Hub.

## Note on timing

10.15 is about to be dropped from the published site and archived as
`x_archived_10.15`, so this content will not be published for long. It is worth
merging anyway: it keeps the branch correct for the window before the
`owncloud/docs` change lands, and should the branch ever be un-archived it is not
left documenting an image tag that points somewhere else. This PR needs to merge
**before** the branch is renamed.

